### PR TITLE
Support OpenSSL 1.1 and later.

### DIFF
--- a/Sources/NIOOpenSSL/SSLInit.swift
+++ b/Sources/NIOOpenSSL/SSLInit.swift
@@ -14,86 +14,15 @@
 
 import CNIOOpenSSL
 
-private let callbackLock: UnsafeMutablePointer<pthread_mutex_t> =  {
-    var ptr = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
-    let err = pthread_mutex_init(ptr, nil)
-    precondition(err == 0)
-    return ptr
-}()
-
-private var sslLocks: UnsafeMutablePointer<pthread_mutex_t>!
-
+/// Initialize OpenSSL. Note that this function IS NOT THREAD SAFE, and so must be called inside
+/// either an explicit or implicit dispatch_once.
 func initializeOpenSSL() -> Bool {
     // Initializing OpenSSL is made up of two steps. First, we need to load all the various crypto bits.
-    SSL_library_init()
-    OPENSSL_add_all_algorithms_conf()
-    SSL_load_error_strings()
-    ERR_load_crypto_strings()
-    OPENSSL_config(nil)
-    
-    // Then, we need to set up the OpenSSL locking callbacks. This is pretty annoying, and also requires synchronization in case
-    // we're doing this from multiple threads concurrently. Sadly this means we can block the I/O thread on this activity:
-    // there's not much that can be done about that, sadly.
-    var err = pthread_mutex_lock(callbackLock)
-    precondition(err == 0)
-    if CRYPTO_get_locking_callback() == nil { setupLockingCallbacks() }
-    err = pthread_mutex_unlock(callbackLock)
-    precondition(err == 0)
+    CNIOOpenSSL_InitializeOpenSSL()
 
     // Now we need to set up our custom BIO.
     setupBIO()
     return true
-}
-
-private func setupLockingCallbacks() {
-    // The default OpenSSL locking callback structure requires an array of locks
-    // that can be locked by index. Is this insane? Yes, yes it is. But here we are,
-    // so let's reimplement this in Swift. Because if we have to do stupid insane things
-    // to keep OpenSSL happy, the least we can do is do those stupid insane things in
-    // a *type-safe* way.
-    let lockCount = Int(CRYPTO_num_locks())
-    sslLocks = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: lockCount)
-
-    // An enterprising developer looking at this code may note that we technically loop over
-    // our array twice: once to copy an unitialized pthread_mutex_t into each element of the
-    // array, and then once again to call pthread_mutex_init. Such a developer might get it
-    // into their head that this could be optimized by instead calling pthread_mutex_init
-    // just once and then using sslLocks.initialize to copy that init-ed mutex into each
-    // element of the array.
-    //
-    // This developer, much like Icarus, has flown too close to the sun. You see,
-    // IEEE Std 1003.1-2001 doesn't define assignment or equality for pthread_mutex_t. This
-    // means that, for example, a pthread_mutex_t could be just a reference to a heap-allocated
-    // structure that handles the actual locking. If this were the case, copying the init-ed
-    // mutex would lead us to have an array of "locks" all of which are actually aliased copies
-    // of the same lock. It seems to me that this would be unlikely to go well. For this reason
-    // we play it safe and do the loop twice.
-    sslLocks.initialize(to: pthread_mutex_t())
-    for index in 0..<lockCount {
-        let err = pthread_mutex_init(&sslLocks[index], nil)
-        precondition(err == 0)
-    }
-    
-    CRYPTO_set_id_callback(getThreadID)
-    CRYPTO_set_locking_callback(opensslLockingCallback)
-}
-
-private func opensslLockingCallback(mode: Int32, index: Int32, callingFile: UnsafePointer<Int8>?, callingLine: Int32) {
-    if (mode & CRYPTO_LOCK) != 0 {
-        let err = pthread_mutex_lock(&sslLocks[Int(index)])
-        precondition(err == 0)
-    } else {
-        let err = pthread_mutex_unlock(&sslLocks[Int(index)])
-        precondition(err == 0)
-    }
-}
-
-private func getThreadID() -> UInt {
-    #if os(Linux)
-    return UInt(pthread_self())
-    #else  // Darwin
-    return UInt(bitPattern:pthread_self())
-    #endif
 }
 
 /// Called to initialize our custom OpenSSL BIO.

