### PR TITLE
Handle close reentrancy in NIOSSLHandler.

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -49,7 +49,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
     private var didDeliverData: Bool = false
     private var storedContext: ChannelHandlerContext? = nil
     
-    internal init (connection: SSLConnection) {
+    internal init(connection: SSLConnection) {
         self.connection = connection
         self.bufferedWrites = MarkedCircularBuffer(initialCapacity: 96)  // 96 brings the total size of the buffer to just shy of one page
     }
@@ -254,6 +254,10 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
     /// Once `state` has transitioned to `.closed`, further calls to this method will
     /// do nothing.
     private func doShutdownStep(context: ChannelHandlerContext) {
+        guard self.state != .closed else {
+            return
+        }
+
         let result = connection.doShutdown()
 
         let targetCompleteState: ConnectionState

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -49,6 +49,7 @@ extension NIOSSLIntegrationTest {
                 ("testRepeatedClosure", testRepeatedClosure),
                 ("testReceivingGibberishAfterAttemptingToClose", testReceivingGibberishAfterAttemptingToClose),
                 ("testPendingWritesFailWhenFlushedOnClose", testPendingWritesFailWhenFlushedOnClose),
+                ("testChannelInactiveAfterCloseNotify", testChannelInactiveAfterCloseNotify),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

- If the NIOSSLHandler had reads to fire during a clean shutdown, then
  they could cause an additional reentrant shutdown.
- This would fail a precondition and crash.

Modifications:

- If we're already in the shutdown state then don't perform shutdown again
- Added a test

Result:

More correct code.