### PR TITLE
make TLSConfiguration.applicationProtocols a [String]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Package.pins
 Package.resolved
 *.pem
 /docs
+DerivedData
+

--- a/Sources/NIOOpenSSL/SSLContext.swift
+++ b/Sources/NIOOpenSSL/SSLContext.swift
@@ -203,7 +203,7 @@ public final class SSLContext {
         }
 
         if configuration.applicationProtocols.count > 0 {
-            try SSLContext.setAlpnProtocols(configuration.applicationProtocols, context: context)
+            try SSLContext.setAlpnProtocols(configuration.encodedApplicationProtocols, context: context)
             SSLContext.setAlpnCallback(context: context)
         }
 
@@ -248,7 +248,7 @@ public final class SSLContext {
     }
 
     fileprivate func alpnSelectCallback(offeredProtocols: UnsafeBufferPointer<UInt8>) ->  (index: Int, length: Int)? {
-        for possibility in configuration.applicationProtocols {
+        for possibility in configuration.encodedApplicationProtocols {
             let match = possibility.withUnsafeBufferPointer {
                 offeredProtocols.locateAlpnIdentifier(identifier: $0)
             }

--- a/Sources/NIOOpenSSL/TLSConfiguration.swift
+++ b/Sources/NIOOpenSSL/TLSConfiguration.swift
@@ -99,6 +99,12 @@ internal func encodeALPNIdentifier(identifier: String) -> [UInt8] {
     return encodedIdentifier
 }
 
+/// Decodes a string from the wire format of an ALPN identifier. These MUST be correctly
+/// formatted ALPN identifiers, and so this routine will crash the program if they aren't.
+internal func decodeALPNIdentifier(identifier: [UInt8]) -> String {
+    return String(decoding: identifier[1..<identifier.count], as: Unicode.ASCII.self)
+}
+
 /// Manages configuration of OpenSSL for SwiftNIO programs.
 ///
 /// OpenSSL has a number of configuration options that are worth setting. This structure allows
@@ -134,11 +140,16 @@ public struct TLSConfiguration {
     /// strings representing the ALPN identifiers of the protocols to negotiate. For clients,
     /// the protocols will be offered in the order given. For servers, the protocols will be matched
     /// against the client's offered protocols in order.
-    public var applicationProtocols: [String]
-    
-    internal var encodedApplicationProtocols: [[UInt8]] {
-        return self.applicationProtocols.map(encodeALPNIdentifier)
+    public var applicationProtocols: [String] {
+        get {
+            return self.encodedApplicationProtocols.map(decodeALPNIdentifier)
+        }
+        set {
+            self.encodedApplicationProtocols = newValue.map(encodeALPNIdentifier)
+        }
     }
+    
+    internal var encodedApplicationProtocols: [[UInt8]]
 
     private init(cipherSuites: String,
                  minimumTLSVersion: TLSVersion,
@@ -155,6 +166,7 @@ public struct TLSConfiguration {
         self.trustRoots = trustRoots
         self.certificateChain = certificateChain
         self.privateKey = privateKey
+        self.encodedApplicationProtocols = []
         self.applicationProtocols = applicationProtocols
     }
 

--- a/Sources/NIOOpenSSL/TLSConfiguration.swift
+++ b/Sources/NIOOpenSSL/TLSConfiguration.swift
@@ -134,7 +134,11 @@ public struct TLSConfiguration {
     /// strings representing the ALPN identifiers of the protocols to negotiate. For clients,
     /// the protocols will be offered in the order given. For servers, the protocols will be matched
     /// against the client's offered protocols in order.
-    public var applicationProtocols: [[UInt8]]
+    public var applicationProtocols: [String]
+    
+    internal var encodedApplicationProtocols: [[UInt8]] {
+        return self.applicationProtocols.map(encodeALPNIdentifier)
+    }
 
     private init(cipherSuites: String,
                  minimumTLSVersion: TLSVersion,
@@ -151,7 +155,7 @@ public struct TLSConfiguration {
         self.trustRoots = trustRoots
         self.certificateChain = certificateChain
         self.privateKey = privateKey
-        self.applicationProtocols = applicationProtocols.map(encodeALPNIdentifier)
+        self.applicationProtocols = applicationProtocols
     }
 
     /// Create a TLS configuration for use with server-side contexts.

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest+XCTest.swift
@@ -33,6 +33,7 @@ extension TLSConfigurationTest {
                 ("testServerCannotValidateClientPostTLS13", testServerCannotValidateClientPostTLS13),
                 ("testMutualValidation", testMutualValidation),
                 ("testNonexistentFileObject", testNonexistentFileObject),
+                ("testComputedApplicationProtocols", testComputedApplicationProtocols),
            ]
    }
 }

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
@@ -258,4 +258,13 @@ class TLSConfigurationTest: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+    
+    func testComputedApplicationProtocols() throws {
+        var config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"])
+        XCTAssertEqual(config.applicationProtocols, ["http/1.1"])
+        XCTAssertEqual(config.encodedApplicationProtocols, [[8, 104, 116, 116, 112, 47, 49, 46, 49]])
+        config.applicationProtocols.insert("h2", at: 0)
+        XCTAssertEqual(config.applicationProtocols, ["h2", "http/1.1"])
+        XCTAssertEqual(config.encodedApplicationProtocols, [[2, 104, 50], [8, 104, 116, 116, 112, 47, 49, 46, 49]])
+    }
 }


### PR DESCRIPTION
`TLSConfiguration` currently accepts `applicationProtocols` as a `[String]` during init, but stores them as `[[UInt8]]`. This makes the TLS config struct awkward to work with if you want to check or mutate the application protocols after initialization. 

This PR moves the `[[UInt8]]` representation to being a computed property. This makes it easier to work with application protocols as a `[String]` before passing the struct to `SSLContext`. 

### Alternatives Considered

1: Make `[String]` the computed property and store `[[UInt8]]`. If accessing the ALPN identifiers must be fast, it would be better to store `[[UInt8]]` and allow computed access via `[String]`
2: Publicize `encodeALPNIdentifier` so that one can more easily interact with the `[[UInt8]` API. (Not a fan of this option)