### PR TITLE
Add benchmarks.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ MANGLE_END */
                 dependencies: ["NIO", "NIOConcurrencyHelpers", "CNIOBoringSSL", "CNIOBoringSSLShims", "NIOTLS"]),
         .target(name: "NIOTLSServer", dependencies: ["NIO", "NIOSSL", "NIOConcurrencyHelpers"]),
         .target(name: "NIOSSLHTTP1Client", dependencies: ["NIO", "NIOHTTP1", "NIOSSL", "NIOFoundationCompat"]),
+        .target(name: "NIOSSLPerformanceTester", dependencies: ["NIO", "NIOSSL"]),
         .testTarget(name: "NIOSSLTests", dependencies: ["NIOTLS", "NIOSSL"]),
     ],
     cxxLanguageStandard: .cxx11

--- a/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOSSL
+
+final class BenchManyWrites: Benchmark {
+    let clientContext: NIOSSLContext
+    let serverContext: NIOSSLContext
+    let dummyAddress: SocketAddress
+    let backToBack: BackToBackEmbeddedChannel
+    let loopCount: Int
+    let writeSize: Int
+    var buffer: ByteBuffer?
+
+    init(loopCount: Int, writeSizeInBytes writeSize: Int) throws {
+        self.loopCount = loopCount
+        self.writeSize = writeSize
+        self.serverContext = try NIOSSLContext(configuration: .forServer(certificateChain: [.certificate(.forTesting())], privateKey: .privateKey(.forTesting())))
+        self.clientContext = try NIOSSLContext(configuration: .forClient(trustRoots: .certificates([.forTesting()])))
+        self.dummyAddress = try SocketAddress(ipAddress: "1.2.3.4", port: 5678)
+        self.backToBack = BackToBackEmbeddedChannel()
+    }
+
+    func setUp() throws {
+        let serverHandler = try NIOSSLServerHandler(context: self.serverContext)
+        let clientHandler = try NIOSSLClientHandler(context: self.clientContext, serverHostname: "localhost")
+        try self.backToBack.client.pipeline.addHandler(clientHandler).wait()
+        try self.backToBack.server.pipeline.addHandler(serverHandler).wait()
+
+        // To trigger activation of both channels we use connect().
+        try self.backToBack.client.connect(to: dummyAddress).wait()
+        try self.backToBack.server.connect(to: dummyAddress).wait()
+        try self.backToBack.interactInMemory()
+
+        self.buffer = self.backToBack.client.allocator.buffer(capacity: self.writeSize)
+        self.buffer!.writeBytes(repeatElement(0, count: self.writeSize))
+
+    }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        guard let buffer = self.buffer else {
+            fatalError("Couldn't get buffer")
+        }
+
+        for _ in 0..<self.loopCount {
+            // A vector of 100 writes.
+            for _ in 0..<100 {
+                self.backToBack.client.write(buffer, promise: nil)
+            }
+            self.backToBack.client.flush()
+
+            try self.backToBack.interactInMemory()
+
+            // Pull any data out of the server to avoid ballooning in memory.
+            while let _ = try self.backToBack.server.readInbound(as: ByteBuffer.self) { }
+        }
+
+        return self.loopCount
+    }
+}

--- a/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOSSL
+
+final class BenchRepeatedHandshakes: Benchmark {
+    let clientContext: NIOSSLContext
+    let serverContext: NIOSSLContext
+    let dummyAddress: SocketAddress
+    let loopCount: Int
+
+    init(loopCount: Int) throws {
+        self.loopCount = loopCount
+        self.serverContext = try NIOSSLContext(configuration: .forServer(certificateChain: [.certificate(.forTesting())], privateKey: .privateKey(.forTesting())))
+        self.clientContext = try NIOSSLContext(configuration: .forClient(trustRoots: .certificates([.forTesting()])))
+        self.dummyAddress = try SocketAddress(ipAddress: "1.2.3.4", port: 5678)
+    }
+
+    func setUp() { }
+
+    func tearDown() { }
+
+    func run() throws -> Int {
+        for _ in 0..<self.loopCount {
+            let backToBack = BackToBackEmbeddedChannel()
+            let serverHandler = try NIOSSLServerHandler(context: self.serverContext)
+            let clientHandler = try NIOSSLClientHandler(context: self.clientContext, serverHostname: "localhost")
+            try backToBack.client.pipeline.addHandler(clientHandler).wait()
+            try backToBack.server.pipeline.addHandler(serverHandler).wait()
+
+            // To trigger activation of both channels we use connect().
+            try backToBack.client.connect(to: self.dummyAddress).wait()
+            try backToBack.server.connect(to: self.dummyAddress).wait()
+
+            try backToBack.interactInMemory()
+
+            // Ok, now do shutdown.
+            backToBack.client.close(promise: nil)
+            try backToBack.interactInMemory()
+            try backToBack.client.closeFuture.wait()
+            try backToBack.server.closeFuture.wait()
+         }
+
+        return self.loopCount
+    }
+}

--- a/Sources/NIOSSLPerformanceTester/Benchmark.swift
+++ b/Sources/NIOSSLPerformanceTester/Benchmark.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+protocol Benchmark: class {
+    func setUp() throws
+    func tearDown()
+    func run() throws -> Int
+}
+
+func measureAndPrint<B: Benchmark>(desc: String, benchmark bench: B) throws {
+    try bench.setUp()
+    defer {
+        bench.tearDown()
+    }
+    try measureAndPrint(desc: desc) {
+        return try bench.run()
+    }
+}

