### PR TITLE
Add tests for untested assumptions.

### DIFF
--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest+XCTest.swift
@@ -47,6 +47,8 @@ extension OpenSSLIntegrationTest {
                 ("testForcingVerificationFailure", testForcingVerificationFailure),
                 ("testExtractingCertificates", testExtractingCertificates),
                 ("testRepeatedClosure", testRepeatedClosure),
+                ("testReceivingGibberishAfterAttemptingToClose", testReceivingGibberishAfterAttemptingToClose),
+                ("testPendingWritesFailWhenFlushedOnClose", testPendingWritesFailWhenFlushedOnClose),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

While working on an unwrapping patch, I wrote a few tests to provide an
envelope on the unwrapping behaviour in OpenSSL. Some of these tests
should have counterparts for closure, but do not. This patch brings the
equivalent tests forward.

Modifications:

- Tested the failure mode when receiving gibberish instead of
    CLOSE_NOTIFY.
- Tested what happens to writes that are flushed after close().

Result:

Better test coverage.