### PR TITLE
Support extracting public keys in handshakes.

### DIFF
--- a/Sources/CNIOOpenSSL/include/c_nio_openssl.h
+++ b/Sources/CNIOOpenSSL/include/c_nio_openssl.h
@@ -57,6 +57,8 @@ void CNIOOpenSSL_SSL_CTX_setAutoECDH(SSL_CTX *ctx);
 int CNIOOpenSSL_SSL_set_tlsext_host_name(SSL *ssl, const char *name);
 const unsigned char *CNIOOpenSSL_ASN1_STRING_get0_data(ASN1_STRING *x);
 const SSL_METHOD *CNIOOpenSSL_TLS_Method(void);
+int CNIOOpenSSL_X509_up_ref(X509 *x);
+int CNIOOpenSSL_SSL_get_ex_new_index(long argl, void *argp, CRYPTO_EX_new *new_func, CRYPTO_EX_dup *dup_func, CRYPTO_EX_free *free_func);
 
 // MARK: Macro wrappers
 // These are functions that rely on things declared in macros in OpenSSL, at least in
@@ -108,6 +110,7 @@ int CNIOOpenSSL_BIO_should_retry(BIO *bio);
 int CNIOOpenSSL_BIO_should_read(BIO *bio);
 int CNIOOpenSSL_BIO_get_close(BIO *bio);
 int CNIOOpenSSL_BIO_set_close(BIO *bio, long flag);
+long CNIOOpenSSL_BIO_get_mem_data(BIO *bio, char **dataPtr);
 
 // MARK: BIO helpers
 /// This is a pointer to the BIO_METHOD structure for NIO's ByteBufferBIO.

--- a/Sources/NIOOpenSSL/OpenSSLClientHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLClientHandler.swift
@@ -32,7 +32,7 @@ private extension String {
 /// are acting as the client in the TLS dialog. For server connections,
 /// use the `OpenSSLServerHandler`.
 public final class OpenSSLClientHandler: OpenSSLHandler {
-    public init(context: SSLContext, serverHostname: String? = nil) throws {
+    public init(context: SSLContext, serverHostname: String? = nil, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
             throw NIOOpenSSLError.unableToAllocateOpenSSLObject
         }
@@ -46,6 +46,11 @@ public final class OpenSSLClientHandler: OpenSSLHandler {
             // IP addresses must not be provided in the SNI extension, so filter them.
             try connection.setSNIServerName(name: serverHostname)
         }
+
+        if let verificationCallback = verificationCallback {
+            connection.setVerificationCallback(verificationCallback)
+        }
+
         super.init(connection: connection, expectedHostname: serverHostname)
     }
 }

--- a/Sources/NIOOpenSSL/OpenSSLHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLHandler.swift
@@ -61,6 +61,13 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler {
         }
     }
 
+    public func handlerRemoved(ctx: ChannelHandlerContext) {
+        /// Get the connection to drop any state it might have. This state can cause reference cycles,
+        /// so we need to break those when we know it's safe to do so. This is a good safe point, as no
+        /// further I/O can possibly occur.
+        self.connection.close()
+    }
+
     public func channelActive(ctx: ChannelHandlerContext) {
         // We fire this a bit early, entirely on purpose. This is because
         // in doHandshakeStep we may end up closing the channel again, and

--- a/Sources/NIOOpenSSL/OpenSSLServerHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLServerHandler.swift
@@ -19,12 +19,17 @@ import NIO
 /// are acting as the server in the TLS dialog. For client connections,
 /// use the `OpenSSLClientHandler`.
 public final class OpenSSLServerHandler: OpenSSLHandler {
-    public init(context: SSLContext) throws {
+    public init(context: SSLContext, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
             throw NIOOpenSSLError.unableToAllocateOpenSSLObject
         }
 
         connection.setAcceptState()
+
+        if let verificationCallback = verificationCallback {
+            connection.setVerificationCallback(verificationCallback)
+        }
+
         super.init(connection: connection)
     }
 }

--- a/Sources/NIOOpenSSL/SSLCertificate.swift
+++ b/Sources/NIOOpenSSL/SSLCertificate.swift
@@ -212,6 +212,25 @@ public class OpenSSLCertificate {
     }
 }
 