--- a/Sources/NIOOpenSSL/SSLPointerTricks.swift
+++ b/Sources/NIOOpenSSL/SSLPointerTricks.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+
+// MARK:- Awful code begins here
+// Hello dear reader. Let me explain what we're doing here.
+//
+// From OpenSSL 1.0 to OpenSSL 1.1 one of the major breaking changes was the so-called
+// "great opaquifiying". Essentially, OpenSSL took all of its public structures and made
+// them opaque, such that they cannot be introspected from client code. This is a great
+// forward step, and brings them more in line with modern C library practices.
+//
+// However, it's an *enormous* inconvenience from Swift code. This is because the Swift
+// translation of the C type `SSL_CTX *` changed from `UnsafeMutablePointer<SSL_CTX>` to
+// `OpaquePointer`.
+//
+// This change exists for reasonable enough reasons in Swift land (see
+// https://forums.swift.org/t/opaque-pointers-in-swift/6875 for a discussion), but
+// nonetheless causes enormous problems in our codebase.
+//
+// Our cheap way out is to make everything an OpaquePointer, and then provide initializers
+// between OpaquePointer and the typed pointers. This allows us to tolerate either pointer
+// type in our Swift code by bridging them over to OpaquePointer and back, and lets the
+// compiler worry about how exactly to make that work.
+//
+// Now, in fact, Swift already has initializers between the pointer types. What it does
+// not have is self-initializers: the ability to create an `OpaquePointer` from an `OpaquePointer`,
+// or an `UnsafePointer<T>` from an `UnsafePointer<T>`. We add those two initializers here.
+// We also add a special "make" function that exists to handle the special case of optional pointer
+// values, which we mostly encounter in the ALPN callbacks.
+//
+// The *downside* of this approach is that we totally break the pointer type system. It becomes
+// trivially possible to alias a pointer of type T to type U through two calls to init. This
+// is not a thing we want to widely promote. For this reason, these extensions are hidden in
+// this file, where we can laugh and jeer at them and generally make them feel bad about
+// themselves.
+//
+// Hopefully, in time, these extensions can be removed.
+extension UnsafePointer {
+    init(_ ptr: UnsafePointer<Pointee>) {
+        self = ptr
+    }
+
+    static func make(optional ptr: UnsafePointer<Pointee>?) -> UnsafePointer<Pointee>? {
+        return ptr.map(UnsafePointer<Pointee>.init)
+    }
+
+    static func make(optional ptr: OpaquePointer?) -> UnsafePointer<Pointee>? {
+        return ptr.map(UnsafePointer<Pointee>.init)
+    }
+}
+
+extension UnsafeMutablePointer {
+    init(_ ptr: UnsafeMutableRawPointer) {
+        let x = UnsafeMutablePointer<Pointee>(bitPattern: UInt(bitPattern: ptr))!
+        self = x
+    }
+
+    static func make(optional ptr: UnsafeMutablePointer<Pointee>?) -> UnsafeMutablePointer<Pointee>? {
+        return ptr.map(UnsafeMutablePointer<Pointee>.init)
+    }
+
+    static func make(optional ptr: UnsafeMutableRawPointer?) -> UnsafeMutablePointer<Pointee>? {
+        return ptr.map(UnsafeMutablePointer<Pointee>.init)
+    }
+
+    static func make(optional ptr: OpaquePointer?) -> UnsafeMutablePointer<Pointee>? {
+        return ptr.map(UnsafeMutablePointer<Pointee>.init)
+    }
+}
+
+extension UnsafeMutableRawPointer {
+    static func make(optional ptr: OpaquePointer?) -> UnsafeMutableRawPointer? {
+        return ptr.map(UnsafeMutableRawPointer.init)
+    }
+}
+
+extension OpaquePointer {
+    init(_ ptr: OpaquePointer) {
+        self = ptr
+    }
+
+    static func make(optional ptr: OpaquePointer?) -> OpaquePointer? {
+        return ptr.map(OpaquePointer.init)
+    }
+
+    static func make(optional ptr: UnsafeMutableRawPointer?) -> OpaquePointer? {
+        return ptr.map(OpaquePointer.init)
+    }
+
+    static func make<Pointee>(optional ptr: UnsafeMutablePointer<Pointee>?) -> OpaquePointer? {
+        return ptr.map(OpaquePointer.init)
+    }
+}

--- a/Tests/NIOOpenSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOOpenSSLTests/ByteBufferBIOTest.swift
@@ -25,7 +25,7 @@ final class ByteBufferBIOTest: XCTestCase {
         }
     }
 
