### PR TITLE
Rename SSLContext to NIOSSLContext

### DIFF
--- a/Sources/NIOOpenSSL/OpenSSLClientHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLClientHandler.swift
@@ -32,7 +32,7 @@ private extension String {
 /// are acting as the client in the TLS dialog. For server connections,
 /// use the `OpenSSLServerHandler`.
 public final class OpenSSLClientHandler: OpenSSLHandler {
-    public init(context: SSLContext, serverHostname: String? = nil, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
+    public init(context: NIOSSLContext, serverHostname: String? = nil, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
             throw NIOOpenSSLError.unableToAllocateOpenSSLObject
         }

--- a/Sources/NIOOpenSSL/OpenSSLServerHandler.swift
+++ b/Sources/NIOOpenSSL/OpenSSLServerHandler.swift
@@ -19,7 +19,7 @@ import NIO
 /// are acting as the server in the TLS dialog. For client connections,
 /// use the `OpenSSLClientHandler`.
 public final class OpenSSLServerHandler: OpenSSLHandler {
-    public init(context: SSLContext, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
+    public init(context: NIOSSLContext, verificationCallback: OpenSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
             throw NIOOpenSSLError.unableToAllocateOpenSSLObject
         }

--- a/Sources/NIOOpenSSL/SSLConnection.swift
+++ b/Sources/NIOOpenSSL/SSLConnection.swift
@@ -38,11 +38,11 @@ enum AsyncOperationResult<T> {
 /// A wrapper class that encapsulates OpenSSL's `SSL *` object.
 ///
 /// This class represents a single TLS connection, and performs all of crypto and record
-/// framing required by TLS. It also records the configuration and parent `SSLContext` object
+/// framing required by TLS. It also records the configuration and parent `NIOSSLContext` object
 /// used to create the connection.
 internal final class SSLConnection {
     private let ssl: OpaquePointer
-    private let parentContext: SSLContext
+    private let parentContext: NIOSSLContext
     private var bio: ByteBufferBIO?
     private var verificationCallback: OpenSSLVerificationCallback?
 
@@ -54,7 +54,7 @@ internal final class SSLConnection {
         return false
     }
 
-    init(ownedSSL: OpaquePointer, parentContext: SSLContext) {
+    init(ownedSSL: OpaquePointer, parentContext: NIOSSLContext) {
         self.ssl = ownedSSL
         self.parentContext = parentContext
 

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -28,7 +28,7 @@ private final class EchoHandler: ChannelInboundHandler {
     }
 }
 
-let sslContext = try! SSLContext(configuration: TLSConfiguration.forServer(certificateChain: [.file("cert.pem")], privateKey: .file("key.pem")))
+let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.forServer(certificateChain: [.file("cert.pem")], privateKey: .file("key.pem")))
 
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/NIOOpenSSLTests/ClientSNITests.swift
+++ b/Tests/NIOOpenSSLTests/ClientSNITests.swift
@@ -29,11 +29,11 @@ class ClientSNITests: XCTestCase {
         OpenSSLIntegrationTest.key = key
     }
 
-    private func configuredSSLContext() throws -> NIOOpenSSL.SSLContext {
+    private func configuredSSLContext() throws -> NIOOpenSSL.NIOSSLContext {
         let config = TLSConfiguration.forServer(certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                 privateKey: .privateKey(OpenSSLIntegrationTest.key),
                                                 trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        let context = try SSLContext(configuration: config)
+        let context = try NIOSSLContext(configuration: config)
         return context
     }
 

--- a/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
+++ b/Tests/NIOOpenSSLTests/OpenSSLIntegrationTest.swift
@@ -248,7 +248,7 @@ private class WriteDelayHandler: ChannelOutboundHandler {
     }
 }
 
-internal func serverTLSChannel(context: NIOOpenSSL.SSLContext,
+internal func serverTLSChannel(context: NIOOpenSSL.NIOSSLContext,
                                handlers: [ChannelHandler],
                                group: EventLoopGroup,
                                file: StaticString = #file,
@@ -262,7 +262,7 @@ internal func serverTLSChannel(context: NIOOpenSSL.SSLContext,
                                       file: file, line: line)
 }
 
-internal func serverTLSChannel(context: NIOOpenSSL.SSLContext,
+internal func serverTLSChannel(context: NIOOpenSSL.NIOSSLContext,
                                preHandlers: [ChannelHandler],
                                postHandlers: [ChannelHandler],
                                group: EventLoopGroup,
@@ -283,7 +283,7 @@ internal func serverTLSChannel(context: NIOOpenSSL.SSLContext,
         }.bind(host: "127.0.0.1", port: 0).wait(), file: file, line: line)
 }
 
-internal func clientTLSChannel(context: NIOOpenSSL.SSLContext,
+internal func clientTLSChannel(context: NIOOpenSSL.NIOSSLContext,
                                preHandlers: [ChannelHandler],
                                postHandlers: [ChannelHandler],
                                group: EventLoopGroup,
@@ -324,25 +324,25 @@ class OpenSSLIntegrationTest: XCTestCase {
         _ = unlink(OpenSSLIntegrationTest.encryptedKeyPath)
     }
     
-    private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.SSLContext {
+    private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.NIOSSLContext {
         let config = TLSConfiguration.forServer(certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                 privateKey: .privateKey(OpenSSLIntegrationTest.key),
                                                 trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        return try assertNoThrowWithValue(SSLContext(configuration: config), file: file, line: line)
+        return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
 
     private func configuredSSLContext<T: Collection>(passphraseCallback: @escaping OpenSSLPassphraseCallback<T>,
-                                                     file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.SSLContext
+                                                     file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.NIOSSLContext
                                                      where T.Element == UInt8 {
         let config = TLSConfiguration.forServer(certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                 privateKey: .file(OpenSSLIntegrationTest.encryptedKeyPath),
                                                 trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        return try assertNoThrowWithValue(SSLContext(configuration: config, passphraseCallback: passphraseCallback), file: file, line: line)
+        return try assertNoThrowWithValue(NIOSSLContext(configuration: config, passphraseCallback: passphraseCallback), file: file, line: line)
     }
 
-    private func configuredClientContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.SSLContext {
+    private func configuredClientContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.NIOSSLContext {
         let config = TLSConfiguration.forClient(trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        return try assertNoThrowWithValue(SSLContext(configuration: config), file: file, line: line)
+        return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
 
     static func keyInFile(key: OpenSSLPrivateKey, passphrase: String) -> String {
@@ -868,7 +868,7 @@ class OpenSSLIntegrationTest: XCTestCase {
         defer {
             precondition(.some(0) == tempFile.map { unlink($0) }, "couldn't remove temp file \(tempFile.debugDescription)")
         }
-        let clientCtx = try assertNoThrowWithValue(SSLContext(configuration: config))
+        let clientCtx = try assertNoThrowWithValue(NIOSSLContext(configuration: config))
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -904,7 +904,7 @@ class OpenSSLIntegrationTest: XCTestCase {
                                                       trustRoots: .file("/tmp"),
                                                       certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                       privateKey: .privateKey(OpenSSLIntegrationTest.key))
-        let clientCtx = try assertNoThrowWithValue(SSLContext(configuration: clientConfig))
+        let clientCtx = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig))
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {

--- a/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOOpenSSLTests/TLSConfigurationTest.swift
@@ -78,8 +78,8 @@ class TLSConfigurationTest: XCTestCase {
                               errorTextContainsAnyOf messages: [String],
                               file: StaticString = #file,
                               line: UInt = #line) throws {
-        let clientContext = try assertNoThrowWithValue(SSLContext(configuration: clientConfig), file: file, line: line)
-        let serverContext = try assertNoThrowWithValue(SSLContext(configuration: serverConfig), file: file, line: line)
+        let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig), file: file, line: line)
+        let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig), file: file, line: line)
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -113,8 +113,8 @@ class TLSConfigurationTest: XCTestCase {
                                   errorTextContains message: String,
                                   file: StaticString = #file,
                                   line: UInt = #line) throws {
-        let clientContext = try assertNoThrowWithValue(SSLContext(configuration: clientConfig), file: file, line: line)
-        let serverContext = try assertNoThrowWithValue(SSLContext(configuration: serverConfig), file: file, line: line)
+        let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig), file: file, line: line)
+        let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig), file: file, line: line)
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -213,8 +213,8 @@ class TLSConfigurationTest: XCTestCase {
                                                       certificateVerification: .noHostnameVerification,
                                                       trustRoots: .certificates([TLSConfigurationTest.cert2]))
 
-        let clientContext = try SSLContext(configuration: clientConfig)
-        let serverContext = try SSLContext(configuration: serverConfig)
+        let clientContext = try NIOSSLContext(configuration: clientConfig)
+        let serverContext = try NIOSSLContext(configuration: serverConfig)
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -250,7 +250,7 @@ class TLSConfigurationTest: XCTestCase {
         let clientConfig = TLSConfiguration.forClient(trustRoots: .file("/thispathbetternotexist/bogus.foo"))
 
         do {
-            _ = try SSLContext(configuration: clientConfig)
+            _ = try NIOSSLContext(configuration: clientConfig)
             XCTFail("Did not throw")
         } catch NIOOpenSSLError.noSuchFilesystemObject {
             // This is fine

--- a/Tests/NIOOpenSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOOpenSSLTests/UnwrappingTests.swift
@@ -60,11 +60,11 @@ final class UnwrappingTests: XCTestCase {
         _ = unlink(OpenSSLIntegrationTest.encryptedKeyPath)
     }
 
-    private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.SSLContext {
+    private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOOpenSSL.NIOSSLContext {
         let config = TLSConfiguration.forServer(certificateChain: [.certificate(OpenSSLIntegrationTest.cert)],
                                                 privateKey: .privateKey(OpenSSLIntegrationTest.key),
                                                 trustRoots: .certificates([OpenSSLIntegrationTest.cert]))
-        return try assertNoThrowWithValue(SSLContext(configuration: config), file: file, line: line)
+        return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
 
     func testSimpleUnwrapping() throws {


### PR DESCRIPTION
Motivation:

The name SSLContext conflicts with a type in Security.framework. That's
a really unnecessary naming clash, and while it's unlikely to be a real
problem in most programs, we still shouldn't encourage that if we can
avoid it.

Modifications:

- Rename SSLContext to NIOSSLContext.

Result:

Fewer naming conflicts.