### PR TITLE
Get tests passing with OpenSSL 1.1.1.

### DIFF
--- a/Sources/CNIOOpenSSL/include/c_nio_openssl.h
+++ b/Sources/CNIOOpenSSL/include/c_nio_openssl.h
@@ -27,6 +27,12 @@
 #include <openssl/x509v3.h>
 
 // MARK: OpenSSL version shims
+#if defined(SSL_OP_NO_TLSv1_3)
+int CNIOOpenSSL_SSL_OP_NO_TLSv1_3 = SSL_OP_NO_TLSv1_3;
+#else
+int CNIOOpenSSL_SSL_OP_NO_TLSv1_3 = 0;
+#endif
+
 // These are functions that shim over differences in different OpenSSL versions,
 // which are best handled by using the C preprocessor.
 static inline void CNIOOpenSSL_SSL_CTX_setAutoECDH(SSL_CTX *ctx) {

--- a/Sources/NIOOpenSSL/SSLContext.swift
+++ b/Sources/NIOOpenSSL/SSLContext.swift
@@ -158,7 +158,10 @@ public final class SSLContext {
             fallthrough
         case .some(.tlsv11):
             opensslOptions |= Int(SSL_OP_NO_TLSv1_2)
-        case .some(.tlsv12), .some(.tlsv13), .none:
+            fallthrough
+        case .some(.tlsv12):
+            opensslOptions |= Int(CNIOOpenSSL_SSL_OP_NO_TLSv1_3)
+        case .some(.tlsv13), .none:
             break
         }
 

--- a/Sources/NIOOpenSSL/SSLErrors.swift
+++ b/Sources/NIOOpenSSL/SSLErrors.swift
@@ -26,7 +26,7 @@ public struct OpenSSLInternalError: Equatable, CustomStringConvertible {
     }
 
     public var description: String {
-        return"Error: \(errorCode) \(errorMessage ?? "")"
+        return "Error: \(errorCode) \(errorMessage ?? "")"
     }
 
     init(errorCode: u_long) {

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
@@ -27,9 +27,10 @@ extension TLSConfigurationTest {
    static var allTests : [(String, (TLSConfigurationTest) -> () throws -> Void)] {
       return [
                 ("testNonOverlappingTLSVersions", testNonOverlappingTLSVersions),
-                ("testNonOverlappingCipherSuites", testNonOverlappingCipherSuites),
+                ("testNonOverlappingCipherSuitesPreTLS13", testNonOverlappingCipherSuitesPreTLS13),
                 ("testCannotVerifySelfSigned", testCannotVerifySelfSigned),
-                ("testServerCannotValidateClient", testServerCannotValidateClient),
+                ("testServerCannotValidateClientPreTLS13", testServerCannotValidateClientPreTLS13),
+                ("testServerCannotValidateClientPostTLS13", testServerCannotValidateClientPostTLS13),
                 ("testMutualValidation", testMutualValidation),
                 ("testNonexistentFileObject", testNonexistentFileObject),
            ]


### PR DESCRIPTION
Motivation:

As OpenSSL 1.1.1 has just been released, it is reasonable for users to
be able to use it with SwiftNIO.

Modifications:

- Fixed an issue where we would fail to exclude TLSv1.3 when users set
  max TLS version to lower than TLSv1.3.
- Fixed an issue where we'd fail to read application data sent in the
  same TCP segment as a Finished message.
- Fixed a minor typo in error message strings.

Result:

OpenSSL 1.1.1 is formally supported.