+// MARK:- Utility Functions
+// We don't really want to get too far down the road of providing helpers for things like certificates
+// and private keys: this is really the domain of alternative cryptography libraries. However, to
+// enable users of swift-nio-ssl to use other cryptography libraries it will be helpful to provide
+// the ability to obtain the bytes that correspond to certificates and keys.
+extension OpenSSLCertificate {
+    /// Obtain the public key for this `OpenSSLCertificate`.
+    ///
+    /// - returns: This certificate's `OpenSSLPublicKey`.
+    /// - throws: If an error is encountered extracting the key.
+    public func extractPublicKey() throws -> OpenSSLPublicKey {
+        guard let key = X509_get_pubkey(.make(optional: self.ref)) else {
+            throw NIOOpenSSLError.unableToAllocateOpenSSLObject
+        }
+
+        return OpenSSLPublicKey.fromInternalPointer(takingOwnership: .init(key))
+    }
+}
+
 extension OpenSSLCertificate: Equatable {
     public static func ==(lhs: OpenSSLCertificate, rhs: OpenSSLCertificate) -> Bool {
         return X509_cmp(.make(optional: lhs.ref), .make(optional: rhs.ref)) == 0

--- a/Sources/NIOOpenSSL/SSLPublicKey.swift
+++ b/Sources/NIOOpenSSL/SSLPublicKey.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CNIOOpenSSL
+
+/// An `OpenSSLPublicKey` is an abstract handle to a public key owned by OpenSSL.
+///
+/// This object is of minimal utility, as it cannot be used for very many operations
+/// in `NIOOpenSSL`. Its primary purpose is to allow extracting public keys from
+/// `OpenSSLCertificate` objects to be serialized, so that they can be passed to
+/// general-purpose cryptography libraries.
+public class OpenSSLPublicKey {
+    private let ref: OpaquePointer
+
+    fileprivate init(withOwnedReference ref: OpaquePointer) {
+        self.ref = ref
+    }
+
+    deinit {
+        EVP_PKEY_free(.make(optional: self.ref))
+    }
+}
+
+// MARK:- Helpful initializers
+extension OpenSSLPublicKey {
+    /// Create an `OpenSSLPublicKey` object from an internal `EVP_PKEY` pointer.
+    ///
+    /// This method expects `pointer` to be passed at +1, and consumes that reference.
+    ///
+    /// - parameters:
+    ///    - pointer: A pointer to an `EVP_PKEY` structure containing the public key.
+    /// - returns: An `OpenSSLPublicKey` wrapping the pointer.
+    internal static func fromInternalPointer(takingOwnership pointer: OpaquePointer) -> OpenSSLPublicKey {
+        return OpenSSLPublicKey(withOwnedReference: pointer)
+    }
+}
+
+extension OpenSSLPublicKey {
+    /// Extracts the bytes of this public key in the SubjectPublicKeyInfo format.
+    ///
+    /// The SubjectPublicKeyInfo format is defined in RFC 5280. In addition to the raw key bytes, it also
+    /// provides an identifier of the algorithm, ensuring that the key can be unambiguously decoded.
+    ///
+    /// - returns: The DER-encoded SubjectPublicKeyInfo bytes for this public key.
+    /// - throws: If an error occurred while serializing the key.
+    public func toSPKIBytes() throws -> [UInt8] {
+        guard let bio = BIO_new(BIO_s_mem()) else {
+            throw NIOOpenSSLError.unableToAllocateOpenSSLObject
+        }
+
+        defer {
+            BIO_free(bio)
+        }
+
+        let rc = i2d_PUBKEY_bio(bio, .make(optional: self.ref))
+        guard rc == 1 else {
+            let errorStack = OpenSSLError.buildErrorStack()
+            throw OpenSSLError.unknownError(errorStack)
+        }
+
+        var dataPtr: UnsafeMutablePointer<CChar>? = nil
+        let length = CNIOOpenSSL_BIO_get_mem_data(bio, &dataPtr)
+
+        guard let bytes = dataPtr.map({ UnsafeMutableRawBufferPointer(start: $0, count: length) }) else {
+            throw NIOOpenSSLError.unableToAllocateOpenSSLObject
+        }
+
+        return Array(bytes)
+    }
+}

--- a/Sources/NIOOpenSSL/SSLVerificationCallbacks.swift
+++ b/Sources/NIOOpenSSL/SSLVerificationCallbacks.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CNIOOpenSSL
+
+/// The result of an attempt to verify an X.509 certificate.
+public enum OpenSSLVerificationResult {
+    /// The certificate was successfully verified.
+    case certificateVerified
+
+    /// The certificate was not verified.
+    case failed
+
+    internal init(fromOpenSSLPreverify preverify: CInt) {
+        switch preverify {
+        case 1:
+            self = .certificateVerified
+        case 0:
+            self = .failed
+        default:
+            preconditionFailure("Invalid preverify value: \(preverify)")
+        }
+    }
+}
+
+/// A custom verification callback.
+///
+/// This verification callback is usually called more than once per connection, as it is called once
+/// per certificate in the peer's complete certificate chain (including the root CA). The calls proceed
+/// from root to leaf, ending with the peer's leaf certificate. Each time it is invoked with 2 arguments:
+///
+/// 1. The result of the OpenSSL verification for this certificate
+/// 2. The `SSLCertificate` for this level of the chain.
+///
+/// Please be cautious with calling out from this method. This method is always invoked on the event loop,
+/// so you must not block or wait. It is not possible to return an `EventLoopFuture` from this method, as it
+/// must not block or wait. Additionally, this method must take care to ensure that it does not cause any
+/// ChannelHandler to recursively call back into the `OpenSSLHandler` that triggered it, as making re-entrant
+/// calls into OpenSSL is not supported by SwiftNIO and leads to undefined behaviour.
+///
+/// In general, the only safe thing to do here is to either perform some cryptographic operations, to log,
+/// or to store the `OpenSSLCertificate` somewhere for later consumption. The easiest way to be sure that the
+/// `OpenSSLCertificate` is safe to consume is to wait for a user event that shows the handshake as completed,
+/// or for channelInactive.
+public typealias OpenSSLVerificationCallback = (OpenSSLVerificationResult, OpenSSLCertificate) -> OpenSSLVerificationResult

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
@@ -44,6 +44,8 @@ extension OpenSSLIntegrationTest {
                 ("testZeroLengthWritePromisesFireInOrder", testZeroLengthWritePromisesFireInOrder),
                 ("testEncryptedFileInContext", testEncryptedFileInContext),
                 ("testFlushPendingReadsOnCloseNotify", testFlushPendingReadsOnCloseNotify),
+                ("testForcingVerificationFailure", testForcingVerificationFailure),
+                ("testExtractingCertificates", testExtractingCertificates),
            ]
    }
 }

