### PR TITLE
tests: remove unused varible

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -577,7 +577,6 @@ class NIOSSLIntegrationTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let recorderHandler = EventRecorderHandler<TLSUserEvent>()
         let serverChannel = try serverTLSChannel(context: context, handlers: [SimpleEchoServer()], group: group)
         defer {
             XCTAssertNoThrow(try serverChannel.close().wait())
@@ -624,7 +623,6 @@ class NIOSSLIntegrationTest: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        let recorderHandler = EventRecorderHandler<TLSUserEvent>()
         let serverChannel = try serverTLSChannel(context: context, handlers: [SimpleEchoServer()], group: group)
         defer {
             XCTAssertNoThrow(try serverChannel.close().wait())


### PR DESCRIPTION
Motivation:

Warnings are bad and newer Swift compilers find more stuff.

Modification:

Remove unused variable.

Result:

Fewer warnings.