-    private func retainedBIO() -> UnsafeMutablePointer<BIO> {
+    private func retainedBIO() -> OpaquePointer {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         return swiftBIO.retainedBIO()
     }
@@ -34,13 +34,13 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
 
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
-        let rc = BIO_write(cBIO, &bytesToWrite, 5)
+        let rc = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
         XCTAssertEqual(rc, 5)
 
         guard let extractedBytes = swiftBIO.outboundCiphertext().flatMap({ $0.getBytes(at: $0.readerIndex, length: $0.readableBytes) }) else {
@@ -55,7 +55,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
@@ -63,7 +63,7 @@ final class ByteBufferBIOTest: XCTestCase {
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
         var expectedBytes = [UInt8]()
         for _ in 0..<10 {
-            let rc = BIO_write(cBIO, &bytesToWrite, 5)
+            let rc = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
             XCTAssertEqual(rc, 5)
             expectedBytes.append(contentsOf: bytesToWrite)
         }
@@ -80,14 +80,14 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var targetBuffer = [UInt8](repeating: 0, count: 512)
-        let rc = BIO_read(cBIO, &targetBuffer, 512)
+        let rc = BIO_read(.make(optional: cBIO), &targetBuffer, 512)
         XCTAssertEqual(rc, -1)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) != 0)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(cBIO) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(.make(optional: cBIO)) != 0)
         XCTAssertEqual(targetBuffer, [UInt8](repeating: 0, count: 512))
     }
 
@@ -95,7 +95,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var inboundBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -104,7 +104,7 @@ final class ByteBufferBIOTest: XCTestCase {
 
         var receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
         let rc = receivedBytes.writeWithUnsafeMutableBytes { pointer in
-            let innerRC = BIO_read(cBIO, pointer.baseAddress!, CInt(pointer.count))
+            let innerRC = BIO_read(.make(optional: cBIO), pointer.baseAddress!, CInt(pointer.count))
             XCTAssertTrue(innerRC > 0)
             return innerRC > 0 ? Int(innerRC) : 0
         }
@@ -113,18 +113,18 @@ final class ByteBufferBIOTest: XCTestCase {
         XCTAssertEqual(receivedBytes, inboundBytes)
 
         let secondRC = receivedBytes.withUnsafeMutableWritableBytes { pointer in
-            BIO_read(cBIO, pointer.baseAddress!, CInt(pointer.count))
+            BIO_read(.make(optional: cBIO), pointer.baseAddress!, CInt(pointer.count))
         }
         XCTAssertEqual(secondRC, -1)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) != 0)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(cBIO) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(.make(optional: cBIO)) != 0)
     }
 
     func testShortReads() throws {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var inboundBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -134,7 +134,7 @@ final class ByteBufferBIOTest: XCTestCase {
         var receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
         for _ in 0..<5 {
             let rc = receivedBytes.writeWithUnsafeMutableBytes { pointer in
-                let innerRC = BIO_read(cBIO, pointer.baseAddress!, 1)
+                let innerRC = BIO_read(.make(optional: cBIO), pointer.baseAddress!, 1)
                 XCTAssertTrue(innerRC > 0)
                 return innerRC > 0 ? Int(innerRC) : 0
             }
@@ -144,20 +144,20 @@ final class ByteBufferBIOTest: XCTestCase {
         XCTAssertEqual(receivedBytes, inboundBytes)
 
         let secondRC = receivedBytes.withUnsafeMutableWritableBytes { pointer in
-            BIO_read(cBIO, pointer.baseAddress!, CInt(pointer.count))
+            BIO_read(.make(optional: cBIO), pointer.baseAddress!, CInt(pointer.count))
         }
         XCTAssertEqual(secondRC, -1)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) != 0)
-        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(cBIO) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) != 0)
+        XCTAssertTrue(CNIOOpenSSL_BIO_should_read(.make(optional: cBIO)) != 0)
     }
 
     func testDropRefToBaseObjectOnRead() throws {
         let cBIO = self.retainedBIO()
         let receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
         receivedBytes.withVeryUnsafeBytes { pointer in
-            let rc = BIO_read(cBIO, UnsafeMutableRawPointer(mutating: pointer.baseAddress!), 1)
+            let rc = BIO_read(.make(optional: cBIO), UnsafeMutableRawPointer(mutating: pointer.baseAddress!), 1)
             XCTAssertEqual(rc, -1)
-            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) == 0)
+            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) == 0)
         }
     }
 
