### PR TITLE
fix Android support

### DIFF
--- a/Sources/NIOOpenSSL/PosixPort.swift
+++ b/Sources/NIOOpenSSL/PosixPort.swift
@@ -29,7 +29,7 @@ private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mun
 // Sadly, stat has different signatures with glibc and macOS libc.
 #if os(Android)
 private let sysStat: (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif os(Linux) || os(FreeBSD)
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)

--- a/Sources/NIOOpenSSL/PosixPort.swift
+++ b/Sources/NIOOpenSSL/PosixPort.swift
@@ -27,7 +27,9 @@ private let sysMlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mlock
 private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = munlock
 
 // Sadly, stat has different signatures with glibc and macOS libc.
-#if os(Linux) || os(FreeBSD) || os(Android)
+#if os(Android)
+private let sysStat: (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
+#elseif os(Linux) || os(FreeBSD) || os(Android)
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)

--- a/Sources/NIOOpenSSL/PosixPort.swift
+++ b/Sources/NIOOpenSSL/PosixPort.swift
@@ -27,12 +27,10 @@ private let sysMlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mlock
 private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = munlock
 
 // Sadly, stat has different signatures with glibc and macOS libc.
-#if os(Android)
-private let sysStat: (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
+private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)
 #elseif os(Linux) || os(FreeBSD)
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
-#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)
 #endif
 
 

--- a/Sources/NIOOpenSSL/SSLContext.swift
+++ b/Sources/NIOOpenSSL/SSLContext.swift
@@ -32,7 +32,11 @@ private enum FileSystemObject {
             return nil
         }
 
+#if os(Android)
+        return (statObj.st_mode & UInt32(Glibc.S_IFDIR)) != 0 ? .directory : .file
+#else
         return (statObj.st_mode & S_IFDIR) != 0 ? .directory : .file
+#endif
     }
 }
 


### PR DESCRIPTION
### Android support

**Motivation:**
fix `swift-nio-ssl` compatible with Android. This is a continuation(apple/swift-nio#609) of porting `Vapor/WebSocket` and all related packages to Android.

**Modifications:**
fix `FileSystemObject::pathType` and `sysStat` Android API inconsistency

**Result:**
now `swift-nio-ssl` compatible with Android!