### PR TITLE
Record BoringSSL revision hash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,15 @@
 
 import PackageDescription
 
+// This package contains a vendored copy of BoringSSL. For ease of tracking
+// down problems with the copy of BoringSSL in use, we include a copy of the
+// commit hash of the revision of BoringSSL included in the given release.
+// This is also reproduced in a file called hash.txt in the
+// Sources/CNIOBoringSSL directory. The source repository is at
+// https://boringssl.googlesource.com/boringssl.
+//
+// BoringSSL Commit: 35941f2923155664bd9fa5d897cb336a0ab729a1
+
 let package = Package(
     name: "swift-nio-ssl",
     products: [

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/vpaes-armv8.ios.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/vpaes-armv8.ios.aarch64.S
@@ -13,7 +13,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <boringssl_prefix_symbols_asm.h>
 #endif
-.text
+.section	__TEXT,__const
 
 
 .align	7	// totally strategic alignment
@@ -105,6 +105,8 @@ Lk_deskew:	//	deskew tables: inverts the sbox's "skew"
 .align	2
 
 .align	6
+
+.text
 ##
 ##  _aes_preheat
 ##
@@ -114,7 +116,8 @@ Lk_deskew:	//	deskew tables: inverts the sbox's "skew"
 
 .align	4
 _vpaes_encrypt_preheat:
-	adr	x10, Lk_inv
+	adrp	x10, Lk_inv@PAGE
+	add	x10, x10, Lk_inv@PAGEOFF
 	movi	v17.16b, #0x0f
 	ld1	{v18.2d,v19.2d}, [x10],#32	// Lk_inv
 	ld1	{v20.2d,v21.2d,v22.2d,v23.2d}, [x10],#64	// Lk_ipt, Lk_sbo
@@ -142,7 +145,8 @@ _vpaes_encrypt_preheat:
 _vpaes_encrypt_core:
 	mov	x9, x2
 	ldr	w8, [x2,#240]			// pull rounds
-	adr	x11, Lk_mc_forward+16
+	adrp	x11, Lk_mc_forward@PAGE+16
+	add	x11, x11, Lk_mc_forward@PAGEOFF+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -228,7 +232,8 @@ _vpaes_encrypt:
 _vpaes_encrypt_2x:
 	mov	x9, x2
 	ldr	w8, [x2,#240]			// pull rounds
-	adr	x11, Lk_mc_forward+16
+	adrp	x11, Lk_mc_forward@PAGE+16
+	add	x11, x11, Lk_mc_forward@PAGEOFF+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b,  v14.16b,  v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -331,9 +336,11 @@ Lenc_2x_entry:
 
 .align	4
 _vpaes_decrypt_preheat:
-	adr	x10, Lk_inv
+	adrp	x10, Lk_inv@PAGE
+	add	x10, x10, Lk_inv@PAGEOFF
 	movi	v17.16b, #0x0f
-	adr	x11, Lk_dipt
+	adrp	x11, Lk_dipt@PAGE
+	add	x11, x11, Lk_dipt@PAGEOFF
 	ld1	{v18.2d,v19.2d}, [x10],#32	// Lk_inv
 	ld1	{v20.2d,v21.2d,v22.2d,v23.2d}, [x11],#64	// Lk_dipt, Lk_dsbo
 	ld1	{v24.2d,v25.2d,v26.2d,v27.2d}, [x11],#64	// Lk_dsb9, Lk_dsbd
@@ -355,10 +362,12 @@ _vpaes_decrypt_core:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	$4, %r11
 	eor	x11, x11, #0x30			// xor		$0x30,	%r11
-	adr	x10, Lk_sr
+	adrp	x10, Lk_sr@PAGE
+	add	x10, x10, Lk_sr@PAGEOFF
 	and	x11, x11, #0x30			// and		$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, Lk_mc_forward+48
+	adrp	x10, Lk_mc_forward@PAGE+48
+	add	x10, x10, Lk_mc_forward@PAGEOFF+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -465,10 +474,12 @@ _vpaes_decrypt_2x:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	$4, %r11
 	eor	x11, x11, #0x30			// xor		$0x30,	%r11
-	adr	x10, Lk_sr
+	adrp	x10, Lk_sr@PAGE
+	add	x10, x10, Lk_sr@PAGEOFF
 	and	x11, x11, #0x30			// and		$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, Lk_mc_forward+48
+	adrp	x10, Lk_mc_forward@PAGE+48
+	add	x10, x10, Lk_mc_forward@PAGEOFF+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b,  v14.16b, v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -597,14 +608,18 @@ Ldec_2x_entry:
 
 .align	4
 _vpaes_key_preheat:
-	adr	x10, Lk_inv
+	adrp	x10, Lk_inv@PAGE
+	add	x10, x10, Lk_inv@PAGEOFF
 	movi	v16.16b, #0x5b			// Lk_s63
-	adr	x11, Lk_sb1
+	adrp	x11, Lk_sb1@PAGE
+	add	x11, x11, Lk_sb1@PAGEOFF
 	movi	v17.16b, #0x0f			// Lk_s0F
 	ld1	{v18.2d,v19.2d,v20.2d,v21.2d}, [x10]		// Lk_inv, Lk_ipt
-	adr	x10, Lk_dksd
+	adrp	x10, Lk_dksd@PAGE
+	add	x10, x10, Lk_dksd@PAGEOFF
 	ld1	{v22.2d,v23.2d}, [x11]		// Lk_sb1
-	adr	x11, Lk_mc_forward
+	adrp	x11, Lk_mc_forward@PAGE
+	add	x11, x11, Lk_mc_forward@PAGEOFF
 	ld1	{v24.2d,v25.2d,v26.2d,v27.2d}, [x10],#64	// Lk_dksd, Lk_dksb
 	ld1	{v28.2d,v29.2d,v30.2d,v31.2d}, [x10],#64	// Lk_dkse, Lk_dks9
 	ld1	{v8.2d}, [x10]			// Lk_rcon
@@ -627,7 +642,9 @@ _vpaes_schedule_core:
 	bl	_vpaes_schedule_transform
 	mov	v7.16b, v0.16b			// vmovdqa	%xmm0,	%xmm7
 
-	adr	x10, Lk_sr			// lea	Lk_sr(%rip),%r10
+	adrp	x10, Lk_sr@PAGE		// lea	Lk_sr(%rip),%r10
+	add	x10, x10, Lk_sr@PAGEOFF
+
 	add	x8, x8, x10
 	cbnz	w3, Lschedule_am_decrypting
 
@@ -753,12 +770,15 @@ Loop_schedule_256:
 .align	4
 Lschedule_mangle_last:
 	// schedule last round key from xmm0
-	adr	x11, Lk_deskew			// lea	Lk_deskew(%rip),%r11	# prepare to deskew
+	adrp	x11, Lk_deskew@PAGE	// lea	Lk_deskew(%rip),%r11	# prepare to deskew
+	add	x11, x11, Lk_deskew@PAGEOFF
+
 	cbnz	w3, Lschedule_mangle_last_dec
 
 	// encrypting
 	ld1	{v1.2d}, [x8]			// vmovdqa	(%r8,%r10),%xmm1
-	adr	x11, Lk_opt			// lea	Lk_opt(%rip),	%r11		# prepare to output transform
+	adrp	x11, Lk_opt@PAGE		// lea	Lk_opt(%rip),	%r11		# prepare to output transform
+	add	x11, x11, Lk_opt@PAGEOFF
 	add	x2, x2, #32			// add	$32,	%rdx
 	tbl	v0.16b, {v0.16b}, v1.16b	// vpshufb	%xmm1,	%xmm0,	%xmm0		# output permute
 

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/vpaes-armv8.linux.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/vpaes-armv8.linux.aarch64.S
@@ -14,7 +14,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <boringssl_prefix_symbols_asm.h>
 #endif
-.text
+.section	.rodata
 
 .type	_vpaes_consts,%object
 .align	7	// totally strategic alignment
@@ -106,6 +106,8 @@ _vpaes_consts:
 .align	2
 .size	_vpaes_consts,.-_vpaes_consts
 .align	6
+
+.text
 ##
 ##  _aes_preheat
 ##
@@ -115,7 +117,8 @@ _vpaes_consts:
 .type	_vpaes_encrypt_preheat,%function
 .align	4
 _vpaes_encrypt_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, :lo12:.Lk_inv
 	movi	v17.16b, #0x0f
 	ld1	{v18.2d,v19.2d}, [x10],#32	// .Lk_inv
 	ld1	{v20.2d,v21.2d,v22.2d,v23.2d}, [x10],#64	// .Lk_ipt, .Lk_sbo
@@ -143,7 +146,8 @@ _vpaes_encrypt_preheat:
 _vpaes_encrypt_core:
 	mov	x9, x2
 	ldr	w8, [x2,#240]			// pull rounds
-	adr	x11, .Lk_mc_forward+16
+	adrp	x11, .Lk_mc_forward+16
+	add	x11, x11, :lo12:.Lk_mc_forward+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -229,7 +233,8 @@ vpaes_encrypt:
 _vpaes_encrypt_2x:
 	mov	x9, x2
 	ldr	w8, [x2,#240]			// pull rounds
-	adr	x11, .Lk_mc_forward+16
+	adrp	x11, .Lk_mc_forward+16
+	add	x11, x11, :lo12:.Lk_mc_forward+16
 						// vmovdqa	.Lk_ipt(%rip),	%xmm2	# iptlo
 	ld1	{v16.2d}, [x9], #16		// vmovdqu	(%r9),	%xmm5		# round0 key
 	and	v1.16b,  v14.16b,  v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -332,9 +337,11 @@ _vpaes_encrypt_2x:
 .type	_vpaes_decrypt_preheat,%function
 .align	4
 _vpaes_decrypt_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, :lo12:.Lk_inv
 	movi	v17.16b, #0x0f
-	adr	x11, .Lk_dipt
+	adrp	x11, .Lk_dipt
+	add	x11, x11, :lo12:.Lk_dipt
 	ld1	{v18.2d,v19.2d}, [x10],#32	// .Lk_inv
 	ld1	{v20.2d,v21.2d,v22.2d,v23.2d}, [x11],#64	// .Lk_dipt, .Lk_dsbo
 	ld1	{v24.2d,v25.2d,v26.2d,v27.2d}, [x11],#64	// .Lk_dsb9, .Lk_dsbd
@@ -356,10 +363,12 @@ _vpaes_decrypt_core:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	$4, %r11
 	eor	x11, x11, #0x30			// xor		$0x30,	%r11
-	adr	x10, .Lk_sr
+	adrp	x10, .Lk_sr
+	add	x10, x10, :lo12:.Lk_sr
 	and	x11, x11, #0x30			// and		$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, .Lk_mc_forward+48
+	adrp	x10, .Lk_mc_forward+48
+	add	x10, x10, :lo12:.Lk_mc_forward+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b, v7.16b, v17.16b		// vpand	%xmm9,	%xmm0,	%xmm1
@@ -466,10 +475,12 @@ _vpaes_decrypt_2x:
 						// vmovdqa	.Lk_dipt(%rip), %xmm2	# iptlo
 	lsl	x11, x8, #4			// mov	%rax,	%r11;	shl	$4, %r11
 	eor	x11, x11, #0x30			// xor		$0x30,	%r11
-	adr	x10, .Lk_sr
+	adrp	x10, .Lk_sr
+	add	x10, x10, :lo12:.Lk_sr
 	and	x11, x11, #0x30			// and		$0x30,	%r11
 	add	x11, x11, x10
-	adr	x10, .Lk_mc_forward+48
+	adrp	x10, .Lk_mc_forward+48
+	add	x10, x10, :lo12:.Lk_mc_forward+48
 
 	ld1	{v16.2d}, [x9],#16		// vmovdqu	(%r9),	%xmm4		# round0 key
 	and	v1.16b,  v14.16b, v17.16b	// vpand	%xmm9,	%xmm0,	%xmm1
@@ -598,14 +609,18 @@ _vpaes_decrypt_2x:
 .type	_vpaes_key_preheat,%function
 .align	4
 _vpaes_key_preheat:
-	adr	x10, .Lk_inv
+	adrp	x10, .Lk_inv
+	add	x10, x10, :lo12:.Lk_inv
 	movi	v16.16b, #0x5b			// .Lk_s63
-	adr	x11, .Lk_sb1
+	adrp	x11, .Lk_sb1
+	add	x11, x11, :lo12:.Lk_sb1
 	movi	v17.16b, #0x0f			// .Lk_s0F
 	ld1	{v18.2d,v19.2d,v20.2d,v21.2d}, [x10]		// .Lk_inv, .Lk_ipt
-	adr	x10, .Lk_dksd
+	adrp	x10, .Lk_dksd
+	add	x10, x10, :lo12:.Lk_dksd
 	ld1	{v22.2d,v23.2d}, [x11]		// .Lk_sb1
-	adr	x11, .Lk_mc_forward
+	adrp	x11, .Lk_mc_forward
+	add	x11, x11, :lo12:.Lk_mc_forward
 	ld1	{v24.2d,v25.2d,v26.2d,v27.2d}, [x10],#64	// .Lk_dksd, .Lk_dksb
 	ld1	{v28.2d,v29.2d,v30.2d,v31.2d}, [x10],#64	// .Lk_dkse, .Lk_dks9
 	ld1	{v8.2d}, [x10]			// .Lk_rcon
@@ -628,7 +643,9 @@ _vpaes_schedule_core:
 	bl	_vpaes_schedule_transform
 	mov	v7.16b, v0.16b			// vmovdqa	%xmm0,	%xmm7
 
-	adr	x10, .Lk_sr			// lea	.Lk_sr(%rip),%r10
+	adrp	x10, .Lk_sr		// lea	.Lk_sr(%rip),%r10
+	add	x10, x10, :lo12:.Lk_sr
+
 	add	x8, x8, x10
 	cbnz	w3, .Lschedule_am_decrypting
 
@@ -754,12 +771,15 @@ _vpaes_schedule_core:
 .align	4
 .Lschedule_mangle_last:
 	// schedule last round key from xmm0
-	adr	x11, .Lk_deskew			// lea	.Lk_deskew(%rip),%r11	# prepare to deskew
+	adrp	x11, .Lk_deskew	// lea	.Lk_deskew(%rip),%r11	# prepare to deskew
+	add	x11, x11, :lo12:.Lk_deskew
+
 	cbnz	w3, .Lschedule_mangle_last_dec
 
 	// encrypting
 	ld1	{v1.2d}, [x8]			// vmovdqa	(%r8,%r10),%xmm1
-	adr	x11, .Lk_opt			// lea	.Lk_opt(%rip),	%r11		# prepare to output transform
+	adrp	x11, .Lk_opt		// lea	.Lk_opt(%rip),	%r11		# prepare to output transform
+	add	x11, x11, :lo12:.Lk_opt
 	add	x2, x2, #32			// add	$32,	%rdx
 	tbl	v0.16b, {v0.16b}, v1.16b	// vpshufb	%xmm1,	%xmm0,	%xmm0		# output permute
 

--- a/Sources/CNIOBoringSSL/hash.txt
+++ b/Sources/CNIOBoringSSL/hash.txt
@@ -1,0 +1,1 @@
+This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision 35941f2923155664bd9fa5d897cb336a0ab729a1

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -48,7 +48,6 @@ SRCROOT="${TMPDIR}/src/boringssl.googlesource.com/boringssl"
 # This function namespaces the awkward inline functions declared in OpenSSL
 # and BoringSSL.
 function namespace_inlines {
-    echo `pwd`
     # Pull out all STACK_OF functions.
     STACKS=$(grep --no-filename -rE "DEFINE_(SPECIAL_)?STACK_OF\([A-Z_0-9a-z]+\)" "$1/"* | grep -v '//' | grep -v '#' | gsed 's/DEFINE_\(SPECIAL_\)\?STACK_OF(\(.*\))/\2/')
     STACK_FUNCTIONS=("call_free_func" "call_copy_func" "call_cmp_func" "new" "new_null" "num" "zero" "value" "set" "free" "pop_free" "insert" "delete" "delete_ptr" "find" "shift" "push" "pop" "dup" "sort" "is_sorted" "set_cmp_func" "deep_copy")
@@ -95,6 +94,10 @@ rm -rf $DSTROOT/err_data.c
 echo "CLONING boringssl"
 mkdir -p "$SRCROOT"
 git clone https://boringssl.googlesource.com/boringssl "$SRCROOT"
+cd "$SRCROOT"
+BORINGSSL_REVISION=$(git rev-parse HEAD)
+cd "$HERE"
+echo "CLONED boringssl@${BORINGSSL_REVISION}"
 
 echo "OBTAINING submodules"
 (
@@ -211,6 +214,10 @@ module CNIOBoringSSL {
   export *
 }
 EOF
+
+echo "RECORDING BoringSSL revision"
+$sed -i -e "s/BoringSSL Commit: [0-9a-f]\+/BoringSSL Commit: ${BORINGSSL_REVISION}/" "$HERE/Package.swift"
+echo "This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision ${BORINGSSL_REVISION}" > "$DSTROOT/hash.txt"
 
 echo "CLEANING temporary directory"
 rm -rf "${TMPDIR}"


### PR DESCRIPTION
Motivation:

When debugging, users may find it helpful to be able to nail down exactly
which version of BoringSSL is used to generate the specific release. We should
record this in two easy-to-find places: one in the Package.swift for users
going to GitHub, and one in the Sources tree for users who check the code
out.

Modifications:

- Updated the script to record the BoringSSL hash.

Result:

Easier to find out what BoringSSL release is in use.