--- a/Tests/NIOOpenSSLTests/OpenSSLTestHelpers.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLTestHelpers.swift
@@ -197,6 +197,10 @@ Qm9iVKtLrDinHUpMsA==
 -----END ENCRYPTED PRIVATE KEY-----
 """
 
+let sampleDerCertSPKI = Array(Data(base64Encoded: """
+'MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA72vMk44TxyawioAkwKscPGQEAyBmEywnzrcyda1XPkkgkroIoj827bq0TOiQfLcQj3nrlHCKS9q6F4yxZpMUDg8P8/6zUO3FEIYhwrnH5KhM3sOuflm56gk1lF9Ni436DDKGmvOtmtiNem8RU9i5Ih5SorlcatPIUDa4aP3Bjd/0gXit3slPR7BFvVTw5xHvFBtcoaORjiIkTVPJ+YiwFlugpob9phr0pudbJOQOyxoQtZQgquPDC4+BWBK+UBiajXYyWwYTOQ73PvyO8WaFQ6xoSV0zxRrYCE4pbShJiBq5W6uj8Cn+jnOfw8MgNqmX2D7m+M3Yu5ypfZr262gW/FIpdPg29+kv18m/N0E0wzjGmq0ciRXR+SIxtaQRbYUWU5cqcglXzBPhr2J264gMyDw7uhz6C32kb0wdNa2FebhLb0MBFOp9njxtbvvPxGsRRFXTejTlv+3C4AlJHLI4JSLrXIyjdg3K15uNjZbc/Gqmr5iZPmqGoFkMuVMsym24V0hK/pJCCDsmgUcYxZFdRq8yP+yfmpkPilDJlOgcnZW2Dlb8wjWkrBzegoPozf/sZ/fmv3ZX+jHpdPv5+cSwAfwC1CJkmQRu/MnmWlSKFIhpXdr9L6OeTsvDxOm+O2l+M6D7AFuVzfw5r22TZZ1fBgNue9t4vbpabIfBBNQGLWMCAwEAAQ=='
+""", options: .ignoreUnknownCharacters)!)
+
 let sampleDerCert = pemToDer(samplePemCert)
 let sampleDerKey = pemToDer(samplePemKey)
 // No DER version of the private key becuase encrypted DERs aren't real.

--- a/Tests/NIOOpenSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/SSLCertificateTest+XCTest.swift
@@ -44,6 +44,7 @@ extension SSLCertificateTest {
                 ("testMultipleCommonNames", testMultipleCommonNames),
                 ("testNoCommonName", testNoCommonName),
                 ("testUnicodeCommonName", testUnicodeCommonName),
+                ("testExtractingPublicKey", testExtractingPublicKey),
            ]
    }
 }

--- a/Tests/NIOOpenSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOOpenSSLTests/SSLCertificateTest.swift
@@ -327,4 +327,12 @@ class SSLCertificateTest: XCTestCase {
         let cert = try OpenSSLCertificate(buffer: [Int8](unicodeCNCert.utf8CString), format: .pem)
         XCTAssertEqual([UInt8]("straße.org".utf8), cert.commonName()!)
     }
+
+    func testExtractingPublicKey() throws {
+        let cert = try assertNoThrowWithValue(OpenSSLCertificate(buffer: [Int8](samplePemCert.utf8CString), format: .pem))
+        let publicKey = try assertNoThrowWithValue(cert.extractPublicKey())
+        let spkiBytes = try assertNoThrowWithValue(publicKey.toSPKIBytes())
+
+        XCTAssertEqual(spkiBytes, sampleDerCertSPKI)
+    }
 }


### PR DESCRIPTION
Motivation:

Users have requested the ability to extract information about the
public keys provided by peers during TLS handshakes. This is a reasonable
request: it's potentially very useful to have access to this information.

While I'm reluctant to add too much in the way of general cryptographic
functionality, it seems like a good idea to enable it for others. For
this reason, this patch extends NIOOpenSSL to enable this use case.

Modifications:

1. Added an OpenSSLPublicKey class that can be serialized to bytes.
2. Added support for obtaining an OpenSSLPublicKey from an
    OpenSSLCertificate.
3. Added support for setting the OpenSSL cert verification callback.

Result:

Much more flexibility and power in the library.