### PR TITLE
Add regression test for executable stacks.

### DIFF
--- a/IntegrationTests/tests_01_general/test_02_execstack.sh
+++ b/IntegrationTests/tests_01_general/test_02_execstack.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+source defines.sh
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "No need to run execstack on Darwin"
+    exit 0
+fi
+
+swift build -c debug
+swift build -c release
+
+DEBUG_SERVER_PATH="$(swift build --show-bin-path)/NIOTLSServer"
+RELEASE_SERVER_PATH="$(swift build --show-bin-path -c release)/NIOTLSServer"
+
+results=$(execstack $DEBUG_SERVER_PATH $RELEASE_SERVER_PATH)
+count=$(echo "$results" | grep -c '^X' || true)
+if [ "$count" -ne 0 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools expect curl jq # used by integration tests
 RUN apt-get update && apt-get install -y libssl-dev
+RUN apt-get update && apt-get install -y execstack
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev


### PR DESCRIPTION
Motivation:

We want the CI to make sure we don't accidentally regress the executable
stack property of the binary.

Modifications:

Run execstack against our build output in the integration tests.

Result:

We shouldn't regress the executable stacks.