### PR TITLE
Set SSL_VERIFY_FAIL_IF_NO_PEER_CERT.

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -345,7 +345,7 @@ extension NIOSSLContext {
         // If validation is turned on, set the trust roots and turn on cert validation.
         switch verification {
         case .fullVerification, .noHostnameVerification:
-            CNIOBoringSSL_SSL_CTX_set_verify(context, SSL_VERIFY_PEER, nil)
+            CNIOBoringSSL_SSL_CTX_set_verify(context, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nil)
 
             switch trustRoots {
             case .some(.default), .none:

--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -32,6 +32,8 @@ extension TLSConfigurationTest {
                 ("testServerCannotValidateClientPreTLS13", testServerCannotValidateClientPreTLS13),
                 ("testServerCannotValidateClientPostTLS13", testServerCannotValidateClientPostTLS13),
                 ("testMutualValidation", testMutualValidation),
+                ("testMutualValidationRequiresClientCertificatePreTLS13", testMutualValidationRequiresClientCertificatePreTLS13),
+                ("testMutualValidationRequiresClientCertificatePostTLS13", testMutualValidationRequiresClientCertificatePostTLS13),
                 ("testNonexistentFileObject", testNonexistentFileObject),
                 ("testComputedApplicationProtocols", testComputedApplicationProtocols),
            ]


### PR DESCRIPTION
Motivation:

When server users turn on certificate verification, they usually expect
that they'll actually require the certificate from their peer. Sadly,
this is not the BoringSSL default behaviour.

Modifications:

Set `SSL_VERIFY_FAIL_IF_NO_PEER_CERT` when requesting certificate
validation.

Result:

Better certificate validation.