### PR TITLE
Clean up now-unnecessary warnings.

### DIFF
--- a/Sources/NIOOpenSSL/OpenSSLHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLHandler.swift
@@ -317,7 +317,7 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler {
                 // of data, though this number is utterly arbitrary. In practice this will
                 // always double the storage if it has to.
                 if receiveBuffer.writableBytes < 1024 {
-                    receiveBuffer.changeCapacity(to: receiveBuffer.capacity + 1024)
+                    receiveBuffer.reserveCapacity(receiveBuffer.capacity + 1024)
                 }
 
             case .incomplete:
@@ -619,13 +619,13 @@ extension OpenSSLHandler {
 }
 
 fileprivate extension MarkedCircularBuffer {
-    fileprivate mutating func forEachElementUntilMark(callback: (E) throws -> Bool) rethrows {
+    mutating func forEachElementUntilMark(callback: (E) throws -> Bool) rethrows {
         while try self.hasMark() && callback(self.first!) {
             _ = self.removeFirst()
         }
     }
 
-    fileprivate mutating func forEachRemoving(callback: (E) -> Void) {
+    mutating func forEachRemoving(callback: (E) -> Void) {
         while self.count > 0 {
             callback(self.removeFirst())
         }

--- a/Sources/NIOOpenSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOOpenSSL/SSLPKCS12Bundle.swift
@@ -168,7 +168,7 @@ internal extension Collection where Element == UInt8 {
     ///
     /// This method should be used when it is necessary to take a secure copy of a collection of
     /// bytes. Its implementation relies on OpenSSL directly.
-    internal func withSecureCString<T>(_ block: (UnsafePointer<Int8>) throws -> T) throws -> T {
+    func withSecureCString<T>(_ block: (UnsafePointer<Int8>) throws -> T) throws -> T {
         // We need to allocate some memory and prevent it being swapped to disk while we use it.
         // For that reason we use mlock.
         // Note that here we use UnsafePointer and UnsafeBufferPointer. Ideally we'd just use
@@ -211,7 +211,7 @@ internal extension Collection where Element == UInt8 {
 
 
 internal extension Optional where Wrapped: Collection, Wrapped.Element == UInt8 {
-    internal func withSecureCString<T>(_ block: (UnsafePointer<Int8>?) throws -> T) throws -> T {
+    func withSecureCString<T>(_ block: (UnsafePointer<Int8>?) throws -> T) throws -> T {
         if let `self` = self {
             return try self.withSecureCString(block)
         } else {

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -31,7 +31,7 @@ private final class EchoHandler: ChannelInboundHandler {
 let sslContext = try! SSLContext(configuration: TLSConfiguration.forServer(certificateChain: [.file("cert.pem")], privateKey: .file("key.pem")))
 
 
-let group = MultiThreadedEventLoopGroup(numThreads: 1)
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 let bootstrap = ServerBootstrap(group: group)
     // Specify backlog and enable SO_REUSEADDR for the server itself
     .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Tests/NIOOpenSSLTests/ClientSNITests.swift
+++ b/Tests/NIOOpenSSLTests/ClientSNITests.swift
@@ -40,7 +40,7 @@ class ClientSNITests: XCTestCase {
     private func assertSniResult(sniField: String?, expectedResult: SniResult) throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             try? group.syncShutdownGracefully()
         }

--- a/Tests/NIOOpenSSLTests/OpenSSLALPNTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLALPNTest.swift
@@ -41,7 +41,7 @@ class OpenSSLALPNTest: XCTestCase {
     private func assertNegotiatedProtocol(protocol: String?,
                                           serverContext: NIOOpenSSL.SSLContext,
                                           clientContext: NIOOpenSSL.SSLContext) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -81,7 +81,7 @@ class OpenSSLALPNTest: XCTestCase {
     }
 
     private func assertDoesNotNegotiate(serverContext: NIOOpenSSL.SSLContext, clientContext: NIOOpenSSL.SSLContext) throws {
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
@@ -383,7 +383,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testSimpleEcho() throws {
         let ctx = try configuredSSLContext()
         
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -415,7 +415,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testHandshakeEventSequencing() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -462,7 +462,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testShutdownEventSequencing() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -508,7 +508,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         var serverClosed = false
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -568,7 +568,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testCoalescedWrites() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -615,7 +615,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testCoalescedWritesWithFutures() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -679,7 +679,7 @@ class OpenSSLIntegrationTest: XCTestCase {
 
     func testAddingTlsToActiveChannelStillHandshakes() throws {
         let ctx = try configuredSSLContext()
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -729,7 +729,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         let serverCtx = try configuredSSLContext()
         let clientCtx = try configuredClientContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             try? group.syncShutdownGracefully()
         }
@@ -771,7 +771,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         let serverCtx = try configuredSSLContext()
         let clientCtx = try configuredClientContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -870,7 +870,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         }
         let clientCtx = try assertNoThrowWithValue(SSLContext(configuration: config))
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -906,7 +906,7 @@ class OpenSSLIntegrationTest: XCTestCase {
                                                       privateKey: .privateKey(OpenSSLIntegrationTest.key))
         let clientCtx = try assertNoThrowWithValue(SSLContext(configuration: clientConfig))
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -989,7 +989,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testZeroLengthWrite() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             try? group.syncShutdownGracefully()
         }
@@ -1084,7 +1084,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testEncryptedFileInContext() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1161,7 +1161,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testForcingVerificationFailure() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -1209,7 +1209,7 @@ class OpenSSLIntegrationTest: XCTestCase {
     func testExtractingCertificates() throws {
         let ctx = try configuredSSLContext()
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
@@ -75,7 +75,7 @@ class TLSConfigurationTest: XCTestCase {
         let clientContext = try SSLContext(configuration: clientConfig)
         let serverContext = try SSLContext(configuration: serverConfig)
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -109,7 +109,7 @@ class TLSConfigurationTest: XCTestCase {
         let clientContext = try SSLContext(configuration: clientConfig)
         let serverContext = try SSLContext(configuration: serverConfig)
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
@@ -234,7 +234,7 @@ class TLSConfigurationTest: XCTestCase {
         let clientContext = try SSLContext(configuration: clientConfig)
         let serverContext = try SSLContext(configuration: serverConfig)
 
-        let group = MultiThreadedEventLoopGroup(numThreads: 1)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }


### PR DESCRIPTION
Motivation:

As we bumped the dependency of NIO to 1.12 to resolve #54, we can now avoid some
deprecation warnings, as even the low-end of NIO versions we
support will be safe.

While we're here, we can remove the warnings that Swift 5 started
emitting for our visibility specifiers in extensions.

Modifications:

- Replaced changeCapacity with reserveCapacity
- Replaced numThreads with numberOfThreads
- Removed redundant visibility specifiers

Result:

Back to warning free compilation.

Resolves #44 