### PR TITLE
add support for muliple build architectures and swift versions with docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,50 @@
-FROM ubuntu:14.04
-MAINTAINER tomerd@apple.com
+ARG ubuntu_version=16.04
+FROM ubuntu:$ubuntu_version
+# needed to do again after FROM due to docker limitation
+ARG ubuntu_version
+
+ARG DEBIAN_FRONTEND=noninteractive
+# do not start services during installation as this will fail and log a warning / error.
+RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
+
+# basic dependencies
+RUN apt-get update && apt-get install -y wget git build-essential software-properties-common pkg-config locales
+RUN apt-get update && apt-get install -y libicu-dev libblocksruntime0 libssl-dev
 
 # local
+RUN locale-gen en_US.UTF-8
 RUN locale-gen en_US en_US.UTF-8
 RUN dpkg-reconfigure locales
 RUN echo 'export LANG=en_US.UTF-8' >> $HOME/.profile
 RUN echo 'export LANGUAGE=en_US:en' >> $HOME/.profile
 RUN echo 'export LC_ALL=en_US.UTF-8' >> $HOME/.profile
 
-# basic dependencies
-RUN apt-get update
-RUN apt-get install -y wget git curl software-properties-common pkg-config
-RUN apt-get install -y libicu-dev libblocksruntime0 libssl-dev
+# known_hosts
+RUN mkdir -p $HOME/.ssh
+RUN touch $HOME/.ssh/known_hosts
+RUN ssh-keyscan github.com 2> /dev/null >> $HOME/.ssh/known_hosts
 
 # clang
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
-RUN apt-get update
-RUN apt-get install -y clang-5.0 lldb-5.0
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 100
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
+RUN apt-get update && apt-get install -y clang-3.9
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 100
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100
+
+# modern curl, if needed
+ARG install_curl_from_source
+RUN apt-get update && apt-get install -y curl libcurl4-openssl-dev libz-dev
+
+# ruby
+ARG skip_ruby_from_ppa
+RUN [ -n "$skip_ruby_from_ppa" ] || apt-add-repository -y ppa:brightbox/ruby-ng
+RUN [ -n "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby2.4 ruby2.4-dev; }
+RUN [ -z "$skip_ruby_from_ppa" ] || { apt-get update && apt-get install -y ruby ruby-dev; }
+RUN apt-get update && apt-get install -y libsqlite3-dev
 
 # swift
-ARG version=4.0.2
+ARG swift_version=4.0.3
+ARG swift_flavour=RELEASE
 RUN mkdir $HOME/.swift
-RUN wget -q https://swift.org/builds/swift-${version}-release/ubuntu1404/swift-${version}-RELEASE/swift-${version}-RELEASE-ubuntu14.04.tar.gz -O $HOME/swift.tar.gz
+RUN wget -q https://swift.org/builds/swift-${swift_version}-$(echo $swift_flavour | tr A-Z a-z)/ubuntu$(echo $ubuntu_version | sed 's/\.//g')/swift-${swift_version}-${swift_flavour}/swift-${swift_version}-${swift_flavour}-ubuntu${ubuntu_version}.tar.gz -O $HOME/swift.tar.gz
 RUN tar xzf $HOME/swift.tar.gz --directory $HOME/.swift --strip-components=1
 RUN echo 'export PATH="$HOME/.swift/usr/bin:$PATH"' >> $HOME/.profile
 RUN echo 'export LINUX_SOURCEKIT_LIB_PATH="$HOME/.swift/usr/lib"' >> $HOME/.profile
@@ -34,13 +54,3 @@ RUN mkdir -p $HOME/.scripts
 RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.scripts/symbolicate-linux-fatal
 RUN chmod 755 $HOME/.scripts/symbolicate-linux-fatal
 RUN echo 'export PATH="$HOME/.scripts:$PATH"' >> $HOME/.profile
-
-# ruby
-RUN apt-add-repository -y ppa:brightbox/ruby-ng
-RUN apt-get update
-RUN apt-get install -y ruby2.4 ruby2.4-dev libsqlite3-dev
-
-# known_hosts
-RUN mkdir -p $HOME/.ssh
-RUN touch $HOME/.ssh/known_hosts
-RUN ssh-keyscan github.com >> $HOME/.ssh/known_hosts

--- a/docker/docker-compose.1404.403.yaml
+++ b/docker/docker-compose.1404.403.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:14.04-4.0.3
+    build:
+      args:
+        ubuntu_version : "14.04"
+        swift_version : "4.0.3"
+
+  test:
+    image: swift-nio-ssl:14.04-4.0.3

--- a/docker/docker-compose.1404.41.yaml
+++ b/docker/docker-compose.1404.41.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:14.04-4.1
+    build:
+      args:
+        ubuntu_version : "14.04"
+        swift_version : "4.1"
+
+  test:
+    image: swift-nio-ssl:14.04-4.1

--- a/docker/docker-compose.1404.42.yaml
+++ b/docker/docker-compose.1404.42.yaml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:14.04-4.2
+    build:
+      args:
+        ubuntu_version : "14.04"
+        swift_version : "4.2"
+        swift_flavour : "CONVERGENCE"
+
+  test:
+    image: swift-nio-ssl:14.04-4.2

--- a/docker/docker-compose.1604.403.yaml
+++ b/docker/docker-compose.1604.403.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:16.04-4.0.3
+    build:
+      args:
+        ubuntu_version : "16.04"
+        swift_version : "4.0.3"
+
+  test:
+    image: swift-nio-ssl:16.04-4.0.3

--- a/docker/docker-compose.1604.41.yaml
+++ b/docker/docker-compose.1604.41.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:16.04-4.1
+    build:
+      args:
+        ubuntu_version : "16.04"
+        swift_version : "4.1"
+
+  test:
+    image: swift-nio-ssl:16.04-4.1

--- a/docker/docker-compose.1604.42.yaml
+++ b/docker/docker-compose.1604.42.yaml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:16.04-4.2
+    build:
+      args:
+        ubuntu_version : "16.04"
+        swift_version : "4.2"
+        swift_flavour : "CONVERGENCE"
+
+  test:
+    image: swift-nio-ssl:16.04-4.2

--- a/docker/docker-compose.1804.42.yaml
+++ b/docker/docker-compose.1804.42.yaml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:18.04-4.2
+    build:
+      args:
+        ubuntu_version : "18.04"
+        swift_version : "4.2"
+        swift_flavour : "CONVERGENCE"
+        skip_ruby_from_ppa : "true"
+
+  test:
+    image: swift-nio-ssl:18.04-4.2

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,28 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.1604.41.yaml run test
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:default
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: swift-nio-ssl:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code
+    working_dir: /code
+
+  sanity:
+    <<: *common
+    command: /bin/bash -cl "./scripts/sanity.sh"
+
+  test:
+    <<: *common
+    command: /bin/bash -cl "swift test"


### PR DESCRIPTION
motivation: easier testing on different architectures and swift versions

changes:
* update dockerfile to match more closely what we do in swift-nio, including support for extenral versions of ubuntu and swift
* add docker-compose files representing different permutations of ubuntu and swift versions