### PR TITLE
Prevent crashes when closing twice.

### DIFF
--- a/Sources/NIOOpenSSL/OpenSSLHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLHandler.swift
@@ -151,8 +151,10 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler {
         case .closing:
             // We're in the process of TLS shutdown, so let's let that happen. However,
             // we want to cascade the result of the first request into this new one.
-            if let promise = promise {
-                closePromise!.futureResult.cascade(promise: promise)
+            if let promise = promise, let closePromise = self.closePromise {
+                closePromise.futureResult.cascade(promise: promise)
+            } else if let promise = promise {
+                self.closePromise = promise
             }
         case .idle:
             state = .closed

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
@@ -46,6 +46,7 @@ extension OpenSSLIntegrationTest {
                 ("testFlushPendingReadsOnCloseNotify", testFlushPendingReadsOnCloseNotify),
                 ("testForcingVerificationFailure", testForcingVerificationFailure),
                 ("testExtractingCertificates", testExtractingCertificates),
+                ("testRepeatedClosure", testRepeatedClosure),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

If a user called close on a channel without attaching a promise, and
subsequently called close again with a promise, before the TLS shutdown
completes, this would lead to a crash due to a force-unwrap. It has
been my experience that crashes are less than ideal, especially when
users have done nothing wrong.

Modifications:

Replaced the force-unwrap with code that correctly persists the promise.
Added a test.

Result:

Less likely to crash.