### PR TITLE
Fix BoringSSL compilation on aarch64 ARM Linux

### DIFF
--- a/Sources/CNIOBoringSSL/include/CNIOBoringSSL_arm_arch.h
+++ b/Sources/CNIOBoringSSL/include/CNIOBoringSSL_arm_arch.h
@@ -49,7 +49,7 @@
  * This product includes cryptographic software written by Eric Young
  * (eay@cryptsoft.com).  This product includes software written by Tim
  * Hudson (tjh@cryptsoft.com). */
-#if __arm__ || __arm64__
+#if __arm__ || __arm64__ || __aarch64__
 #ifndef OPENSSL_HEADER_ARM_ARCH_H
 #define OPENSSL_HEADER_ARM_ARCH_H
 
@@ -119,4 +119,4 @@
 
 
 #endif  // OPENSSL_HEADER_ARM_ARCH_H
-#endif  // __arm__ || __arm64__
+#endif  // __arm__ || __arm64__ || __aarch64__

--- a/scripts/patch-2-arm-arch.patch
+++ b/scripts/patch-2-arm-arch.patch
@@ -7,7 +7,7 @@ index faa2655..0e76796 100644
   * (eay@cryptsoft.com).  This product includes software written by Tim
   * Hudson (tjh@cryptsoft.com). */
 -
-+#if __arm__ || __arm64__
++#if __arm__ || __arm64__ || __aarch64__
  #ifndef OPENSSL_HEADER_ARM_ARCH_H
  #define OPENSSL_HEADER_ARM_ARCH_H
  
@@ -15,4 +15,4 @@ index faa2655..0e76796 100644
  
  
  #endif  // OPENSSL_HEADER_ARM_ARCH_H
-+#endif  // __arm__ || __arm64__
++#endif  // __arm__ || __arm64__ || __aarch64__


### PR DESCRIPTION
This fixes issue #140 

The `patch-2-arm-arch.patch` file was manually updated and the `vendor-boringssl.sh` script was used to apply the patch.

I specifically avoided updating the BoringSSL SHA checkout, but I'd be happy to bump that if that is the preferred approach (both approaches successfully compiled for me on aarch64).