### PR TITLE
Use UInt8 instead of Int8 for buffer types

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -78,8 +78,17 @@ public class NIOSSLCertificate {
 
     /// Create a NIOSSLCertificate from a buffer of bytes in either PEM or
     /// DER format.
+    ///
+    /// - SeeAlso: `NIOSSLCertificate.init(bytes:format:)`
+    @available(*, deprecated, renamed: "NIOSSLCertificate.init(bytes:format:)")
     public convenience init(buffer: [Int8], format: NIOSSLSerializationFormats) throws  {
-        let ref = buffer.withUnsafeBytes { (ptr) -> UnsafeMutablePointer<X509>? in
+        try self.init(bytes: buffer.map(UInt8.init), format: format)
+    }
+
+    /// Create a NIOSSLCertificate from a buffer of bytes in either PEM or
+    /// DER format.
+    public convenience init(bytes: [UInt8], format: NIOSSLSerializationFormats) throws {
+        let ref = bytes.withUnsafeBytes { (ptr) -> UnsafeMutablePointer<X509>? in
             let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), Int32(ptr.count))!
 
             defer {
@@ -194,13 +203,23 @@ extension NIOSSLCertificate {
     ///
     /// - Parameter buffer: The PEM buffer to read certificates from.
     /// - Throws: If an error is encountered while reading certificates.
+    /// - SeeAlso: `NIOSSLCertificate.fromPEMBytes(_:)`
+    @available(*, deprecated, renamed: "NIOSSLCertificate.fromPEMBytes(_:)")
     public class func fromPEMBuffer(_ buffer: [Int8]) throws -> [NIOSSLCertificate] {
+        return try fromPEMBytes(buffer.map(UInt8.init))
+    }
+
+    /// Create an array of `NIOSSLCertificate`s from a buffer of bytes in PEM format.
+    ///
+    /// - Parameter bytes: The PEM buffer to read certificates from.
+    /// - Throws: If an error is encountered while reading certificates.
+    public class func fromPEMBytes(_ bytes: [UInt8]) throws -> [NIOSSLCertificate] {
         CNIOBoringSSL_ERR_clear_error()
         defer {
             CNIOBoringSSL_ERR_clear_error()
         }
 
-        return try buffer.withUnsafeBytes { (ptr) -> [NIOSSLCertificate] in
+        return try bytes.withUnsafeBytes { (ptr) -> [NIOSSLCertificate] in
             let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), Int32(ptr.count))!
             defer {
                 CNIOBoringSSL_BIO_free(bio)

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -72,7 +72,7 @@ func ipv6Supported() throws -> Bool {
 
 class IdentityVerificationTest: XCTestCase {
     func testCanValidateHostnameInFirstSan() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -80,7 +80,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testCanValidateHostnameInSecondSan() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -88,7 +88,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testIgnoresTrailingPeriod() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "example.com.",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -96,7 +96,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testLowercasesHostnameForSan() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "LoCaLhOsT",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -104,7 +104,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsIncorrectHostname() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "httpbin.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -112,7 +112,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testAcceptsIpv4Address() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: try .makeAddressResolvingHost("192.168.0.1", port: 443),
                                                   leafCertificate: cert)
@@ -124,7 +124,7 @@ class IdentityVerificationTest: XCTestCase {
         guard try ipv6Supported() else { return }
         let ipv6Address = try SocketAddress.makeAddressResolvingHost("2001:db8::1", port: 443)
 
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: ipv6Address,
                                                   leafCertificate: cert)
@@ -132,7 +132,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsIncorrectIpv4Address() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: try .makeAddressResolvingHost("192.168.0.2", port: 443),
                                                   leafCertificate: cert)
@@ -143,7 +143,7 @@ class IdentityVerificationTest: XCTestCase {
         guard try ipv6Supported() else { return }
         let ipv6Address = try SocketAddress.makeAddressResolvingHost("2001:db8::2", port: 443)
 
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiSanCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: ipv6Address,
                                                   leafCertificate: cert)
@@ -151,7 +151,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testAcceptsWildcards() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "this.wildcard.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -159,7 +159,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testAcceptsSuffixWildcard() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "foo.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -167,7 +167,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testAcceptsPrefixWildcard() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "bar.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -175,7 +175,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testAcceptsInfixWildcard() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "baz.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -183,7 +183,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testIgnoresTrailingPeriodInCert() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "trailing.period.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -191,7 +191,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsEncodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         do {
             _ = try validIdentityForService(serverHostname: "straße.unicode.example.com",
                                             socketAddress: try .init(unixDomainSocketPath: "/path"),
@@ -204,7 +204,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testMatchesUnencodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--strae-oqa.unicode.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -212,7 +212,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testDoesNotMatchIDNALabelWithWildcard() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--xx-gia.unicode.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -220,7 +220,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testDoesNotMatchNonLeftmostWildcards() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "weirdwildcard.nomatch.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -228,7 +228,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testDoesNotMatchMultipleWildcards() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "one.two.double.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -236,7 +236,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsWildcardBeforeUnencodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         do {
             _ = try validIdentityForService(serverHostname: "foo.straße.example.com",
                                             socketAddress: try .init(unixDomainSocketPath: "/path"),
@@ -249,7 +249,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testMatchesWildcardBeforeEncodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "foo.xn--strae-oqa.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -257,7 +257,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testDoesNotMatchSANWithEmbeddedNULL() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "nul\u{0000}l.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -265,7 +265,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testFallsBackToCommonName() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiCNCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -273,7 +273,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testLowercasesForCommonName() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](multiCNCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "LoCaLhOsT",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -281,7 +281,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsUnicodeCommonNameWithUnencodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](unicodeCNCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(unicodeCNCert.utf8), format: .pem)
         do {
             _ = try validIdentityForService(serverHostname: "straße.org",
                                             socketAddress: try .init(unixDomainSocketPath: "/path"),
@@ -294,7 +294,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testRejectsUnicodeCommonNameWithEncodedIDNALabel() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](unicodeCNCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(unicodeCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--strae-oqa.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -302,7 +302,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testHandlesMissingCommonName() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](noCNCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(noCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)
@@ -310,7 +310,7 @@ class IdentityVerificationTest: XCTestCase {
     }
 
     func testDoesNotFallBackToCNWithSans() throws {
-        let cert = try NIOSSLCertificate(buffer: [Int8](weirdoPEMCert.utf8CString), format: .pem)
+        let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "httpbin.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
                                                   leafCertificate: cert)

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
@@ -434,8 +434,8 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingSimpleP12FromMemory() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(buffer: simpleP12, passphrase: "thisisagreatpassword".utf8)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: Array(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: Array(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert])
@@ -443,12 +443,12 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingComplexP12FromMemory() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(buffer: complexP12, passphrase: "thisisagreatpassword".utf8)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
-        let caOne = try NIOSSLCertificate(buffer: Array(multiSanCert.utf8CString), format: .pem)
-        let caTwo = try NIOSSLCertificate(buffer: Array(multiCNCert.utf8CString), format: .pem)
-        let caThree = try NIOSSLCertificate(buffer: Array(noCNCert.utf8CString), format: .pem)
-        let caFour = try NIOSSLCertificate(buffer: Array(unicodeCNCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: Array(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: Array(samplePemCert.utf8), format: .pem)
+        let caOne = try NIOSSLCertificate(bytes: Array(multiSanCert.utf8), format: .pem)
+        let caTwo = try NIOSSLCertificate(bytes: Array(multiCNCert.utf8), format: .pem)
+        let caThree = try NIOSSLCertificate(bytes: Array(noCNCert.utf8), format: .pem)
+        let caFour = try NIOSSLCertificate(bytes: Array(unicodeCNCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert, caOne, caTwo, caThree, caFour])
@@ -456,8 +456,8 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingSimpleP12FromMemoryWithoutPassphrase() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(buffer: noPassP12)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: Array(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: Array(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert])
@@ -465,8 +465,8 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingSimpleP12FromFile() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(file: SSLPKCS12BundleTest.simpleFilePath, passphrase: "thisisagreatpassword".utf8)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert])
@@ -474,12 +474,12 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingComplexP12FromFile() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(file: SSLPKCS12BundleTest.complexFilePath, passphrase: "thisisagreatpassword".utf8)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
-        let caOne = try NIOSSLCertificate(buffer: Array(multiSanCert.utf8CString), format: .pem)
-        let caTwo = try NIOSSLCertificate(buffer: Array(multiCNCert.utf8CString), format: .pem)
-        let caThree = try NIOSSLCertificate(buffer: Array(noCNCert.utf8CString), format: .pem)
-        let caFour = try NIOSSLCertificate(buffer: Array(unicodeCNCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
+        let caOne = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
+        let caTwo = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
+        let caThree = try NIOSSLCertificate(bytes: .init(noCNCert.utf8), format: .pem)
+        let caFour = try NIOSSLCertificate(bytes: .init(unicodeCNCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert, caOne, caTwo, caThree, caFour])
@@ -487,8 +487,8 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingSimpleP12FromFileWithoutPassphrase() throws {
         let p12Bundle = try NIOSSLPKCS12Bundle(file: SSLPKCS12BundleTest.noPassFilePath)
-        let expectedKey = try NIOSSLPrivateKey(buffer: Array(samplePemKey.utf8CString), format: .pem)
-        let expectedCert = try NIOSSLCertificate(buffer: Array(samplePemCert.utf8CString), format: .pem)
+        let expectedKey = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
+        let expectedCert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(p12Bundle.privateKey, expectedKey)
         XCTAssertEqual(p12Bundle.certificateChain, [expectedCert])

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
@@ -75,25 +75,25 @@ class SSLPrivateKeyTest: XCTestCase {
     }
 
     func testLoadingPemKeyFromMemory() throws {
-        let key1 = try NIOSSLPrivateKey(buffer: [Int8](samplePemKey.utf8CString), format: .pem)
-        let key2 = try NIOSSLPrivateKey(buffer: [Int8](samplePemKey.utf8CString), format: .pem)
+        let key1 = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
+        let key2 = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
 
         XCTAssertEqual(key1, key2)
     }
 
     func testLoadingDerKeyFromMemory() throws {
-        let keyBuffer = sampleDerKey.asArray()
-        let key1 = try NIOSSLPrivateKey(buffer: keyBuffer, format: .der)
-        let key2 = try NIOSSLPrivateKey(buffer: keyBuffer, format: .der)
+        let keyBytes = [UInt8](sampleDerKey)
+        let key1 = try NIOSSLPrivateKey(bytes: keyBytes, format: .der)
+        let key2 = try NIOSSLPrivateKey(bytes: keyBytes, format: .der)
 
         XCTAssertEqual(key1, key2)
     }
 
     func testLoadingGibberishFromMemoryAsPemFails() throws {
-        let keyBuffer: [Int8] = [1, 2, 3]
+        let keyBytes: [UInt8] = [1, 2, 3]
 
         do {
-            _ = try NIOSSLPrivateKey(buffer: keyBuffer, format: .pem)
+            _ = try NIOSSLPrivateKey(bytes: keyBytes, format: .pem)
             XCTFail("Gibberish successfully loaded")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // Do nothing.
@@ -101,10 +101,10 @@ class SSLPrivateKeyTest: XCTestCase {
     }
 
     func testLoadingGibberishFromMemoryAsDerFails() throws {
-        let keyBuffer: [Int8] = [1, 2, 3]
+        let keyBytes: [UInt8] = [1, 2, 3]
 
         do {
-            _ = try NIOSSLPrivateKey(buffer: keyBuffer, format: .der)
+            _ = try NIOSSLPrivateKey(bytes: keyBytes, format: .der)
             XCTFail("Gibberish successfully loaded")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // Do nothing.
@@ -188,15 +188,15 @@ class SSLPrivateKeyTest: XCTestCase {
     }
 
     func testLoadingEncryptedRSAKeyFromMemory() throws {
-        let key1 = try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
-        let key2 = try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
+        let key1 = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
+        let key2 = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
     }
 
     func testLoadingEncryptedRSAPKCS8KeyFromMemory() throws {
-        let key1 = try NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
-        let key2 = try NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
+        let key1 = try NIOSSLPrivateKey(bytes: .init(samplePKCS8PemPrivateKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
+        let key2 = try NIOSSLPrivateKey(bytes: .init(samplePKCS8PemPrivateKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
     }
@@ -217,7 +217,7 @@ class SSLPrivateKeyTest: XCTestCase {
 
     func testWildlyOverlongPassphraseRSAFromMemory() throws {
         do {
-            _ = try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
+            _ = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
             XCTFail("Should not have created the key")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // ok
@@ -228,7 +228,7 @@ class SSLPrivateKeyTest: XCTestCase {
 
     func testWildlyOverlongPassphrasePKCS8FromMemory() throws {
         do {
-            _ = try NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
+            _ = try NIOSSLPrivateKey(bytes: .init(samplePKCS8PemPrivateKey.utf8), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
             XCTFail("Should not have created the key")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // ok
@@ -239,7 +239,7 @@ class SSLPrivateKeyTest: XCTestCase {
 
     func testWildlyOverlongPassphraseRSAFromFile() throws {
         do {
-            _ = try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
+            _ = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
             XCTFail("Should not have created the key")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // ok
@@ -250,7 +250,7 @@ class SSLPrivateKeyTest: XCTestCase {
 
     func testWildlyOverlongPassphrasePKCS8FromFile() throws {
         do {
-            _ = try NIOSSLPrivateKey(buffer: [Int8](samplePKCS8PemPrivateKey.utf8CString), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
+            _ = try NIOSSLPrivateKey(bytes: .init(samplePKCS8PemPrivateKey.utf8), format: .pem) { closure in closure(Array(repeating: UInt8(8), count: 1 << 16)) }
             XCTFail("Should not have created the key")
         } catch NIOSSLError.failedToLoadPrivateKey {
             // ok
@@ -265,7 +265,7 @@ class SSLPrivateKeyTest: XCTestCase {
         }
 
         do {
-            _ = try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) { (_: NIOSSLPassphraseSetter<Array<UInt8>>) in
+            _ = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { (_: NIOSSLPassphraseSetter<Array<UInt8>>) in
                 throw MyError.error
             }
             XCTFail("Should not have created the key")
@@ -277,7 +277,7 @@ class SSLPrivateKeyTest: XCTestCase {
     }
 
     func testWrongPassword() {
-        XCTAssertThrowsError(try NIOSSLPrivateKey(buffer: [Int8](samplePemRSAEncryptedKey.utf8CString), format: .pem) {
+        XCTAssertThrowsError(try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) {
             closure in closure("incorrect password".utf8)
         }) { error in
             XCTAssertEqual(.failedToLoadPrivateKey, error as? NIOSSLError)


### PR DESCRIPTION
Motivation:

The underlying BoringSSL BIO APIs used by NIOSSLCertificate,
NIOSSLPrivateKey take a raw byte buffer and a count,
and do not need the input buffers to be NUL-terminated. However, the API
currently takes an `Array<Int8>` (which is a typealias of `Array<CChar>` on
platforms where NIO is primarily developed). This suggests an incorrect
completion in Xcode (`utf8CString`) which includes a trailing NUL byte.
In fact, all of the NIOSSL unit tests make this mistake. The more common
use case of creating a these types from a `Data`, `ByteBuffer`, or
`String.UTF8View` is made more awkward as these are easy to convert to
`[UInt8]` but harder to convert to `[CChar]` without extending them with
an unnessary NUL byte.

Modifications:

Add new `bytes:` overloads to the convenience initializers and deprecate
the `buffer:` convenience initalizers. Use these new initializers in the
unit tests.

Result:

A more ergnomic way to correctly create these types from `Data`,
`ByteBuffer`, and `String.UTF8View`.