### PR TITLE
Fix compilation on iPad Pro 1st Gen with iPadOS13 and iOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 // Sources/CNIOBoringSSL directory. The source repository is at
 // https://boringssl.googlesource.com/boringssl.
 //
-// BoringSSL Commit: ae223d6138807a13006342edfeef32e813246b39
+// BoringSSL Commit: bc2a2013e03754a89a701739a7b58c422391efa2
 
 let package = Package(
     name: "swift-nio-ssl",

--- a/Sources/CNIOBoringSSL/hash.txt
+++ b/Sources/CNIOBoringSSL/hash.txt
@@ -1,1 +1,1 @@
-This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision ae223d6138807a13006342edfeef32e813246b39
+This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision bc2a2013e03754a89a701739a7b58c422391efa2

--- a/Sources/CNIOBoringSSL/include/CNIOBoringSSL_arm_arch.h
+++ b/Sources/CNIOBoringSSL/include/CNIOBoringSSL_arm_arch.h
@@ -49,7 +49,7 @@
  * This product includes cryptographic software written by Eric Young
  * (eay@cryptsoft.com).  This product includes software written by Tim
  * Hudson (tjh@cryptsoft.com). */
-#if __arm__
+#if __arm__ || __arm64__
 #ifndef OPENSSL_HEADER_ARM_ARCH_H
 #define OPENSSL_HEADER_ARM_ARCH_H
 
@@ -119,4 +119,4 @@
 
 
 #endif  // OPENSSL_HEADER_ARM_ARCH_H
-#endif  // __arm__
+#endif  // __arm__ || __arm64__

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -21,7 +21,6 @@ import CNIOBoringSSL
 import NIO
 @testable import NIOSSL
 import NIOTLS
-import class Foundation.Process
 
 public func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
     do {

--- a/scripts/patch-2-arm-arch.patch
+++ b/scripts/patch-2-arm-arch.patch
@@ -7,7 +7,7 @@ index faa2655..0e76796 100644
   * (eay@cryptsoft.com).  This product includes software written by Tim
   * Hudson (tjh@cryptsoft.com). */
 -
-+#if __arm__
++#if __arm__ || __arm64__
  #ifndef OPENSSL_HEADER_ARM_ARCH_H
  #define OPENSSL_HEADER_ARM_ARCH_H
  
@@ -15,4 +15,4 @@ index faa2655..0e76796 100644
  
  
  #endif  // OPENSSL_HEADER_ARM_ARCH_H
-+#endif  // __arm__
++#endif  // __arm__ || __arm64__


### PR DESCRIPTION
Fixes #124 by making it compile again on said platforms.

@Lukasa is this the correct fix?
