### PR TITLE
Add regression limits for allocation tests.

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -19,6 +19,8 @@ services:
     image: swift-nio-ssl:16.04-5.1
     environment:
       - SANITIZER_ARG=--sanitize=thread
+      - MAX_ALLOCS_ALLOWED_simple_handshake=740000
+      - MAX_ALLOCS_ALLOWED_many_writes=201000
 
   performance-test:
     image: swift-nio-ssl:16.04-5.1

--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -17,6 +17,9 @@ services:
 
   test:
     image: swift-nio-ssl:18.04-5.0
+    environment:
+      - MAX_ALLOCS_ALLOWED_simple_handshake=743000
+      - MAX_ALLOCS_ALLOWED_many_writes=201000
 
   performance-test:
     image: swift-nio-ssl:18.04-5.0


### PR DESCRIPTION
Motivation:

We missed these out, which means we failed to detect the massive
allocation win in #159.

Modifications:

Correctly add allocation limits.

Result:

We'll know if we regress.