### PR TITLE
Avoid using un-thread-safe static buffers when printing errors.

### DIFF
--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -19,10 +19,12 @@ public struct BoringSSLInternalError: Equatable, CustomStringConvertible {
     let errorCode: UInt32
 
     var errorMessage: String? {
-        if let cErrorMessage = CNIOBoringSSL_ERR_error_string(errorCode, nil) {
-            return String.init(cString: cErrorMessage)
+        // TODO(cory): This should become non-optional in the future, as it always succeeds.
+        var scratchBuffer = [CChar](repeating: 0, count: 512)
+        return scratchBuffer.withUnsafeMutableBufferPointer { pointer in
+            CNIOBoringSSL_ERR_error_string_n(self.errorCode, pointer.baseAddress!, pointer.count)
+            return String(cString: pointer.baseAddress!)
         }
-        return nil
     }
 
     public var description: String {


### PR DESCRIPTION
Motivation:

BoringSSL's docs make it pretty clear that ERR_error_string is not safe to use in a
concurrent context. Sadly, NIO is pretty damn concurrent, so we should probably stop using it.

Modifications:

- Rewrite the error printing logic to use ERR_error_string_n which takes a buffer to write
    into.

Result:

Error strings will not be corrupted in multithreaded contexts.