@@ -166,9 +166,9 @@ final class ByteBufferBIOTest: XCTestCase {
         var receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
         receivedBytes.write(bytes: [1, 2, 3, 4, 5])
         receivedBytes.withVeryUnsafeBytes { pointer in
-            let rc = BIO_write(cBIO, pointer.baseAddress!, 1)
+            let rc = BIO_write(.make(optional: cBIO), pointer.baseAddress!, 1)
             XCTAssertEqual(rc, -1)
-            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) == 0)
+            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) == 0)
         }
     }
 
@@ -176,11 +176,11 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var targetBuffer = [UInt8](repeating: 0, count: 512)
-        let rc = BIO_read(cBIO, &targetBuffer, 0)
+        let rc = BIO_read(.make(optional: cBIO), &targetBuffer, 0)
         XCTAssertEqual(rc, 0)
         XCTAssertEqual(targetBuffer, [UInt8](repeating: 0, count: 512))
     }
@@ -189,11 +189,11 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
-        let rc = BIO_write(cBIO, &bytesToWrite, 5)
+        let rc = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
         XCTAssertEqual(rc, 5)
 
         guard let firstWrite = swiftBIO.outboundCiphertext() else {
@@ -201,7 +201,7 @@ final class ByteBufferBIOTest: XCTestCase {
             return
         }
 
-        let secondRC = BIO_write(cBIO, &bytesToWrite, 5)
+        let secondRC = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
         XCTAssertEqual(secondRC, 5)
         guard let secondWrite = swiftBIO.outboundCiphertext() else {
             XCTFail("Did not write second time")
@@ -212,9 +212,9 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testWriteWhenDroppedBufferDoesNotTriggerCoW() {
-        func writeAddress(swiftBIO: ByteBufferBIO, cBIO: UnsafeMutablePointer<BIO>) -> UInt? {
+        func writeAddress(swiftBIO: ByteBufferBIO, cBIO: OpaquePointer) -> UInt? {
             var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
-            let rc = BIO_write(cBIO, &bytesToWrite, 5)
+            let rc = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
             XCTAssertEqual(rc, 5)
             return swiftBIO.outboundCiphertext()?.baseAddress()
         }
@@ -222,11 +222,11 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
-        let firstAddress = writeAddress(swiftBIO: swiftBIO, cBIO: cBIO)
-        let secondAddress = writeAddress(swiftBIO: swiftBIO, cBIO: cBIO)
+        let firstAddress = writeAddress(swiftBIO: swiftBIO, cBIO: .init(cBIO))
+        let secondAddress = writeAddress(swiftBIO: swiftBIO, cBIO: .init(cBIO))
         XCTAssertNotNil(firstAddress)
         XCTAssertNotNil(secondAddress)
         XCTAssertEqual(firstAddress, secondAddress)
@@ -239,11 +239,11 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
-        let rc = BIO_write(cBIO, &bytesToWrite, 5)
+        let rc = BIO_write(.make(optional: cBIO), &bytesToWrite, 5)
         XCTAssertEqual(rc, 5)
 
         guard let firstWrite = swiftBIO.outboundCiphertext() else {
@@ -251,7 +251,7 @@ final class ByteBufferBIOTest: XCTestCase {
             return
         }
         withExtendedLifetime(firstWrite) {
-            let secondRC = BIO_write(cBIO, &bytesToWrite, 0)
+            let secondRC = BIO_write(.make(optional: cBIO), &bytesToWrite, 0)
             XCTAssertEqual(secondRC, 0)
             XCTAssertNil(swiftBIO.outboundCiphertext())
         }
@@ -261,14 +261,14 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
 
         let stringToWrite = "Hello, world!"
         let rc = stringToWrite.withCString {
-            BIO_puts(cBIO, $0)
+            BIO_puts(.make(optional: cBIO), $0)
         }
         XCTAssertEqual(rc, 13)
 
@@ -281,7 +281,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
@@ -290,9 +290,9 @@ final class ByteBufferBIOTest: XCTestCase {
 
         buffer.withUnsafeMutableReadableBytes { pointer in
             let myPointer = pointer.baseAddress!.bindMemory(to: Int8.self, capacity: pointer.count)
-            let rc = BIO_gets(cBIO, myPointer, CInt(pointer.count))
+            let rc = BIO_gets(.make(optional: cBIO), myPointer, CInt(pointer.count))
             XCTAssertEqual(rc, -2)
-            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(cBIO) == 0)
+            XCTAssertTrue(CNIOOpenSSL_BIO_should_retry(.make(optional: cBIO)) == 0)
         }
     }
 
@@ -300,22 +300,22 @@ final class ByteBufferBIOTest: XCTestCase {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
         let cBIO = swiftBIO.retainedBIO()
         defer {
-            BIO_free(cBIO)
+            BIO_free(.make(optional: cBIO))
         }
 
-        let originalShutdown = CNIOOpenSSL_BIO_get_close(cBIO)
+        let originalShutdown = CNIOOpenSSL_BIO_get_close(.make(optional: cBIO))
         XCTAssertEqual(originalShutdown, BIO_CLOSE)
 
-        let rc = CNIOOpenSSL_BIO_set_close(cBIO, CLong(BIO_NOCLOSE))
+        let rc = CNIOOpenSSL_BIO_set_close(.make(optional: cBIO), CLong(BIO_NOCLOSE))
         XCTAssertEqual(rc, 1)
 
-        let newShutdown = CNIOOpenSSL_BIO_get_close(cBIO)
+        let newShutdown = CNIOOpenSSL_BIO_get_close(.make(optional: cBIO))
         XCTAssertEqual(newShutdown, BIO_NOCLOSE)
 
-        let rc2 = CNIOOpenSSL_BIO_set_close(cBIO, CLong(BIO_CLOSE))
+        let rc2 = CNIOOpenSSL_BIO_set_close(.make(optional: cBIO), CLong(BIO_CLOSE))
         XCTAssertEqual(rc2, 1)
 
-        let newShutdown2 = CNIOOpenSSL_BIO_get_close(cBIO)
+        let newShutdown2 = CNIOOpenSSL_BIO_get_close(.make(optional: cBIO))
         XCTAssertEqual(newShutdown2, BIO_CLOSE)
     }
 }

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
@@ -319,7 +319,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         let manager = OpenSSLPassphraseCallbackManager { closure in closure(passphrase.utf8) }
         let rc = withExtendedLifetime(manager) { manager -> CInt in
             let userData = Unmanaged.passUnretained(manager).toOpaque()
-            return PEM_write_bio_PrivateKey(fileBio, key.ref, EVP_aes_256_cbc(), nil, 0, globalOpenSSLPassphraseCallback, userData)
+            return PEM_write_bio_PrivateKey(fileBio, .make(optional: key.ref), EVP_aes_256_cbc(), nil, 0, globalOpenSSLPassphraseCallback, userData)
         }
         BIO_free(fileBio)
         precondition(rc == 1)
@@ -338,7 +338,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         let fileBio = BIO_new_fp(fdopen(tempFile, "w+"), BIO_CLOSE)
         precondition(fileBio != nil)
 
-        let rc = PEM_write_bio_X509(fileBio, OpenSSLIntegrationTest.cert.ref)
+        let rc = PEM_write_bio_X509(fileBio, .make(optional: OpenSSLIntegrationTest.cert.ref))
         BIO_free(fileBio)
         precondition(rc == 1)
         return try fn(fileName)


### PR DESCRIPTION
Motivation:

Currently there are no Swift.org distributions of Swift for Linux that link against an OpenSSL 1.1 release, but with the recent release of Ubuntu 18.04, the next LTS release of Ubuntu, it seems reasonable that at some point such a release will exist.

Given that OpenSSL 1.1 is substantially better than OpenSSL 1.0, we should endeavour to allow our users to take advantage of this new support and compile against this newer OpenSSL.

*Unfortunately*, OpenSSL's specific source change is not well-tolerated by Swift code. There are a number of reasons for this, mostly explained in https://forums.swift.org/t/opaque-pointers-in-swift/6875. The end result of this is that we require substantial, wide-ranging changes to the implementation in order to successfully compile against both OpenSSL versions 1.0.X and 1.1.X.

This patch contains those wide ranging modifications. The most profound of them is to use the compiler to essentially convert between arbitrary pointer types without writing the names of those types down. Unfortunately this totally escapes the Swift type system, which is substantially less than ideal. However, in the current mode where opaque C structures are unityped in Swift it is really the best we can do.

Modifications:

- Supported converting all pointer types to OpaquePointer.
- Added conversions absolutely everywhere.
- Fixed a few problems with callbacks.
- Moved OpenSSL initialization to C to support both macros and
  functions.
- Made locking callbacks optional.
- Fixed tests that relied on OpenSSL 1.0.2 behaviour of ALPN failure
  to now check OpenSSL version before they assume an outcome.

Result:

Compile against OpenSSL 1.1.0 at the very least.