### PR TITLE
Clean up includes that were hidden by whitespace.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     products: [
         .library(name: "NIOSSL", targets: ["NIOSSL"]),
         .executable(name: "NIOTLSServer", targets: ["NIOTLSServer"]),
-        .executable(name: "NIOHTTP1Client", targets: ["NIOHTTP1Client"])
+        .executable(name: "NIOHTTP1Client", targets: ["NIOHTTP1Client"]),
 /* This target is used only for symbol mangling. It's added and removed automatically because it emits build warnings. MANGLE_START
         .library(name: "CNIOBoringSSL", type: .static, targets: ["CNIOBoringSSL"]),
 MANGLE_END */

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/aes-armv4.ios.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/aes-armv4.ios.arm.S
@@ -54,7 +54,7 @@
 @ improvement on Cortex A8 core and ~21.5 cycles per byte.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #else
 # define __ARM_ARCH__ __LINUX_ARM_ARCH__
 #endif

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/aes-armv4.linux.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/aes-armv4.linux.arm.S
@@ -55,7 +55,7 @@
 @ improvement on Cortex A8 core and ~21.5 cycles per byte.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #else
 # define __ARM_ARCH__ __LINUX_ARM_ARCH__
 #endif

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/bsaes-armv7.ios.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/bsaes-armv7.ios.arm.S
@@ -65,7 +65,7 @@
 @ Add CBC, CTR and XTS subroutines and adapt for kernel use; courtesy of Ard.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 
 # define VFP_ABI_PUSH	vstmdb	sp!,{d8-d15}
 # define VFP_ABI_POP	vldmia	sp!,{d8-d15}

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/bsaes-armv7.linux.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/bsaes-armv7.linux.arm.S
@@ -66,7 +66,7 @@
 @ Add CBC, CTR and XTS subroutines and adapt for kernel use; courtesy of Ard.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 
 # define VFP_ABI_PUSH	vstmdb	sp!,{d8-d15}
 # define VFP_ABI_POP	vldmia	sp!,{d8-d15}

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv4.ios.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv4.ios.arm.S
@@ -59,7 +59,7 @@
 @ Add ARMv8 code path performing at 2.0 cpb on Apple A7.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #else
 # define __ARM_ARCH__ __LINUX_ARM_ARCH__
 # define __ARM_MAX_ARCH__ 7

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv4.linux.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv4.linux.arm.S
@@ -60,7 +60,7 @@
 @ Add ARMv8 code path performing at 2.0 cpb on Apple A7.
 
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #else
 # define __ARM_ARCH__ __LINUX_ARM_ARCH__
 # define __ARM_MAX_ARCH__ 7

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv8.ios.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv8.ios.aarch64.S
@@ -53,7 +53,7 @@
 //	and the gap is only 40-90%.
 
 #ifndef	__KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #endif
 
 .text

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv8.linux.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha256-armv8.linux.aarch64.S
@@ -54,7 +54,7 @@
 //	and the gap is only 40-90%.
 
 #ifndef	__KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #endif
 
 .text

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv4.ios.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv4.ios.arm.S
@@ -68,7 +68,7 @@
 @ was reflected in below two parameters as 0 and 4. Now caller is
 @ expected to maintain native byte order for whole 64-bit values.
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 # define VFP_ABI_PUSH	vstmdb	sp!,{d8-d15}
 # define VFP_ABI_POP	vldmia	sp!,{d8-d15}
 #else

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv4.linux.arm.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv4.linux.arm.S
@@ -69,7 +69,7 @@
 @ was reflected in below two parameters as 0 and 4. Now caller is
 @ expected to maintain native byte order for whole 64-bit values.
 #ifndef __KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 # define VFP_ABI_PUSH	vstmdb	sp!,{d8-d15}
 # define VFP_ABI_POP	vldmia	sp!,{d8-d15}
 #else

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv8.ios.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv8.ios.aarch64.S
@@ -53,7 +53,7 @@
 //	and the gap is only 40-90%.
 
 #ifndef	__KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #endif
 
 .text

--- a/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv8.linux.aarch64.S
+++ b/Sources/CNIOBoringSSL/crypto/fipsmodule/sha512-armv8.linux.aarch64.S
@@ -54,7 +54,7 @@
 //	and the gap is only 40-90%.
 
 #ifndef	__KERNEL__
-# include <openssl/arm_arch.h>
+# include <CNIOBoringSSL/arm_arch.h>
 #endif
 
 .text

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -194,7 +194,7 @@ echo "RENAMING header files"
 (
     cd "$DSTROOT"
     mv "include/openssl" "include/CNIOBoringSSL"
-    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" | xargs $sed -i -e 's_#include <openssl/_#include <CNIOBoringSSL/_'
+    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" | xargs $sed -i -e 's_include <openssl/_include <CNIOBoringSSL/_'
 )
 
 # We need BoringSSL to be modularised


### PR DESCRIPTION
Motivation:

We namespaced our header files, but some includes had weird whitespace in
the directive that we didn't notice. This meant that ARM builds failed.

Modifications:

- Became more tolerant of whitespace.
- Fixed an error in Package.swift

Result:

Better builds on ARM