### PR TITLE
Set SSL_MODE_RELEASE_BUFFERS and SSL_MODE_AUTO_RETRY.

### DIFF
--- a/Sources/NIOOpenSSL/SSLContext.swift
+++ b/Sources/NIOOpenSSL/SSLContext.swift
@@ -119,6 +119,12 @@ public final class SSLContext {
         // TODO(cory): It doesn't seem like this initialization should happen here: where?
         CNIOOpenSSL_SSL_CTX_setAutoECDH(ctx)
 
+        // First, let's set some basic modes. We set the following:
+        // - SSL_MODE_RELEASE_BUFFERS: Because this can save a bunch of memory on idle connections.
+        // - SSL_MODE_AUTO_RETRY: Because OpenSSL's default behaviour on SSL_read without this flag is bad.
+        //     See https://github.com/openssl/openssl/issues/6234 for more discussion on this.
+        SSL_CTX_ctrl(ctx, SSL_CTRL_MODE, SSL_MODE_RELEASE_BUFFERS | SSL_MODE_AUTO_RETRY, nil)
+
         var opensslOptions = Int(SSL_OP_NO_COMPRESSION)
 
         // Handle TLS versions


### PR DESCRIPTION
Motivation:

There are two key issues at play here.

Firstly, OpenSSL connections by default hang on to buffers for idle
connections. This isn't really necessary, and setting
SSL_MODE_RELEASE_BUFFERS can save enormous amounts of memory (tens of kb
per connection in some cases).

Secondly, and more profoundly, OpenSSL's default behaviour on SSL_read
is unexpected. In particular, it is possible to get SSL_read to return
SSL_ERROR_WANT_READ in cases where the receive BIO does actually have
an application data record in it, but where a non-application data
record was received first.

Handling that is a tricky case, but it's much easier to ask OpenSSL to
do it for us by just setting SSL_MODE_AUTO_RETRY. This really ought to
be the default behaviour: the fact that it isn't is fairly perplexing.

See https://github.com/openssl/openssl/issues/6234 for more discussion
of SSL_MODE_AUTO_RETRY.

As a side note, I have not added tests for either of these because they are extremely difficult to test. `SSL_MODE_RELEASE_BUFFERS` is tested by monitoring memory usage, and `SSL_MODE_AUTO_RETRY` by low-level control of the TLS record layer that OpenSSL doesn't make it very easy for us to get before TLS 1.3. For this reason, for now I'm just committing the changes without tests.

Modifications:

Set SSL_MODE_RELEASE_BUFFERS and SSL_MODE_AUTO_RETRY.

Result:

Less memory usage, fewer subtle bugs.