### PR TITLE
NIOSSLClientHandler: require serverHostname

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -31,7 +31,7 @@ private extension String {
 /// This handler can be used in channels that are acting as the client
 /// in the TLS dialog. For server connections, use the `NIOSSLServerHandler`.
 public final class NIOSSLClientHandler: NIOSSLHandler {
-    public init(context: NIOSSLContext, serverHostname: String? = nil, verificationCallback: NIOSSLVerificationCallback? = nil) throws {
+    public init(context: NIOSSLContext, serverHostname: String?, verificationCallback: NIOSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
             throw NIOSSLError.unableToAllocateBoringSSLObject
         }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -665,7 +665,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     func testImmediateCloseSatisfiesPromises() throws {
         let context = try configuredSSLContext()
         let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(NIOSSLClientHandler(context: context)).wait()
+        try channel.pipeline.addHandler(NIOSSLClientHandler(context: context, serverHostname: nil)).wait()
 
         // Start by initiating the handshake.
         try channel.connect(to: SocketAddress(unixDomainSocketPath: "/tmp/doesntmatter")).wait()
@@ -711,7 +711,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         }.wait()
 
         // Now, add the TLS handler to the pipeline.
-        try clientChannel.pipeline.addHandler(NIOSSLClientHandler(context: context), position: .first).wait()
+        try clientChannel.pipeline.addHandler(NIOSSLClientHandler(context: context, serverHostname: nil), position: .first).wait()
         var data = clientChannel.allocator.buffer(capacity: 1)
         data.writeStaticString("x")
         try clientChannel.writeAndFlush(data).wait()
@@ -813,7 +813,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let context = try configuredSSLContext()
 
         try serverChannel.pipeline.addHandler(try NIOSSLServerHandler(context: context)).wait()
-        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context)).wait()
+        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context, serverHostname: nil)).wait()
 
         let addr: SocketAddress = try SocketAddress(unixDomainSocketPath: "/tmp/whatever")
         let connectFuture = clientChannel.connect(to: addr)
@@ -950,7 +950,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let context = try configuredSSLContext()
 
         try serverChannel.pipeline.addHandler(try NIOSSLServerHandler(context: context)).wait()
-        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context)).wait()
+        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context, serverHostname: nil)).wait()
 
         let addr = try SocketAddress(unixDomainSocketPath: "/tmp/whatever2")
         let connectFuture = clientChannel.connect(to: addr)
@@ -1039,7 +1039,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let context = try configuredSSLContext()
 
         try serverChannel.pipeline.addHandler(try NIOSSLServerHandler(context: context)).wait()
-        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context)).wait()
+        try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context, serverHostname: nil)).wait()
 
         let addr = try SocketAddress(unixDomainSocketPath: "/tmp/whatever2")
         let connectFuture = clientChannel.connect(to: addr)
@@ -1126,7 +1126,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(try NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(ReadRecordingHandler(completePromise: completePromise)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(try NIOSSLClientHandler(context: context, serverHostname: nil)).wait())
 
         // Connect
         let addr = try assertNoThrowWithValue(SocketAddress(unixDomainSocketPath: "/tmp/whatever2"))
@@ -1259,7 +1259,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
-        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(NIOSSLClientHandler(context: context)).wait())
+        XCTAssertNoThrow(try clientChannel.pipeline.addHandler(NIOSSLClientHandler(context: context, serverHostname: nil)).wait())
         let handshakeHandler = HandshakeCompletedHandler()
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(handshakeHandler).wait())
 
@@ -1297,7 +1297,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -1352,7 +1352,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -83,7 +83,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -141,7 +141,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         let serverHandler = try assertNoThrowWithValue(NIOSSLServerHandler(context: context))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(serverHandler).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
@@ -208,7 +208,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -267,7 +267,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -320,7 +320,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -358,7 +358,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -392,7 +392,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let handler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let handler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
         channel.pipeline.assertContains(handler: handler)
 
@@ -421,7 +421,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -464,7 +464,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -508,7 +508,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -578,7 +578,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -628,7 +628,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()
@@ -688,7 +688,7 @@ final class UnwrappingTests: XCTestCase {
 
         let context = try assertNoThrowWithValue(configuredSSLContext())
 
-        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context))
+        let clientHandler = try assertNoThrowWithValue(NIOSSLClientHandler(context: context, serverHostname: nil))
         XCTAssertNoThrow(try serverChannel.pipeline.addHandler(NIOSSLServerHandler(context: context)).wait())
         XCTAssertNoThrow(try clientChannel.pipeline.addHandler(clientHandler).wait())
         let handshakeHandler = HandshakeCompletedHandler()


### PR DESCRIPTION
Motivation:

It was too easy to forget passing serverHostname to NIOSSLClientHandler
which made certificate validation fail.

Modification:

Require users to pass a server hostname or `nil` explictly.

Result:

- harder to use NIOSSLClientHandler wrongly
- fixes #80