### PR TITLE
Update the Swift 5 CI version.

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,7 +8,7 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2018-12-04-a"
+        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-01-23-a"
         swift_builds_suffix: "branch"
         skip_ruby_from_ppa: "true"
 


### PR DESCRIPTION
Motivation:

The older Swift 5 we're using in CI breaks on our Package.swift. This
rather limits the utility of our CI.

Modifications:

Use a newer Swift 5 snapshot.

Result:

CI will actually work.