### PR TITLE
Add 'Show on GitHub' link to API docs

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -86,7 +86,8 @@ tmp=`mktemp -d`
 for module in "${modules[@]}"; do
   args=("${jazzy_args[@]}"  --output "$tmp/docs/$version/$module" --docset-path "$tmp/docset/$version/$module" --module "$module")
   if [[ -f "$root_path/.build/sourcekitten/$module.json" ]]; then
-    args+=(--sourcekitten-sourcefile "$root_path/.build/sourcekitten/$module.json")
+    args+=(--sourcekitten-sourcefile "$root_path/.build/sourcekitten/$module.json"
+           --root-url "https://apple.github.io/swift-nio-ssl/docs/$version/$module")
   fi
   jazzy "${args[@]}"
 done


### PR DESCRIPTION
Motivation:

Allowing readers of the API documentation to drill into the implementation of documented declarations can be educational and helpful for debugging, among several other reasons.

Modifications:

Add --github-file-prefix appending the current version in order to keep stable links. This means that documentation generated from any non-release revision may resolve incorrectly. This can be refined in the doc generation script later if it is deemed problematic by resolving to the commit sha if it doesn't exactly align with the version.

Result:

Users will be able to click a 'Show on GitHub' for all documented API declarations.