### PR TITLE
Support configuring TLS 1.3 cipher suites. (#38)

### DIFF
--- a/Sources/CNIOOpenSSL/include/c_nio_openssl.h
+++ b/Sources/CNIOOpenSSL/include/c_nio_openssl.h
@@ -124,6 +124,14 @@ static inline long CNIOOpenSSL_SSL_CTX_set_options(SSL_CTX *ctx, long options) {
     return SSL_CTX_set_options(ctx, options);
 }
 
+static inline int CNIOOpenSSL_SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str) {
+#if (OPENSSL_VERSION_NUMBER < 0x10101000L) || defined(LIBRESSL_VERSION_NUMBER)
+    return 1;
+#else
+    return SSL_CTX_set_ciphersuites(ctx, str);
+#endif
+}
+
 static inline void CNIOOpenSSL_OPENSSL_free(void *addr) {
     OPENSSL_free(addr);
 }

--- a/Sources/NIOOpenSSL/SSLContext.swift
+++ b/Sources/NIOOpenSSL/SSLContext.swift
@@ -171,9 +171,10 @@ public final class SSLContext {
         CNIOOpenSSL_SSL_CTX_set_options(ctx, opensslOptions)
 
         // Cipher suites. We just pass this straight to OpenSSL.
-        configuration.cipherSuites.withCString {
-            precondition(1 == SSL_CTX_set_cipher_list(ctx, $0))
-        }
+        let tls12ReturnCode = SSL_CTX_set_cipher_list(ctx, configuration.cipherSuites)
+        precondition(1 == tls12ReturnCode)
+        let tls13ReturnCode = CNIOOpenSSL_SSL_CTX_set_ciphersuites(ctx, configuration.tls13CipherSuites)
+        precondition(1 == tls13ReturnCode)
 
         // If validation is turned on, set the trust roots and turn on cert validation.
         switch configuration.certificateVerification {

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
@@ -43,6 +43,7 @@ extension OpenSSLIntegrationTest {
                 ("testZeroLengthWrite", testZeroLengthWrite),
                 ("testZeroLengthWritePromisesFireInOrder", testZeroLengthWritePromisesFireInOrder),
                 ("testEncryptedFileInContext", testEncryptedFileInContext),
+                ("testFlushPendingReadsOnCloseNotify", testFlushPendingReadsOnCloseNotify),
            ]
    }
 }

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
@@ -28,6 +28,7 @@ extension TLSConfigurationTest {
       return [
                 ("testNonOverlappingTLSVersions", testNonOverlappingTLSVersions),
                 ("testNonOverlappingCipherSuitesPreTLS13", testNonOverlappingCipherSuitesPreTLS13),
+                ("testNonOverlappingCipherSuitesPostTLS13", testNonOverlappingCipherSuitesPostTLS13),
                 ("testCannotVerifySelfSigned", testCannotVerifySelfSigned),
                 ("testServerCannotValidateClientPreTLS13", testServerCannotValidateClientPreTLS13),
                 ("testServerCannotValidateClientPostTLS13", testServerCannotValidateClientPostTLS13),


### PR DESCRIPTION
Motivation:

OpenSSL uses orthogonal configuration options for pre- and post- TLS 1.3
cipher suites. This is because the two are quite unlike each other, and
so it helps to configure them separately.

Users are therefore currently only able to configure the pre-TLS 1.3
cipher suites. We should allow them to configure the post-TLS1.3 ones too.

Modifications:

Added new configuration options for TLS 1.3 cipher suites.

Result:

Configuration of TLS 1.3 cipher suites will be possible.