### PR TITLE
workaround SR-11125: @_implementationOnly import CNIOBoringSSL

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 
 /// The BoringSSL entry point to write to the `ByteBufferBIO`. This thunk unwraps the user data

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIOTLS
 
 /// The base class for all NIOSSL handlers. This class cannot actually be instantiated by

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 
 /// The result of an attempt to verify an X.509 certificate.

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 internal let SSL_MAX_RECORD_SIZE = 16 * 1024
 

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+@_implementationOnly import CNIOBoringSSLShims
+#else
 import CNIOBoringSSL
 import CNIOBoringSSLShims
+#endif
 
 // This is a neat trick. Swift lazily initializes module-globals based on when they're first
 // used. This lets us defer BoringSSL intialization as late as possible and only do it if people

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 /// Wraps a single error from BoringSSL.
 public struct BoringSSLInternalError: Equatable, CustomStringConvertible {

--- a/Sources/NIOSSL/SSLInit.swift
+++ b/Sources/NIOSSL/SSLInit.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 /// Initialize BoringSSL. Note that this function IS NOT THREAD SAFE, and so must be called inside
 /// either an explicit or implicit dispatch_once.

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 
 

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 /// An `NIOSSLPassphraseCallback` is a callback that will be invoked by NIOSSL when it needs to
 /// get access to a private key that is stored in encrypted form.
@@ -112,10 +116,14 @@ func globalBoringSSLPassphraseCallback(buf: UnsafeMutablePointer<CChar>?,
 /// to obtain an in-memory representation of a key from a buffer of
 /// bytes or from a file path.
 public class NIOSSLPrivateKey {
-    internal let ref: UnsafeMutablePointer<EVP_PKEY>
+    internal let _ref: UnsafeMutableRawPointer /*<EVP_PKEY>*/
+
+    internal var ref: UnsafeMutablePointer<EVP_PKEY> {
+        return self._ref.assumingMemoryBound(to: EVP_PKEY.self)
+    }
 
     private init(withReference ref: UnsafeMutablePointer<EVP_PKEY>) {
-        self.ref = ref
+        self._ref = UnsafeMutableRawPointer(ref) // erasing the type for @_implementationOnly import CNIOBoringSSL
     }
 
     /// A delegating initializer for `init(file:format:passphraseCallback)` and `init(file:format:)`.

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 /// An `NIOSSLPublicKey` is an abstract handle to a public key owned by BoringSSL.
 ///
@@ -21,10 +25,14 @@ import CNIOBoringSSL
 /// `NIOSSLCertificate` objects to be serialized, so that they can be passed to
 /// general-purpose cryptography libraries.
 public class NIOSSLPublicKey {
-    private let ref: UnsafeMutablePointer<EVP_PKEY>
+    private let _ref: UnsafeMutableRawPointer /*<EVP_PKEY>*/
+
+    private var ref: UnsafeMutablePointer<EVP_PKEY> {
+        return self._ref.assumingMemoryBound(to: EVP_PKEY.self)
+    }
 
     fileprivate init(withOwnedReference ref: UnsafeMutablePointer<EVP_PKEY>) {
-        self.ref = ref
+        self._ref = UnsafeMutableRawPointer(ref) // erasing the type for @_implementationOnly import CNIOBoringSSL
     }
 
     deinit {

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -11,7 +11,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 
 /// The current state of the platform verification helper, if one is in use.
 ///

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 
 /// Known and supported TLS versions.

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -14,7 +14,11 @@
 
 import XCTest
 import NIO
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 @testable import NIOSSL
 
 

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 import NIOTLS
 import NIOSSL

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 @testable import NIOSSL
 import NIOTLS

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 @testable import NIOSSL
 
 let samplePemCert = """

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+#if compiler(>=5.1) && compiler(<5.2)
+@_implementationOnly import CNIOBoringSSL
+#else
 import CNIOBoringSSL
+#endif
 import NIO
 @testable import NIOSSL
 import NIOTLS


### PR DESCRIPTION
Motivation:

If we don't import CNIOBoringSSL @_implementationOnly, then some details
of libssl's C structs might leak into NIOSSL's ABI which might lead to
clashes further down the line.

Modification:
- make all CNIOBoringSSL(Shims) imports @_implementationOnly
- remove all concrete libssl types from instance variables

Result:
- fixes #116
- works around SR-11125
- thanks @jrose-apple for suggesting this