### PR TITLE
move uncleanShutdown error to NIOSSLError

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -106,10 +106,10 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             let closePromise = self.closePromise
             self.closePromise = nil
 
-            shutdownPromise?.fail(BoringSSLError.uncleanShutdown)
-            closePromise?.fail(BoringSSLError.uncleanShutdown)
-            context.fireErrorCaught(BoringSSLError.uncleanShutdown)
-            discardBufferedWrites(reason: BoringSSLError.uncleanShutdown)
+            shutdownPromise?.fail(NIOSSLError.uncleanShutdown)
+            closePromise?.fail(NIOSSLError.uncleanShutdown)
+            context.fireErrorCaught(NIOSSLError.uncleanShutdown)
+            discardBufferedWrites(reason: NIOSSLError.uncleanShutdown)
         }
 
         context.fireChannelInactive()

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -57,6 +57,7 @@ public enum NIOSSLError: Error {
     case unableToValidateCertificate
     case cannotFindPeerIP
     case readInInvalidTLSState
+    case uncleanShutdown
 }
 
 extension NIOSSLError: Equatable {
@@ -69,7 +70,8 @@ extension NIOSSLError: Equatable {
              (.failedToLoadPrivateKey, .failedToLoadPrivateKey),
              (.cannotMatchULabel, .cannotMatchULabel),
              (.noCertificateToValidate, .noCertificateToValidate),
-             (.unableToValidateCertificate, .unableToValidateCertificate):
+             (.unableToValidateCertificate, .unableToValidateCertificate),
+             (.uncleanShutdown, .uncleanShutdown):
             return true
         case (.handshakeFailed(let err1), .handshakeFailed(let err2)),
              (.shutdownFailed(let err1), .shutdownFailed(let err2)):
@@ -92,7 +94,6 @@ public enum BoringSSLError: Error {
     case syscallError
     case sslError(NIOBoringSSLErrorStack)
     case unknownError(NIOBoringSSLErrorStack)
-    case uncleanShutdown
     case invalidSNIName(NIOBoringSSLErrorStack)
     case failedToSetALPN(NIOBoringSSLErrorStack)
 }
@@ -108,8 +109,7 @@ public func ==(lhs: BoringSSLError, rhs: BoringSSLError) -> Bool {
          (.wantConnect, .wantConnect),
          (.wantAccept, .wantAccept),
          (.wantX509Lookup, .wantX509Lookup),
-         (.syscallError, .syscallError),
-         (.uncleanShutdown, .uncleanShutdown):
+         (.syscallError, .syscallError):
         return true
     case (.sslError(let e1), .sslError(let e2)),
          (.unknownError(let e1), .unknownError(let e2)):

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -36,8 +36,8 @@ internal func interactInMemory(clientChannel: EmbeddedChannel, serverChannel: Em
     var workToDo = true
     while workToDo {
         workToDo = false
-        let clientDatum = clientChannel.readOutbound(as: IOData.self)
-        let serverDatum = serverChannel.readOutbound(as: IOData.self)
+        let clientDatum = try clientChannel.readOutbound(as: IOData.self)
+        let serverDatum = try serverChannel.readOutbound(as: IOData.self)
 
         if let clientMsg = clientDatum {
             try serverChannel.writeInbound(clientMsg)
@@ -843,7 +843,7 @@ class NIOSSLIntegrationTest: XCTestCase {
             XCTFail("Unexpected success")
         }.whenFailure { error in
             switch error {
-            case let e as BoringSSLError where e == .uncleanShutdown:
+            case let e as NIOSSLError where e == .uncleanShutdown:
                 break
             default:
                 XCTFail("Unexpected error: \(error)")
@@ -1144,7 +1144,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let clientClosePromise = clientChannel.close()
 
         var buffer = clientChannel.allocator.buffer(capacity: 1024)
-        while case .some(.byteBuffer(var data)) = clientChannel.readOutbound(as: IOData.self) {
+        while case .some(.byteBuffer(var data)) = try clientChannel.readOutbound(as: IOData.self) {
             buffer.writeBuffer(&data)
         }
         XCTAssertNoThrow(try serverChannel.writeInbound(buffer))

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -287,7 +287,7 @@ final class UnwrappingTests: XCTestCase {
         clientStopPromise.futureResult.map {
             XCTFail("Must not succeed")
         }.whenFailure { error in
-            XCTAssertEqual(error as? BoringSSLError, .uncleanShutdown)
+            XCTAssertEqual(error as? NIOSSLError, .uncleanShutdown)
             clientUnwrapped = true
         }
         clientHandler.stopTLS(promise: clientStopPromise)
@@ -716,11 +716,11 @@ final class UnwrappingTests: XCTestCase {
         clientHandler.stopTLS(promise: stopPromise)
 
         // Now we want to manually handle the interaction. The client will have sent a CLOSE_NOTIFY: send it to the server.
-        let clientCloseNotify = clientChannel.readOutbound(as: ByteBuffer.self)!
+        let clientCloseNotify = try clientChannel.readOutbound(as: ByteBuffer.self)!
         XCTAssertNoThrow(try serverChannel.writeInbound(clientCloseNotify))
 
         // The server will have sent a CLOSE_NOTIFY: grab it.
-        var serverCloseNotify = serverChannel.readOutbound(as: ByteBuffer.self)!
+        var serverCloseNotify = try serverChannel.readOutbound(as: ByteBuffer.self)!
 
         // We're going to append some plaintext data.
         serverCloseNotify.writeStaticString("Hello, world!")


### PR DESCRIPTION
`uncleanShutdown` was previously on `OpenSSLError` (now renamed to `NIOSSLError`). This PR moves the case back to `NIOSSLError` from `BoringSSLError`.