### PR TITLE
update to latest NIO 2

### DIFF
--- a/Sources/NIOOpenSSL/OpenSSLHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLHandler.swift
@@ -57,17 +57,17 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         self.expectedHostname = expectedHostname
     }
 
-    public func handlerAdded(ctx: ChannelHandlerContext) {
-        self.storedContext = ctx
-        self.connection.setAllocator(ctx.channel.allocator)
-        self.plaintextReadBuffer = ctx.channel.allocator.buffer(capacity: SSL_MAX_RECORD_SIZE)
+    public func handlerAdded(context: ChannelHandlerContext) {
+        self.storedContext = context
+        self.connection.setAllocator(context.channel.allocator)
+        self.plaintextReadBuffer = context.channel.allocator.buffer(capacity: SSL_MAX_RECORD_SIZE)
         // If this channel is already active, immediately begin handshaking.
-        if ctx.channel.isActive {
-            doHandshakeStep(ctx: ctx)
+        if context.channel.isActive {
+            doHandshakeStep(context: context)
         }
     }
 
-    public func handlerRemoved(ctx: ChannelHandlerContext) {
+    public func handlerRemoved(context: ChannelHandlerContext) {
         /// Get the connection to drop any state it might have. This state can cause reference cycles,
         /// so we need to break those when we know it's safe to do so. This is a good safe point, as no
         /// further I/O can possibly occur.
@@ -77,16 +77,16 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         self.storedContext = nil
     }
 
-    public func channelActive(ctx: ChannelHandlerContext) {
+    public func channelActive(context: ChannelHandlerContext) {
         // We fire this a bit early, entirely on purpose. This is because
         // in doHandshakeStep we may end up closing the channel again, and
         // if we do we want to make sure that the channelInactive message received
         // by later channel handlers makes sense.
-        ctx.fireChannelActive()
-        doHandshakeStep(ctx: ctx)
+        context.fireChannelActive()
+        doHandshakeStep(context: context)
     }
     
-    public func channelInactive(ctx: ChannelHandlerContext) {
+    public func channelInactive(context: ChannelHandlerContext) {
         // This fires when the TCP connection goes away. Whatever happens, we end up in the closed
         // state here. This function calls out to a lot of user code, so we need to make sure we're
         // keeping track of the state we're in properly before we do anything else.
@@ -108,14 +108,14 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
 
             shutdownPromise?.fail(OpenSSLError.uncleanShutdown)
             closePromise?.fail(OpenSSLError.uncleanShutdown)
-            ctx.fireErrorCaught(OpenSSLError.uncleanShutdown)
+            context.fireErrorCaught(OpenSSLError.uncleanShutdown)
             discardBufferedWrites(reason: OpenSSLError.uncleanShutdown)
         }
 
-        ctx.fireChannelInactive()
+        context.fireChannelInactive()
     }
     
-    public func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let binaryData = unwrapInboundIn(data)
         
         // The logic: feed the buffers, then take an action based on state.
@@ -123,38 +123,38 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         
         switch state {
         case .handshaking:
-            doHandshakeStep(ctx: ctx)
+            doHandshakeStep(context: context)
         case .active:
-            doDecodeData(ctx: ctx)
-            doUnbufferWrites(ctx: ctx)
+            doDecodeData(context: context)
+            doUnbufferWrites(context: context)
         case .closing:
-            doShutdownStep(ctx: ctx)
+            doShutdownStep(context: context)
         case .unwrapping:
-            self.doShutdownStep(ctx: ctx)
+            self.doShutdownStep(context: context)
         default:
-            ctx.fireErrorCaught(NIOOpenSSLError.readInInvalidTLSState)
-            channelClose(ctx: ctx, reason: NIOOpenSSLError.readInInvalidTLSState)
+            context.fireErrorCaught(NIOOpenSSLError.readInInvalidTLSState)
+            channelClose(context: context, reason: NIOOpenSSLError.readInInvalidTLSState)
         }
     }
     
-    public func channelReadComplete(ctx: ChannelHandlerContext) {
+    public func channelReadComplete(context: ChannelHandlerContext) {
         guard let receiveBuffer = self.plaintextReadBuffer else {
             preconditionFailure("channelReadComplete called before handlerAdded")
         }
 
-        self.doFlushReadData(ctx: ctx, receiveBuffer: receiveBuffer, readOnEmptyBuffer: true)
+        self.doFlushReadData(context: context, receiveBuffer: receiveBuffer, readOnEmptyBuffer: true)
     }
     
-    public func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+    public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         bufferWrite(data: unwrapOutboundIn(data), promise: promise)
     }
 
-    public func flush(ctx: ChannelHandlerContext) {
+    public func flush(context: ChannelHandlerContext) {
         bufferFlush()
-        doUnbufferWrites(ctx: ctx)
+        doUnbufferWrites(context: context)
     }
     
-    public func close(ctx: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
+    public func close(context: ChannelHandlerContext, mode: CloseMode, promise: EventLoopPromise<Void>?) {
         guard mode == .all else {
             // TODO: Support also other modes ?
             promise?.fail(ChannelError.operationUnsupported)
@@ -186,13 +186,13 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         case .closed, .unwrapped:
             // For idle, closed, and unwrapped connections we immediately pass this on to the next
             // channel handler.
-            ctx.close(promise: promise)
+            context.close(promise: promise)
         case .active, .handshaking:
             // We need to begin processing shutdown now. We can't fire the promise for a
             // while though.
             self.state = .closing
             closePromise = promise
-            doShutdownStep(ctx: ctx)
+            doShutdownStep(context: context)
         }
     }
 
@@ -204,41 +204,41 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
     /// network. If we are waiting on data from the remote peer, this method will do nothing.
     ///
     /// This method must not be called once the connection is established.
-    private func doHandshakeStep(ctx: ChannelHandlerContext) {
+    private func doHandshakeStep(context: ChannelHandlerContext) {
         let result = connection.doHandshake()
         
         switch result {
         case .incomplete:
             state = .handshaking
-            writeDataToNetwork(ctx: ctx, promise: nil)
+            writeDataToNetwork(context: context, promise: nil)
         case .complete:
             do {
-                try validateHostname(ctx: ctx)
+                try validateHostname(context: context)
             } catch {
                 // This counts as a failure.
-                ctx.fireErrorCaught(error)
-                channelClose(ctx: ctx, reason: error)
+                context.fireErrorCaught(error)
+                channelClose(context: context, reason: error)
                 return
             }
 
             state = .active
-            writeDataToNetwork(ctx: ctx, promise: nil)
+            writeDataToNetwork(context: context, promise: nil)
             
             // TODO(cory): This event should probably fire out of the OpenSSL info callback.
             let negotiatedProtocol = connection.getAlpnProtocol()
-            ctx.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: negotiatedProtocol))
+            context.fireUserInboundEventTriggered(TLSUserEvent.handshakeCompleted(negotiatedProtocol: negotiatedProtocol))
             
             // We need to unbuffer any pending writes and reads. We will have pending writes if the user attempted to
             // write before we completed the handshake. We may also have pending reads if the user sent data immediately
             // after their FINISHED record. We decode the reads first, as those reads may trigger writes.
-            self.doDecodeData(ctx: ctx)
-            self.doUnbufferWrites(ctx: ctx)
+            self.doDecodeData(context: context)
+            self.doUnbufferWrites(context: context)
         case .failed(let err):
-            writeDataToNetwork(ctx: ctx, promise: nil)
+            writeDataToNetwork(context: context, promise: nil)
             
             // TODO(cory): This event should probably fire out of the OpenSSL info callback.
-            ctx.fireErrorCaught(NIOOpenSSLError.handshakeFailed(err))
-            channelClose(ctx: ctx, reason: NIOOpenSSLError.handshakeFailed(err))
+            context.fireErrorCaught(NIOOpenSSLError.handshakeFailed(err))
+            channelClose(context: context, reason: NIOOpenSSLError.handshakeFailed(err))
         }
     }
 
@@ -253,7 +253,7 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
     ///
     /// Once `state` has transitioned to `.closed`, further calls to this method will
     /// do nothing.
-    private func doShutdownStep(ctx: ChannelHandlerContext) {
+    private func doShutdownStep(context: ChannelHandlerContext) {
         let result = connection.doShutdown()
 
         let targetCompleteState: ConnectionState
@@ -268,32 +268,32 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         
         switch result {
         case .incomplete:
-            writeDataToNetwork(ctx: ctx, promise: nil)
+            writeDataToNetwork(context: context, promise: nil)
         case .complete:
             state = targetCompleteState
-            writeDataToNetwork(ctx: ctx, promise: nil)
+            writeDataToNetwork(context: context, promise: nil)
 
             // TODO(cory): This should probably fire out of the OpenSSL info callback.
-            ctx.fireUserInboundEventTriggered(TLSUserEvent.shutdownCompleted)
+            context.fireUserInboundEventTriggered(TLSUserEvent.shutdownCompleted)
 
             switch targetCompleteState {
             case .closed:
-                self.channelClose(ctx: ctx, reason: NIOTLSUnwrappingError.closeRequestedDuringUnwrap)
+                self.channelClose(context: context, reason: NIOTLSUnwrappingError.closeRequestedDuringUnwrap)
             case .unwrapped:
-                self.channelUnwrap(ctx: ctx)
+                self.channelUnwrap(context: context)
             default:
                 preconditionFailure("Cannot be in \(targetCompleteState) at this code point")
             }
         case .failed(let err):
             // TODO(cory): This should probably fire out of the OpenSSL info callback.
-            ctx.fireErrorCaught(NIOOpenSSLError.shutdownFailed(err))
-            channelClose(ctx: ctx, reason: NIOOpenSSLError.shutdownFailed(err))
+            context.fireErrorCaught(NIOOpenSSLError.shutdownFailed(err))
+            channelClose(context: context, reason: NIOOpenSSLError.shutdownFailed(err))
         }
     }
 
     /// Loops over the `SSL` object, decoding encrypted application data until there is
     /// no more available.
-    private func doDecodeData(ctx: ChannelHandlerContext) {
+    private func doDecodeData(context: ChannelHandlerContext) {
         guard var receiveBuffer = self.plaintextReadBuffer else {
             preconditionFailure("didDecodeData called without handlerAdded firing.")
         }
@@ -336,16 +336,16 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
                 }
 
                 // This is a clean EOF: we can just start doing our own clean shutdown.
-                self.doFlushReadData(ctx: ctx, receiveBuffer: receiveBuffer, readOnEmptyBuffer: false)
-                doShutdownStep(ctx: ctx)
-                writeDataToNetwork(ctx: ctx, promise: nil)
+                self.doFlushReadData(context: context, receiveBuffer: receiveBuffer, readOnEmptyBuffer: false)
+                doShutdownStep(context: context)
+                writeDataToNetwork(context: context, promise: nil)
                 break readLoop
 
             case .failed(let err):
                 self.state = .closed
                 self.plaintextReadBuffer = receiveBuffer
-                ctx.fireErrorCaught(err)
-                channelClose(ctx: ctx, reason: err)
+                context.fireErrorCaught(err)
+                channelClose(context: context, reason: err)
                 break readLoop
             }
         }
@@ -356,7 +356,7 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
     ///
     /// This function will always set the empty buffer back to be the plaintext read buffer.
     /// Do not do this in your own code.
-    private func doFlushReadData(ctx: ChannelHandlerContext, receiveBuffer: ByteBuffer, readOnEmptyBuffer: Bool) {
+    private func doFlushReadData(context: ChannelHandlerContext, receiveBuffer: ByteBuffer, readOnEmptyBuffer: Bool) {
         defer {
             // All exits from this function must restore the plaintext read buffer.
             assert(self.plaintextReadBuffer != nil)
@@ -374,16 +374,16 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
             self.plaintextReadBuffer = ourNewBuffer
 
             // Ok, we can now pass the receive buffer on and fire channelReadComplete.
-            ctx.fireChannelRead(self.wrapInboundOut(receiveBuffer))
-            ctx.fireChannelReadComplete()
+            context.fireChannelRead(self.wrapInboundOut(receiveBuffer))
+            context.fireChannelReadComplete()
         } else if readOnEmptyBuffer {
             // We didn't deliver data, but the channel is still active. If this channel has got
             // autoread turned off then we should call read again, because otherwise the user
             // will never see any result from their read call.
             self.plaintextReadBuffer = receiveBuffer
-            ctx.channel.getOption(ChannelOptions.autoRead).whenSuccess { autoRead in
+            context.channel.getOption(ChannelOptions.autoRead).whenSuccess { autoRead in
                 if !autoRead {
-                    ctx.read()
+                    context.read()
                 }
             }
         } else {
@@ -396,19 +396,19 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
     ///
     /// This method always flushes. For this reason, it should only ever be called when a flush
     /// is intended.
-    private func writeDataToNetwork(ctx: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
+    private func writeDataToNetwork(context: ChannelHandlerContext, promise: EventLoopPromise<Void>?) {
         // There may be no data to write, in which case we can just exit early.
-        guard let dataToWrite = connection.getDataForNetwork(allocator: ctx.channel.allocator) else {
+        guard let dataToWrite = connection.getDataForNetwork(allocator: context.channel.allocator) else {
             if let promise = promise {
                 // If we have a promise, we need to enforce ordering so we issue a zero-length write that
                 // the event loop will have to handle.
-                let buffer = ctx.channel.allocator.buffer(capacity: 0)
-                ctx.writeAndFlush(wrapInboundOut(buffer), promise: promise)
+                let buffer = context.channel.allocator.buffer(capacity: 0)
+                context.writeAndFlush(wrapInboundOut(buffer), promise: promise)
             }
             return
         }
 
-        ctx.writeAndFlush(self.wrapInboundOut(dataToWrite), promise: promise)
+        context.writeAndFlush(self.wrapInboundOut(dataToWrite), promise: promise)
     }
 
     /// Close the underlying channel.
@@ -416,7 +416,7 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
     /// This method does not perform any kind of I/O. Instead, it simply calls ChannelHandlerContext.close with
     /// any promise we may have already been given. It also transitions our state into closed. This should only be
     /// used to clean up after an error, or to perform the final call to close after a clean shutdown attempt.
-    private func channelClose(ctx: ChannelHandlerContext, reason: Error) {
+    private func channelClose(context: ChannelHandlerContext, reason: Error) {
         state = .closed
 
         let shutdownPromise = self.shutdownPromise
@@ -426,10 +426,10 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         self.closePromise = nil
 
         shutdownPromise?.fail(reason)
-        ctx.close(promise: closePromise)
+        context.close(promise: closePromise)
     }
 
-    private func channelUnwrap(ctx: ChannelHandlerContext) {
+    private func channelUnwrap(context: ChannelHandlerContext) {
         assert(self.closePromise == nil)
         self.state = .unwrapped
 
@@ -438,13 +438,13 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
 
         // We create a promise here to make sure we operate in the special magic state
         // where we are not in the pipeline any more, but we still have a valid context.
-        let removalPromise: EventLoopPromise<Void> = ctx.eventLoop.makePromise()
+        let removalPromise: EventLoopPromise<Void> = context.eventLoop.makePromise()
         let removalFuture = removalPromise.futureResult.map {
             // Now drop the writes.
             self.discardBufferedWrites(reason: NIOTLSUnwrappingError.unflushedWriteOnUnwrap)
 
             if let unconsumedData = self.connection.extractUnconsumedData() {
-                ctx.fireChannelRead(self.wrapInboundOut(unconsumedData))
+                context.fireChannelRead(self.wrapInboundOut(unconsumedData))
             }
         }
 
@@ -453,19 +453,19 @@ public class OpenSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Rem
         }
 
         // Ok, we've unwrapped. Let's get out of the channel.
-        ctx.channel.pipeline.remove(ctx: ctx, promise: removalPromise)
+        context.channel.pipeline.removeHandler(context: context, promise: removalPromise)
     }
 
     /// Validates the hostname from the certificate against the hostname provided by
     /// the user, assuming one has been provided at all.
-    private func validateHostname(ctx: ChannelHandlerContext) throws {
+    private func validateHostname(context: ChannelHandlerContext) throws {
         guard connection.validateHostnames else {
             return
         }
 
         // If there is no remote address, something weird is happening here. We can't
         // validate a certificate without it, so bail.
-        guard let ipAddress = ctx.channel.remoteAddress else {
+        guard let ipAddress = context.channel.remoteAddress else {
             throw NIOOpenSSLError.cannotFindPeerIP
         }
 
@@ -518,7 +518,7 @@ extension OpenSSLHandler {
 
             self.state = .unwrapping
             self.shutdownPromise = promise
-            self.channelUnwrap(ctx: storedContext)
+            self.channelUnwrap(context: storedContext)
 
         case .handshaking, .active:
             // Time to try to strip TLS.
@@ -529,7 +529,7 @@ extension OpenSSLHandler {
 
             self.state = .unwrapping
             self.shutdownPromise = promise
-            self.doShutdownStep(ctx: storedContext)
+            self.doShutdownStep(context: storedContext)
 
         case .unwrapped:
             // We are already unwrapped. Succeed the promise, do nothing.
@@ -560,7 +560,7 @@ extension OpenSSLHandler {
         }
     }
 
-    private func doUnbufferWrites(ctx: ChannelHandlerContext) {
+    private func doUnbufferWrites(context: ChannelHandlerContext) {
         // Return early if the user hasn't called flush.
         guard bufferedWrites.hasMark else {
             return
@@ -591,9 +591,9 @@ extension OpenSSLHandler {
         }
 
         func flushWrites() {
-            let ourPromise: EventLoopPromise<Void> = ctx.eventLoop.makePromise()
+            let ourPromise: EventLoopPromise<Void> = context.eventLoop.makePromise()
             promises.forEach { ourPromise.futureResult.cascade(to: $0) }
-            writeDataToNetwork(ctx: ctx, promise: ourPromise)
+            writeDataToNetwork(context: context, promise: ourPromise)
             promises = []
         }
 
@@ -610,7 +610,7 @@ extension OpenSSLHandler {
             }
         } catch {
             // We encountered an error, it's cleanup time. Close ourselves down.
-            channelClose(ctx: ctx, reason: error)
+            channelClose(context: context, reason: error)
             // Fail any writes we've previously encoded but not flushed.
             promises.forEach { $0.fail(error) }
             // Fail everything else.

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -19,12 +19,12 @@ import NIOOpenSSL
 private final class EchoHandler: ChannelInboundHandler {
     public typealias InboundIn = ByteBuffer
 
-    func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
-        ctx.write(data, promise: nil)
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.write(data, promise: nil)
     }
 
-    func channelReadComplete(ctx: ChannelHandlerContext) {
-        ctx.flush()
+    func channelReadComplete(context: ChannelHandlerContext) {
+        context.flush()
     }
 }
 
@@ -39,8 +39,8 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are applied to the accepted channels.
     .childChannelInitializer { channel in
-        return channel.pipeline.add(handler: try! OpenSSLServerHandler(context: sslContext)).flatMap {
-            channel.pipeline.add(handler: EchoHandler())
+        return channel.pipeline.addHandler(try! OpenSSLServerHandler(context: sslContext)).flatMap {
+            channel.pipeline.addHandler(EchoHandler())
         }
     }
 

--- a/Tests/NIOOpenSSLTests/ClientSNITests.swift
+++ b/Tests/NIOOpenSSLTests/ClientSNITests.swift
@@ -33,12 +33,12 @@ class ClientSNITests: XCTestCase {
         let config = TLSConfiguration.forServer(certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                 privateKey: .privateKey(OpenSSLIntegrationTest.key),
                                                 trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        let ctx = try SSLContext(configuration: config)
-        return ctx
+        let context = try SSLContext(configuration: config)
+        return context
     }
 
     private func assertSniResult(sniField: String?, expectedResult: SNIResult) throws {
-        let ctx = try configuredSSLContext()
+        let context = try configuredSSLContext()
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -50,12 +50,12 @@ class ClientSNITests: XCTestCase {
             sniPromise.succeed($0)
             return group.next().makeSucceededFuture(())
         })
-        let serverChannel = try serverTLSChannel(context: ctx, preHandlers: [sniHandler], postHandlers: [], group: group)
+        let serverChannel = try serverTLSChannel(context: context, preHandlers: [sniHandler], postHandlers: [], group: group)
         defer {
             _ = try? serverChannel.close().wait()
         }
 
-        let clientChannel = try clientTLSChannel(context: ctx,
+        let clientChannel = try clientTLSChannel(context: context,
                                                  preHandlers: [],
                                                  postHandlers: [],
                                                  group: group,
@@ -78,10 +78,10 @@ class ClientSNITests: XCTestCase {
     }
 
     func testSNIIsRejectedForIPv4Addresses() throws {
-        let ctx = try configuredSSLContext()
+        let context = try configuredSSLContext()
 
         do {
-            _ = try OpenSSLClientHandler(context: ctx, serverHostname: "192.168.0.1")
+            _ = try OpenSSLClientHandler(context: context, serverHostname: "192.168.0.1")
             XCTFail("Created client handler with invalid SNI name")
         } catch OpenSSLError.invalidSNIName {
             // All fine.
@@ -89,10 +89,10 @@ class ClientSNITests: XCTestCase {
     }
 
     func testSNIIsRejectedForIPv6Addresses() throws {
-        let ctx = try configuredSSLContext()
+        let context = try configuredSSLContext()
 
         do {
-            _ = try OpenSSLClientHandler(context: ctx, serverHostname: "fe80::200:f8ff:fe21:67cf")
+            _ = try OpenSSLClientHandler(context: context, serverHostname: "fe80::200:f8ff:fe21:67cf")
             XCTFail("Created client handler with invalid SNI name")
         } catch OpenSSLError.invalidSNIName {
             // All fine.

--- a/Tests/NIOOpenSSLTests/OpenSSLALPNTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLALPNTest.swift
@@ -81,10 +81,10 @@ class OpenSSLALPNTest: XCTestCase {
     }
 
     func testBasicALPNNegotiation() throws {
-        let ctx: NIOOpenSSL.SSLContext
-        ctx = try assertNoThrowWithValue(configuredSSLContextWithAlpnProtocols(protocols: ["h2", "http/1.1"]))
+        let context: NIOOpenSSL.SSLContext
+        context = try assertNoThrowWithValue(configuredSSLContextWithAlpnProtocols(protocols: ["h2", "http/1.1"]))
 
-        XCTAssertNoThrow(try assertNegotiatedProtocol(protocol: "h2", serverContext: ctx, clientContext: ctx))
+        XCTAssertNoThrow(try assertNegotiatedProtocol(protocol: "h2", serverContext: context, clientContext: context))
     }
 
     func testBasicALPNNegotiationPrefersServerPriority() throws {

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
@@ -26,7 +26,7 @@ class ErrorCatcher<T: Error>: ChannelInboundHandler {
         errors = []
     }
 
-    public func errorCaught(ctx: ChannelHandlerContext, error: Error) {
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
         errors.append(error as! T)
     }
 }
@@ -35,11 +35,11 @@ class HandshakeCompletedHandler: ChannelInboundHandler {
     public typealias InboundIn = Any
     public var handshakeSucceeded = false
 
-    public func userInboundEventTriggered(ctx: ChannelHandlerContext, event: Any) {
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         if let event = event as? TLSUserEvent, case .handshakeCompleted = event {
             self.handshakeSucceeded = true
         }
-        ctx.fireUserInboundEventTriggered(event)
+        context.fireUserInboundEventTriggered(event)
     }
 }
 

--- a/Tests/NIOOpenSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOOpenSSLTests/UnwrappingTests.swift
@@ -81,13 +81,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Mark the closure of the channels.
         clientChannel.closeFuture.whenComplete { _ in
@@ -139,14 +139,14 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        let serverHandler = try assertNoThrowWithValue(OpenSSLServerHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: serverHandler).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        let serverHandler = try assertNoThrowWithValue(OpenSSLServerHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(serverHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Mark the closure of the channels.
         clientChannel.closeFuture.whenComplete { _ in
@@ -206,13 +206,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertThrowsError(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Mark the closure of the client.
         clientChannel.closeFuture.whenComplete { _ in
@@ -265,13 +265,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertThrowsError(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Mark the closure of the client.
         clientChannel.closeFuture.whenComplete { _ in
@@ -318,13 +318,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -356,13 +356,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -390,10 +390,10 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try channel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let handler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try channel.pipeline.add(handler: handler).wait())
+        let handler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
         channel.pipeline.assertContains(handler: handler)
 
         // Let's unwrap. This should succeed easily.
@@ -419,13 +419,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -462,13 +462,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertThrowsError(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -506,13 +506,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertThrowsError(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Mark the closure of the client.
         clientChannel.closeFuture.whenComplete { _ in
@@ -576,13 +576,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -626,13 +626,13 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertThrowsError(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
         // Connect. This should lead to a completed handshake.
         XCTAssertNoThrow(try connectInMemory(client: clientChannel, server: serverChannel))
@@ -686,15 +686,15 @@ final class UnwrappingTests: XCTestCase {
             XCTAssertNoThrow(try clientChannel.finish())
         }
 
-        let ctx = try assertNoThrowWithValue(configuredSSLContext())
+        let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: ctx))
-        XCTAssertNoThrow(try serverChannel.pipeline.add(handler: OpenSSLServerHandler(context: ctx)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: clientHandler).wait())
+        let clientHandler = try assertNoThrowWithValue(OpenSSLClientHandler(context: context))
+        XCTAssertNoThrow(try serverChannel.pipeline.addHandler(OpenSSLServerHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: handshakeHandler).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
         let readPromise: EventLoopPromise<ByteBuffer> = clientChannel.eventLoop.makePromise()
-        XCTAssertNoThrow(try clientChannel.pipeline.add(handler: PromiseOnReadHandler(promise: readPromise)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(PromiseOnReadHandler(promise: readPromise)).wait())
 
         var readCompleted = false
         readPromise.futureResult.whenSuccess { buffer in


### PR DESCRIPTION
Motivation:

Code should compile and have the latest NIO 2 API.

Modifications:

- rename `ctx` to `context`
- apply all fixits

Result:

compiles again