### PR TITLE
Better errors when we fail hostname verification

### DIFF
--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -182,7 +182,7 @@ internal final class SSLConnection {
         guard try validIdentityForService(serverHostname: self.expectedHostname,
                                           socketAddress: address,
                                           leafCertificate: peerCert) else {
-            throw NIOSSLError.unableToValidateCertificate
+            throw NIOSSLExtraError.failedToValidateHostname(expectedName: self.expectedHostname ?? "<none>")
         }
     }
 


### PR DESCRIPTION
Motivation:

We've noticed that the errors you get when hostname verification fail
are a bit gross, and don't tell you much. Users deserve to know more.

Modifications:

- Added a new extensible error type.
- Threw the new error with more diagnostics after verification failed.
- Removed a weird holdover from the old days of Swift.

Result:

Better error messages.