### PR TITLE
Remove @testable use of NIO.

### DIFF
--- a/Tests/NIOOpenSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOOpenSSLTests/SSLCertificateTest.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-@testable import NIO
+import NIO
 @testable import NIOOpenSSL
 
 let multiSanCert = """

--- a/Tests/NIOOpenSSLTests/SSLPrivateKeyTests.swift
+++ b/Tests/NIOOpenSSLTests/SSLPrivateKeyTests.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-@testable import NIO
+import NIO
 @testable import NIOOpenSSL
 
 class SSLPrivateKeyTest: XCTestCase {

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import CNIOOpenSSL
-@testable import NIO
+import NIO
 @testable import NIOOpenSSL
 import NIOTLS
 


### PR DESCRIPTION
Motivation:

When this was in-tree with NIO we could safely use @testable imports to
get at the project internals, becuase we couldn't possibly regress against
them. This is no longer true, so we should avoid @testable imports.

Modifications:

Removed all @testable imports.

Changed NIO.Posix.open to Darwin/Glibc.open.

Replaced uses of fulfilled with either wait() or callbacks.

Result:

Less chance of randomly breaking due to NIO changes.