### PR TITLE
Flush buffered reads when we read a CLOSE_NOTIFY.

### DIFF
--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
@@ -43,6 +43,7 @@ extension OpenSSLIntegrationTest {
                 ("testZeroLengthWrite", testZeroLengthWrite),
                 ("testZeroLengthWritePromisesFireInOrder", testZeroLengthWritePromisesFireInOrder),
                 ("testEncryptedFileInContext", testEncryptedFileInContext),
+                ("testFlushPendingReadsOnCloseNotify", testFlushPendingReadsOnCloseNotify),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When we read a CLOSE_NOTIFY message, we immediately begin closing the
connection down. This *can* cause an instant close, and if that occurs
then we will have un-flushed data in the read buffer that we never
deliver.

If we receive a CLOSE_NOTIFY we will not receive more application data,
so we should deliver all that application data before we initiate the
shutdown process.

Modifications:

Unbuffer the buffered reads when we read a CLOSE_NOTIFY.

Result:

All reads will be shipped before channelInactive can fire.