--- a/Sources/NIOSSLPerformanceTester/main.swift
+++ b/Sources/NIOSSLPerformanceTester/main.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import NIOSSL
+import Foundation
+import Dispatch
+
+// MARK: Test Harness
+
+var warning: String = ""
+assert({
+    print("======================================================")
+    print("= YOU ARE RUNNING NIOPerformanceTester IN DEBUG MODE =")
+    print("======================================================")
+    warning = " <<< DEBUG MODE >>>"
+    return true
+}())
+
+public func measure(_ fn: () throws -> Int) rethrows -> [TimeInterval] {
+    func measureOne(_ fn: () throws -> Int) rethrows -> TimeInterval {
+        let start = Date()
+        _ = try fn()
+        let end = Date()
+        return end.timeIntervalSince(start)
+    }
+
+    _ = try measureOne(fn) /* pre-heat and throw away */
+    var measurements = Array(repeating: 0.0, count: 10)
+    for i in 0..<10 {
+        measurements[i] = try measureOne(fn)
+    }
+
+    return measurements
+}
+
+let limitSet = CommandLine.arguments.dropFirst()
+
+public func measureAndPrint(desc: String, fn: () throws -> Int) rethrows -> Void {
+    if limitSet.count == 0 || limitSet.contains(desc) {
+        print("measuring\(warning): \(desc): ", terminator: "")
+        let measurements = try measure(fn)
+        print(measurements.reduce("") { $0 + "\($1), " })
+    } else {
+        print("skipping '\(desc)', limit set = \(limitSet)")
+    }
+}
+
+// MARK: Utilities
+
+try measureAndPrint(desc: "repeated_handshakes", benchmark: try BenchRepeatedHandshakes(loopCount: 1000))
+try measureAndPrint(desc: "many_writes_512b", benchmark: try BenchManyWrites(loopCount: 2000, writeSizeInBytes: 512))

--- a/Sources/NIOSSLPerformanceTester/shared.swift
+++ b/Sources/NIOSSLPerformanceTester/shared.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import NIO
+import NIOSSL
+
+class BackToBackEmbeddedChannel {
+    private(set) var client: EmbeddedChannel
+    private(set) var server: EmbeddedChannel
+    private var loop: EmbeddedEventLoop
+
+
+    init() {
+        self.loop = EmbeddedEventLoop()
+        self.client = EmbeddedChannel(loop: self.loop)
+        self.server = EmbeddedChannel(loop: self.loop)
+    }
+
+    func run() {
+        self.loop.run()
+    }
+
+    func interactInMemory() throws {
+        var workToDo = true
+
+        while workToDo {
+            workToDo = false
+
+            self.loop.run()
+            let clientDatum = try self.client.readOutbound(as: IOData.self)
+            let serverDatum = try self.server.readOutbound(as: IOData.self)
+
+            if let clientMsg = clientDatum {
+                try self.server.writeInbound(clientMsg)
+                workToDo = true
+            }
+
+            if let serverMsg = serverDatum {
+                try self.client.writeInbound(serverMsg)
+                workToDo = true
+            }
+        }
+    }
+}
+
+
+extension NIOSSLCertificate {
+    static func forTesting() throws -> NIOSSLCertificate {
+        return try .init(bytes: certificatePemBytes, format: .pem)
+    }
+}
+
+
+extension NIOSSLPrivateKey {
+    static func forTesting() throws -> NIOSSLPrivateKey {
+        return try .init(bytes: keyPemBytes, format: .pem)
+    }
+}
+
+
+fileprivate let certificatePemBytes = Array("""
+-----BEGIN CERTIFICATE-----
+MIIBTzCB9qADAgECAhQkvv72Je/v+B/cgJ53f84O82z6WTAKBggqhkjOPQQDAjAU
+MRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMTkxMTI3MTAxMjMwWhcNMjkxMTI0MTAx
+MjMwWjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjOPQMB
+BwNCAAShtZ9TRt7I+7Y0o99XUkrgSYmUmpr4K8CB0IkTCX6b1tXp3Xqs1V5BckTd
+qrls+zsm3AfeiNBb9EDdxiX9DdzuoyYwJDAUBgNVHREEDTALgglsb2NhbGhvc3Qw
+DAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAgNIADBFAiAKxYON+YTnIHNR0R6SLP8R
+R7hjsjV5NDs18XLoeRnA1gIhANwyggmE6NQW/r9l59fexj/ZrjaS3jYOTNCfC1Lo
+5NgJ
+-----END CERTIFICATE-----
+""".utf8)
+
+
+fileprivate let keyPemBytes = Array("""
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCn182hBmYVMAiNPO
++7w05F40SlAqqxgBEYJZOeK47aihRANCAAShtZ9TRt7I+7Y0o99XUkrgSYmUmpr4
+K8CB0IkTCX6b1tXp3Xqs1V5BckTdqrls+zsm3AfeiNBb9EDdxiX9Ddzu
+-----END PRIVATE KEY-----
+""".utf8)


### PR DESCRIPTION
Motivation:

When working with performance its useful to know what your approximate
throughput is. One of the ways we find this out in NIO is to add
benchmarks that let you know what the approximate runtime of a simple
sample program is. NIOSSL doesn't have any of these: it should.

Modifications:

Bring across the benchmark framework from other NIO projects.
Add two benchmarks mirroring the proposed allocation counter tests.

Result:

Insight into performance.