### PR TITLE
Support renegotiation-based client auth.

### DIFF
--- a/IntegrationTests/plugin_echo.sh
+++ b/IntegrationTests/plugin_echo.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+function plugin_echo_test_suite_begin() {
+    echo "Running test suite '$1'"
+}
+
+function plugin_echo_test_suite_end() {
+    true
+}
+
+# test_name
+function plugin_echo_test_begin() {
+    echo -n "Running test '$1'... "
+}
+
+function plugin_echo_test_skip() {
+    echo "Skipping test '$1'"
+}
+
+function plugin_echo_test_ok() {
+    echo "OK (${1}s)"
+}
+
+function plugin_echo_test_fail() {
+    echo "FAILURE ($1)"
+    echo "--- OUTPUT BEGIN ---"
+    cat "$2"
+    echo "--- OUTPUT  END  ---"
+}
+
+function plugin_echo_test_end() {
+    true
+}
+
+function plugin_echo_summary_ok() {
+    echo "OK (ran $1 tests successfully)"
+}
+
+function plugin_echo_summary_fail() {
+    echo "FAILURE (oks: $1, failures: $2)"
+}
+
+function plugin_echo_init() {
+    true
+}

--- a/IntegrationTests/plugin_junit_xml.sh
+++ b/IntegrationTests/plugin_junit_xml.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+junit_testsuite_time=0
+
+function junit_output_write() {
+    extra_flags=""
+    if [[ "$1" == "-n" ]]; then
+        extra_flags="-n"
+        shift
+    fi
+    test -n "$junit_xml_output"
+    echo $extra_flags "$*" >> "$junit_xml_output"
+}
+
+function junit_output_cat() {
+    cat "$@" >> "$junit_xml_output"
+}
+
+# search, replace
+function junit_output_replace() {
+    test -n "$junit_xml_output"
+    case "$(uname -s)" in
+        Linux)
+            sed -i "s/$1/$2/g" "$junit_xml_output"
+            ;;
+        *)
+            sed -i "" "s/$1/$2/g" "$junit_xml_output"
+            ;;
+    esac
+}
+
+function plugin_junit_xml_test_suite_begin() {
+    junit_testsuite_time=0
+    junit_output_write "<testsuite name='$1' hostname='$(hostname)' "\
+"timestamp='$(date -u +"%Y-%m-%dT%H:%M:%S")' tests='XXX-TESTS-XXX' "\
+"failures='XXX-FAILURES-XXX' time='XXX-TIME-XXX' errors='0' id='$(date +%s)'"\
+" package='NIOIntegrationTests.$1'>"
+}
+
+function plugin_junit_xml_test_suite_end() {
+    junit_repl_success_and_fail "$1" "$2"
+    junit_output_write "</testsuite>"
+}
+
+# test_name
+function plugin_junit_xml_test_begin() {
+    junit_output_write -n "  <testcase classname='NIOIntegrationTests.$2' name='$1'"
+}
+
+function plugin_junit_xml_test_skip() {
+    true
+}
+
+function plugin_junit_xml_test_ok() {
+    time_ms=$1
+    junit_output_write " time='$time_ms'>"
+    junit_testsuite_time=$((junit_testsuite_time + time_ms))
+}
+
+function plugin_junit_xml_test_fail() {
+    time_ms=$1
+    junit_output_write " time='$time_ms'>"
+    junit_output_write "  <failure type='test_fail'>"
+    junit_output_write "    <system-out>"
+    junit_output_write '      <![CDATA['
+    junit_output_cat "$2"
+    junit_output_write '      ]]>'
+    junit_output_write "    </system-out>"
+    junit_output_write "  </failure>"
+}
+
+function plugin_junit_xml_test_end() {
+    junit_output_write "  </testcase>"
+}
+
+function junit_repl_success_and_fail() {
+    junit_output_replace XXX-TESTS-XXX "$(($1 + $2))"
+    junit_output_replace XXX-FAILURES-XXX "$2"
+    junit_output_replace XXX-TIME-XXX "$junit_testsuite_time"
+}
+
+function plugin_junit_xml_summary_ok() {
+    junit_output_write "</testsuites>"
+}
+
+function plugin_junit_xml_summary_fail() {
+    junit_output_write "</testsuites>"
+}
+
+function plugin_junit_xml_init() {
+    junit_xml_output=""
+    for f in "$@"; do
+        if [[ "$junit_xml_output" = "PLACEHOLDER" ]]; then
+            junit_xml_output="$f"
+        fi
+        if [[ "$f" == "--junit-xml" && -z "$junit_xml_output" ]]; then
+            junit_xml_output="PLACEHOLDER"
+        fi
+    done
+
+    if [[ -z "$junit_xml_output" || "$junit_xml_output" = "PLACEHOLDER" ]]; then
+        echo >&2 "ERROR: you need to specify the output after the --junit-xml argument"
+        false
+    fi
+    echo "<testsuites>" > "$junit_xml_output"
+}

