### PR TITLE
Enable TLS certificate validation on Apple platforms.

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -43,13 +43,13 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             }
 
             // IP addresses must not be provided in the SNI extension, so filter them.
-            try connection.setSNIServerName(name: serverHostname)
+            try connection.setServerName(name: serverHostname)
         }
 
         if let verificationCallback = verificationCallback {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, expectedHostname: serverHostname)
+        super.init(connection: connection)
     }
 }

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -91,6 +91,7 @@ public enum BoringSSLError: Error {
     case wantConnect
     case wantAccept
     case wantX509Lookup
+    case wantCertificateVerify
     case syscallError
     case sslError(NIOBoringSSLErrorStack)
     case unknownError(NIOBoringSSLErrorStack)
@@ -108,6 +109,7 @@ public func ==(lhs: BoringSSLError, rhs: BoringSSLError) -> Bool {
          (.wantWrite, .wantWrite),
          (.wantConnect, .wantConnect),
          (.wantAccept, .wantAccept),
+         (.wantCertificateVerify, .wantCertificateVerify),
          (.wantX509Lookup, .wantX509Lookup),
          (.syscallError, .syscallError):
         return true
@@ -134,6 +136,8 @@ internal extension BoringSSLError {
             return .wantConnect
         case SSL_ERROR_WANT_ACCEPT:
             return .wantAccept
+        case SSL_ERROR_WANT_CERTIFICATE_VERIFY:
+            return .wantCertificateVerify
         case SSL_ERROR_WANT_X509_LOOKUP:
             return .wantX509Lookup
         case SSL_ERROR_SYSCALL:

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import CNIOBoringSSL
+
+/// The current state of the platform verification helper, if one is in use.
+///
+/// Only used on Apple platforms currently.
+internal struct PlatformVerificationState {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    fileprivate var state: SecurityFrameworkVerificationState? = nil
+    #endif
+}
+
+// We can only use Security.framework to validate TLS certificates on Apple platforms.
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Dispatch
+import Foundation
+import Security
+
+/// A custom certificate verification function for BoringSSL that uses Security.framework to provide certificate verification.
+///
+/// - parameters:
+///     - ssl: The pointer to the SSL * object for this connection.
+///     - outAlert: A C-style inout parameter that contains a pointer to an alert. Is assumed to be non-null.
+internal func securityFrameworkCustomVerify(_ ssl: OpaquePointer?, _ outAlert: UnsafeMutablePointer<UInt8>?) -> ssl_verify_result_t {
+    guard let unwrappedSSL = ssl, let unwrappedOutAlert = outAlert else {
+        preconditionFailure("Unexpected null pointer in custom verification callback. ssl: \(String(describing: ssl)) outAlert: \(String(describing: outAlert))")
+    }
+
+    // Ok, this call may be a resumption of a previous negotiation. We need to check if our connection object has a pre-existing verifiation state.
+    guard let connectionPointer = CNIOBoringSSL_SSL_get_ex_data(unwrappedSSL, sslConnectionExDataIndex) else {
+        // Uh-ok, our application state is gone. Don't let this error silently pass, go bang.
+        preconditionFailure("Unable to find application data from SSL * \(unwrappedSSL), index \(sslConnectionExDataIndex)")
+    }
+
+    let connection = Unmanaged<SSLConnection>.fromOpaque(connectionPointer).takeUnretainedValue()
+
+    do {
+        return try connection.performSecurityFrameworkValidation()
+    } catch {
+        unwrappedOutAlert.pointee = UInt8(SSL_AD_INTERNAL_ERROR)
+        return ssl_verify_invalid
+    }
+}
+
+extension PlatformVerificationState {
+    fileprivate enum SecurityFrameworkVerificationState {
+        case pendingResult
+
+        case complete(SecTrustResultType)
+    }
+}
+
+extension SSLConnection {
+    func performSecurityFrameworkValidation() throws -> ssl_verify_result_t {
+        // First, check whether we have an outstanding or completed query. If we do, don't do any other work.
+        switch self.platformVerificationState.state {
+        case .some(.complete(.proceed)), .some(.complete(.unspecified)):
+            // These two cases mean we have successfully validated the certificate. We're done! Wipe out the state so
+            // that if we need to reverify we can, and return the success.
+            self.platformVerificationState.state = nil
+            return ssl_verify_ok
+        case .some(.complete):
+            // Ok, this broader case means we failed. We're still done, but return the failure instead.
+            self.platformVerificationState.state = nil
+            return ssl_verify_invalid
+        case .some(.pendingResult):
+            // We've got a validation attempt outstanding. Tell BoringSSL to hold its horses.
+            return ssl_verify_retry
+        case .none:
+            // No verification outstanding: do more work.
+            break
+        }
+
+        // Ok, time to kick off a validation. Let's get some certificate buffers.
+        let certificates: [SecCertificate] = try self.withPeerCertificateChainBuffers { buffers in
+            guard let buffers = buffers else {
+                throw NIOSSLError.unableToValidateCertificate
+            }
+
+            return try buffers.map { buffer in
+                let data = Data(bytes: buffer.baseAddress!, count: buffer.count)
+                guard let cert = SecCertificateCreateWithData(nil, data as CFData) else {
+                    throw NIOSSLError.unableToValidateCertificate
+                }
+                return cert
+            }
+        }
+
+        // This force-unwrap is safe as we must have decided if we're a client or a server before validation.
+        var trust: SecTrust? = nil
+        var result: OSStatus
+        let policy = SecPolicyCreateSSL(self.role! == .server, self.expectedHostname as CFString?)
+        result = SecTrustCreateWithCertificates(certificates as CFArray, policy, &trust)
+        guard result == errSecSuccess, let actualTrust = trust else {
+            throw NIOSSLError.unableToValidateCertificate
+        }
+
+        // We create a DispatchQueue here to be called back on, as this validation may perform network activity.
+        let callbackQueue = DispatchQueue(label: "io.swiftnio.ssl.validationCallbackQueue")
+
+        // Now we need to grab some things we need in the callback block. Specifically, we need the parent handler
+        // and the event loop it belongs to. This is because we cannot safely access these things from inside the
+        // block, and we need the eventLoop to get back onto a safe thread.
+        //
+        // We don't hold these references weak because we are ok with keeping the handler alive longer than necessary
+        // in the rare case that the handler is removed before the callback completes.
+        // The force-unwrap is safe, as we cannot be midway through handshaking before the connection has become active.
+        let eventLoop = self.eventLoop!
+
+        result = SecTrustEvaluateAsync(actualTrust, callbackQueue) { (_, result) in
+            // When we complete here we need to set our result state, and then ask to respin certificate verification.
+            // If we can't respin verification because we've dropped the parent handler, that's fine, no harm no foul.
+            eventLoop.execute {
+                self.platformVerificationState.state = .complete(result)
+                self.parentHandler?.asynchronousCertificateVerificationComplete()
+            }
+        }
+
+        guard result == errSecSuccess else {
+            throw NIOSSLError.unableToValidateCertificate
+        }
+
+        return ssl_verify_retry
+    }
+}
+
+#endif

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -301,7 +301,7 @@ func addExtension(x509: UnsafeMutablePointer<X509>, nid: Int32, value: String) {
 func generateSelfSignedCert() -> (NIOSSLCertificate, NIOSSLPrivateKey) {
     let pkey = generateRSAPrivateKey()
     let x = CNIOBoringSSL_X509_new()!
-    CNIOBoringSSL_X509_set_version(x, 3)
+    CNIOBoringSSL_X509_set_version(x, 2)
 
     // NB: X509_set_serialNumber uses an internal copy of the ASN1_INTEGER, so this is
     // safe, there will be no use-after-free.


### PR DESCRIPTION
Motivation:

While our main use-case is users on Linux, many of our users develop on
their Mac. We need to support their development model, which may well
involve making outbound requests. Those requests need certificate
validation.

Modifications:

- Added routines for using Security.framework to validate cert chains.
- Refactored code to be as platform-independent as possible.

Result:

Certificate verification works on Apple platforms.