### PR TITLE
Remove NIO 2.9.0 build warnings.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
 MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.9.0"),
     ],
     targets: [
         .target(name: "CNIOBoringSSL"),

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -337,13 +337,8 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             
             switch result {
             case .complete:
-                // Good read. We need to check how many bytes are still writable and, if it's
-                // too few, move them along. As a general heuristic we want room to write 1kB
-                // of data, though this number is utterly arbitrary. In practice this will
-                // always double the storage if it has to.
-                if receiveBuffer.writableBytes < 1024 {
-                    receiveBuffer.reserveCapacity(receiveBuffer.capacity + 1024)
-                }
+                // Good read. Keep going
+                continue readLoop
 
             case .incomplete:
                 self.plaintextReadBuffer = receiveBuffer

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -275,8 +275,10 @@ internal final class SSLConnection {
         // safely return any of the error values that SSL_read might provide here because writeWithUnsafeMutableBytes
         // will try to use that as the number of bytes written and blow up. If we could prevent it doing that (which
         // we can with reading) that would be grand, but we can't, so instead we need to use a temp variable. Not ideal.
+        //
+        // We require that there is space to write at least one TLS record.
         var bytesRead: CInt = 0
-        let rc = outputBuffer.writeWithUnsafeMutableBytes { (pointer) -> Int in
+        let rc = outputBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: SSL_MAX_RECORD_SIZE) { (pointer) -> Int in
             bytesRead = CNIOBoringSSL_SSL_read(self.ssl, pointer.baseAddress, CInt(pointer.count))
             return bytesRead >= 0 ? Int(bytesRead) : 0
         }

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -107,7 +107,7 @@ final class ByteBufferBIOTest: XCTestCase {
         swiftBIO.receiveFromNetwork(buffer: inboundBytes)
 
         var receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
-        let rc = receivedBytes.writeWithUnsafeMutableBytes { pointer in
+        let rc = receivedBytes.writeWithUnsafeMutableBytes(minimumWritableBytes: 1024) { pointer in
             let innerRC = CNIOBoringSSL_BIO_read(cBIO, pointer.baseAddress!, CInt(pointer.count))
             XCTAssertTrue(innerRC > 0)
             return innerRC > 0 ? Int(innerRC) : 0
@@ -137,7 +137,7 @@ final class ByteBufferBIOTest: XCTestCase {
 
         var receivedBytes = ByteBufferAllocator().buffer(capacity: 1024)
         for _ in 0..<5 {
-            let rc = receivedBytes.writeWithUnsafeMutableBytes { pointer in
+            let rc = receivedBytes.writeWithUnsafeMutableBytes(minimumWritableBytes: 1024) { pointer in
                 let innerRC = CNIOBoringSSL_BIO_read(cBIO, pointer.baseAddress!, 1)
                 XCTAssertTrue(innerRC > 0)
                 return innerRC > 0 ? Int(innerRC) : 0


### PR DESCRIPTION
Motivation:

We were one of the few first-party users of
writeWithUnsafeMutableWritableBytes, and so we hit some build warnings.
We should use the nice interface to request the number of bytes we
actually want.

Modifications:

- Remove build warnings.
- Correctly ask to read a whole SSL record instead of a fragment of one.

Result:

Better code