--- a/IntegrationTests/run-single-test.sh
+++ b/IntegrationTests/run-single-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+(
+# this sub-shell is where the actual test is run
+set -eu
+set -x
+set -o pipefail
+
+test="$1"
+tmp="$2"
+root="$3"
+g_show_info="$4"
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$here/test_functions.sh"
+source "$test"
+wait
+)
+exit_code=$?
+exit $exit_code

--- a/IntegrationTests/run-tests.sh
+++ b/IntegrationTests/run-tests.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+shopt -s nullglob
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+tmp=$(mktemp -d /tmp/.swift-nio-http1-server-sh-tests_XXXXXX)
+
+# start_time
+function time_diff_to_now() {
+    echo "$(( $(date +%s) - $1 ))"
+}
+
+function plugins_do() {
+    local method
+    method="$1"
+    shift
+    for plugin in $plugins; do
+        cd "$orig_cwd"
+        "plugin_${plugin}_${method}" "$@"
+        cd - > /dev/null
+    done
+}
+
+source "$here/plugin_echo.sh"
+source "$here/plugin_junit_xml.sh"
+
+plugins="echo"
+plugin_opts_ind=0
+if [[ "${1-default}" == "--junit-xml" ]]; then
+    plugins="echo junit_xml"
+    plugin_opts_ind=2
+fi
+
+function usage() {
+    echo >&2 "Usage: $0 [OPTIONS]"
+    echo >&2
+    echo >&2 "OPTIONS:"
+    echo >&2 "  -f FILTER: Only run tests matching FILTER (regex)"
+}
+
+orig_cwd=$(pwd)
+cd "$here"
+
+plugins_do init "$@"
+shift $plugin_opts_ind
+
+filter="."
+verbose=false
+show_info=false
+debug=false
+while getopts "f:vid" opt; do
+    case $opt in
+        f)
+            filter="$OPTARG"
+            ;;
+        v)
+            verbose=true
+            ;;
+        i)
+            show_info=true
+            ;;
+        d)
+            debug=true
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+function run_test() {
+    if $verbose; then
+        "$@" 2>&1 | tee -a "$out"
+        # we need to return the return value of the first command
+        return ${PIPESTATUS[0]}
+    else
+        "$@" >> "$out" 2>&1
+    fi
+}
+
+exec 3>&1 4>&2 # copy stdout/err to fd 3/4 to we can output control messages
+cnt_ok=0
+cnt_fail=0
+for f in tests_*; do
+    suite_ok=0
+    suite_fail=0
+    plugins_do test_suite_begin "$f"
+    start_suite=$(date +%s)
+    cd "$f"
+    for t in test_*.sh; do
+        if [[ ! "$f/$t" =~ $filter ]]; then
+            plugins_do test_skip "$t"
+            continue
+        fi
+        out=$(mktemp "$tmp/test.out_XXXXXX")
+        test_tmp=$(mktemp -d "$tmp/test.tmp_XXXXXX")
+        plugins_do test_begin "$t" "$f"
+        start=$(date +%s)
+        if run_test "$here/run-single-test.sh" "$here/$f/$t" "$test_tmp" "$here/.." "$show_info"; then
+            plugins_do test_ok "$(time_diff_to_now $start)"
+            suite_ok=$((suite_ok+1))
+            if $verbose; then
+                cat "$out"
+            fi
+        else
+            plugins_do test_fail "$(time_diff_to_now $start)" "$out"
+            suite_fail=$((suite_fail+1))
+        fi
+        if ! $debug; then
+            rm "$out"
+            rm -rf "$test_tmp"
+        fi
+        plugins_do test_end
+    done
+    cnt_ok=$((cnt_ok + suite_ok))
+    cnt_fail=$((cnt_fail + suite_fail))
+    cd ..
+    plugins_do test_suite_end "$(time_diff_to_now $start_suite)" "$suite_ok" "$suite_fail"
+done
+
+if ! $debug; then
+    rm -rf "$tmp"
+else
+    echo >&2 "debug mode, not deleting '$tmp'"
+fi
+
+
+# report
+if [[ $cnt_fail > 0 ]]; then
+    # kill leftovers (the whole process group)
+    trap '' TERM
+    kill 0
+
+    plugins_do summary_fail "$cnt_ok" "$cnt_fail"
+else
+    plugins_do summary_ok "$cnt_ok" "$cnt_fail"
+fi
+
+if [[ $cnt_fail > 0 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/IntegrationTests/test_functions.sh
+++ b/IntegrationTests/test_functions.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+function fail() {
+    echo >&2 "FAILURE: $*"
+    false
+}
+
+function assert_equal() {
+    if [[ "$1" != "$2" ]]; then
+        fail "expected '$1', got '$2' ${3-}"
+    fi
+}
+
+function assert_equal_files() {
+    if ! cmp -s "$1" "$2"; then
+        diff -u "$1" "$2" || true
+        echo
+        echo "--- SNIP ($1, size=$(wc "$1"), SHA=$(shasum "$1")) ---"
+        cat "$1"
+        echo "--- SNAP ($1)---"
+        echo "--- SNIP ($2, size=$(wc "$2"), SHA=$(shasum "$2")) ---"
+        cat "$2"
+        echo "--- SNAP ($2) ---"
+        fail "file '$1' not equal to '$2'"
+    fi
+}
+
+function assert_less_than() {
+    if [[ ! "$1" -lt "$2" ]]; then
+        fail "assertion '$1' < '$2' failed"
+    fi
+}
+
+function assert_less_than_or_equal() {
+    if [[ ! "$1" -le "$2" ]]; then
+        fail "assertion '$1' <= '$2' failed"
+    fi
+}
+
+function assert_greater_than() {
+    if [[ ! "$1" -gt "$2" ]]; then
+        fail "assertion '$1' > '$2' failed"
+    fi
+}
+
+function assert_greater_than_or_equal() {
+    if [[ ! "$1" -ge "$2" ]]; then
+        fail "assertion '$1' >= '$2' failed"
+    fi
+}
+
+g_has_previously_infoed=false
+
+function info() {
+    if $g_show_info; then
+        if ! $g_has_previously_infoed; then
+            echo >&3 || true # echo an extra newline so it looks better
+            g_has_previously_infoed=true
+        fi
+        echo >&3 "info: $*" || true
+    fi
+}
+
+function warn() {
+    echo >&4 "warning: $*"
+}

--- a/IntegrationTests/tests_01_general/defines.sh
+++ b/IntegrationTests/tests_01_general/defines.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+function client_path() {
+    echo "$(swift build --show-bin-path)/NIOSSLHTTP1Client"
+}
+

--- a/IntegrationTests/tests_01_general/test_01_renegotiation.sh
+++ b/IntegrationTests/tests_01_general/test_01_renegotiation.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+source defines.sh
+
+swift build
+
+# Generate a self-signed certificate.
+cat << EOF > "$tmp/openssl.cnf"
+[ req ]
+distinguished_name = subject
+req_extensions = req_ext
+x509_extensions = x509_ext
+
+[ subject ]
+countryName         = Country Name (2 letter code)
+countryName_default     = US
+
+stateOrProvinceName     = State or Province Name (full name)
+stateOrProvinceName_default = NY
+
+localityName            = Locality Name (eg, city)
+localityName_default        = New York
+
+organizationName         = Organization Name (eg, company)
+organizationName_default    = Example, LLC
+
+[ req_ext ]
+
+basicConstraints = CA:FALSE
+
+[ x509_ext ]
+subjectKeyIdentifier = hash
+subjectAltName = @alternate_names
+
+[ alternate_names ]
+DNS.1 = localhost
+EOF
+
+
+openssl req -new -newkey rsa:4096 -days 365 -nodes -config "$tmp/openssl.cnf" -x509 \
+    -subj "/C=US/ST=NJ/L=Wall/O=NIO/CN=localhost" \
+    -keyout "$tmp/key.pem" -out "$tmp/cert.pem"
+
+expect -c "
+          spawn openssl s_server -cert \"$tmp/cert.pem\" -key \"$tmp/key.pem\"
+          set serverspawn \$spawn_id
+          expect {
+              \"ACCEPT\" {
+              }
+              timeout {
+                  exit 1
+              }
+          }
+
+          spawn $(client_path) http://localhost:4433/get \"$tmp/cert.pem\" \"$tmp/key.pem\" \"$tmp/cert.pem\"
+          set spawn_id \$serverspawn
+
+          expect {
+              \"close\\r\\r\" {
+              }
+              timeout {
+                  exit 2
+              }
+          }
+          send  \"R\r\"
+          expect {
+              \"Read BLOCK\\r\" {
+              }
+              timeout {
+                  exit 3
+              }
+          }
+          "
+


### PR DESCRIPTION
Motivation:

While TLS renegotiation is in general a bad idea, it is widely used for
delayed TLS-based client authentication. We are able to support this
use-case, and so we should enable it.

As with BoringSSL, we'd like to continue to default to not supporting
this mode of operation. However, users are free to enable support if
they so choose.

Modifications:

- Added flags for configuring renegotiation.
- Added integration test harness.
- Added renegotiation integration test with s_server.
- Added renegotiation and client cert support to sample client.

Result:

Users will be able to perform TLS renegotiation.
Resolves #110 