### PR TITLE
Flush embedded channel.

### DIFF
--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
@@ -215,7 +215,7 @@ private class WriteDelayHandler: ChannelOutboundHandler {
     func forceFlush() {
         let writes = self.writes
         self.writes = []
-        writes.forEach { $0.0.write($0.1, promise: $0.2) }
+        writes.forEach { $0.0.writeAndFlush($0.1, promise: $0.2) }
     }
 }
 


### PR DESCRIPTION
Motivation:

apple/swift-nio#421 changed the behaviour of EmbeddedChannel to no longer
automatically succeed write promises without flushes. This is a reasonable
behavioural change, but broke a test that was working around but still
implicitly relied on the old behaviour.

Modifications:

Add the missing flushes.

Result:

This test will pass both on NIO master and NIO 1.7.0