### PR TITLE
test lots of closes

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -52,6 +52,7 @@ extension NIOSSLIntegrationTest {
                 ("testPendingWritesFailWhenFlushedOnClose", testPendingWritesFailWhenFlushedOnClose),
                 ("testChannelInactiveAfterCloseNotify", testChannelInactiveAfterCloseNotify),
                 ("testKeyLoggingClientAndServer", testKeyLoggingClientAndServer),
+                ("testLoadsOfCloses", testLoadsOfCloses),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

A large number of closes in quick succession is a place where races
aren't entirely unlikely as the SSL handler, the Channel, and the
ChannelPipeline are all moving targets.

Modification:

Add a quick test doing 20 closes in one run.

Result:

More test coverage.