### PR TITLE
Use CInt and CUnsignedInt when calling C APIs

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -89,7 +89,7 @@ public class NIOSSLCertificate {
     /// DER format.
     public convenience init(bytes: [UInt8], format: NIOSSLSerializationFormats) throws {
         let ref = bytes.withUnsafeBytes { (ptr) -> UnsafeMutablePointer<X509>? in
-            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), Int32(ptr.count))!
+            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), CInt(ptr.count))!
 
             defer {
                 CNIOBoringSSL_BIO_free(bio)
@@ -145,8 +145,8 @@ public class NIOSSLCertificate {
 
         // Per the man page, to find the first entry we set lastIndex to -1. When there are no
         // more entries, -1 is returned as the index of the next entry.
-        var lastIndex: Int32 = -1
-        var nextIndex: Int32 = -1
+        var lastIndex: CInt = -1
+        var nextIndex: CInt = -1
         repeat {
             lastIndex = nextIndex
             nextIndex = CNIOBoringSSL_X509_NAME_get_index_by_NID(subjectName, NID_commonName, lastIndex)
@@ -220,7 +220,7 @@ extension NIOSSLCertificate {
         }
 
         return try bytes.withUnsafeBytes { (ptr) -> [NIOSSLCertificate] in
-            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), Int32(ptr.count))!
+            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), CInt(ptr.count))!
             defer {
                 CNIOBoringSSL_BIO_free(bio)
             }

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -131,7 +131,7 @@ public func ==(lhs: BoringSSLError, rhs: BoringSSLError) -> Bool {
 }
 
 internal extension BoringSSLError {
-    static func fromSSLGetErrorResult(_ result: Int32) -> BoringSSLError? {
+    static func fromSSLGetErrorResult(_ result: CInt) -> BoringSSLError? {
         switch result {
         case SSL_ERROR_NONE:
             return .noError

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -166,7 +166,7 @@ public class NIOSSLPrivateKey {
     /// A delegating initializer for `init(buffer:format:passphraseCallback)` and `init(buffer:format:)`.
     private convenience init(bytes: [UInt8], format: NIOSSLSerializationFormats, callbackManager: CallbackManagerProtocol?) throws {
         let ref = bytes.withUnsafeBytes { (ptr) -> UnsafeMutablePointer<EVP_PKEY>? in
-            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), Int32(ptr.count))!
+            let bio = CNIOBoringSSL_BIO_new_mem_buf(UnsafeMutableRawPointer(mutating: ptr.baseAddress!), CInt(ptr.count))!
             defer {
                 CNIOBoringSSL_BIO_free(bio)
             }

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -292,7 +292,7 @@ func generateRSAPrivateKey() -> UnsafeMutablePointer<EVP_PKEY> {
     return pkey
 }
 
-func addExtension(x509: UnsafeMutablePointer<X509>, nid: Int32, value: String) {
+func addExtension(x509: UnsafeMutablePointer<X509>, nid: CInt, value: String) {
     var extensionContext = X509V3_CTX()
     
     CNIOBoringSSL_X509V3_set_ctx(&extensionContext, x509, x509, nil, nil, 0)
@@ -335,7 +335,7 @@ func generateSelfSignedCert() -> (NIOSSLCertificate, NIOSSLPrivateKey) {
                                                      NID_commonName,
                                                      MBSTRING_UTF8,
                                                      UnsafeMutablePointer(mutating: pointer),
-                                                     Int32(commonName.lengthOfBytes(using: .utf8)),
+                                                     CInt(commonName.lengthOfBytes(using: .utf8)),
                                                      -1,
                                                      0)
         }


### PR DESCRIPTION
Motivation:

On different platforms C may define `int` and `unsigned` to be different
types. When writing C interop code in Swift it's preferable to
use the `CInt` and `CUnsignedInt` typealiases as they will resolve to
the correct C type on all supported platforms. If the imported C API is
a definite-sized type, like `uint32_t` we leave the Swift type as
definitely-sized.

Modifications:

Use `CInt` instead of `Int32` for C `int` parameters and `CUnsignedInt`
instead of `UInt32` for C `unsigned` parameters.

Result:

Code is more portable and definite-sized types stand out.