### PR TITLE
Use https:// for all git clones.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         .executable(name: "NIOTLSServer", targets: ["NIOTLSServer"]),
     ],
     dependencies: [
-    .package(url: "git@github.com:apple/swift-nio.git", .branch("master")),
-        .package(url: "git@github.com:apple/swift-nio-ssl-support.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "CNIOOpenSSL"),


### PR DESCRIPTION
Motivation:

Users shouldn't need a GitHub account to build the repository.

Modifications:

Use https:// for all git dependencies.

Result:

Happy users