### PR TITLE
Remove the static target from regular Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,10 @@ let package = Package(
     products: [
         .library(name: "NIOSSL", targets: ["NIOSSL"]),
         .executable(name: "NIOTLSServer", targets: ["NIOTLSServer"]),
-        .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]),
         .executable(name: "NIOHTTP1Client", targets: ["NIOHTTP1Client"])
+/* This target is used only for symbol mangling. It's added and removed automatically because it emits build warnings. MANGLE_START
+        .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]),
+MANGLE_END */
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0-convergence.1"),

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,4 +25,4 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test"
+    command: /bin/bash -cl "swift test -Xswiftc -warnings-as-errors"


### PR DESCRIPTION
Motivation:

We have a static library target that is used as part of the BoringSSL
vendoring setup to generate a list of hidden symbols. This works nicely,
but building it fires out a bunch of warnings due to files with no symbols
in them. That's fine during the build phase, but most developers should
never need to see it.

Modifications:

- Hide the static archive product most of the time.
- Update vendor script to un-hide the static archive product on vendoring.
- Enable warnings-as-errors.

Result:

Fewer warnings.