### PR TITLE
Add a timeout for TLS shutdown.

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -50,6 +50,6 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout)
     }
 }

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -29,6 +29,6 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout)
     }
 }

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -82,6 +82,9 @@ extension NIOSSLError: Equatable {
     }
 }
 
+/// Closing the TLS channel cleanly timed out, so it was closed uncleanly.
+public struct NIOSSLCloseTimedOutError: Error {}
+
 /// An enum that wraps individual BoringSSL errors directly.
 public enum BoringSSLError: Error {
     case noError

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import CNIOBoringSSL
+import NIO
 
 /// Known and supported TLS versions.
 public enum TLSVersion {
@@ -145,8 +146,12 @@ public struct TLSConfiguration {
             self.encodedApplicationProtocols = newValue.map(encodeALPNIdentifier)
         }
     }
-    
+
     internal var encodedApplicationProtocols: [[UInt8]]
+
+    /// The amount of time to wait after initiating a shutdown before performing an unclean
+    /// shutdown. Defaults to 5 seconds.
+    public var shutdownTimeout: TimeAmount
 
     /// A callback that can be used to implement `SSLKEYLOGFILE` support.
     public var keyLogCallback: NIOSSLKeyLogCallback?
@@ -159,6 +164,7 @@ public struct TLSConfiguration {
                  certificateChain: [NIOSSLCertificateSource],
                  privateKey: NIOSSLPrivateKeySource?,
                  applicationProtocols: [String],
+                 shutdownTimeout: TimeAmount,
                  keyLogCallback: NIOSSLKeyLogCallback?) {
         self.cipherSuites = cipherSuites
         self.minimumTLSVersion = minimumTLSVersion
@@ -168,6 +174,7 @@ public struct TLSConfiguration {
         self.certificateChain = certificateChain
         self.privateKey = privateKey
         self.encodedApplicationProtocols = []
+        self.shutdownTimeout = shutdownTimeout
         self.applicationProtocols = applicationProtocols
         self.keyLogCallback = keyLogCallback
     }
@@ -184,6 +191,7 @@ public struct TLSConfiguration {
                                  certificateVerification: CertificateVerification = .none,
                                  trustRoots: NIOSSLTrustRoots = .default,
                                  applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
                                  keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
         return TLSConfiguration(cipherSuites: cipherSuites,
                                 minimumTLSVersion: minimumTLSVersion,
@@ -193,6 +201,7 @@ public struct TLSConfiguration {
                                 certificateChain: certificateChain,
                                 privateKey: privateKey,
                                 applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
                                 keyLogCallback: keyLogCallback)
     }
 
@@ -209,6 +218,7 @@ public struct TLSConfiguration {
                                  certificateChain: [NIOSSLCertificateSource] = [],
                                  privateKey: NIOSSLPrivateKeySource? = nil,
                                  applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
                                  keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
         return TLSConfiguration(cipherSuites: cipherSuites,
                                 minimumTLSVersion: minimumTLSVersion,
@@ -218,6 +228,7 @@ public struct TLSConfiguration {
                                 certificateChain: certificateChain,
                                 privateKey: privateKey,
                                 applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
                                 keyLogCallback: keyLogCallback)
     }
 }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -47,6 +47,7 @@ extension NIOSSLIntegrationTest {
                 ("testForcingVerificationFailure", testForcingVerificationFailure),
                 ("testExtractingCertificates", testExtractingCertificates),
                 ("testRepeatedClosure", testRepeatedClosure),
+                ("testClosureTimeout", testClosureTimeout),
                 ("testReceivingGibberishAfterAttemptingToClose", testReceivingGibberishAfterAttemptingToClose),
                 ("testPendingWritesFailWhenFlushedOnClose", testPendingWritesFailWhenFlushedOnClose),
                 ("testChannelInactiveAfterCloseNotify", testChannelInactiveAfterCloseNotify),


### PR DESCRIPTION
Motivation:

The remote peer may not always respond to a close notify. This would
leave the SSL handler waiting to shutdown. The shutdown should timeout
in these cases to ensure shutdown completes.

Modifications:

- Added a shutdown timeout to the NIOSSLHandler, and a configurable
  timeout amount to TLSConfiguration.
- Added a test to validate timing out a shutdown.

Result:

TLS shutdown will complete even if the remote peer does not respond to a
close notify.