### PR TITLE
Add hashability to Certificate and PrivateKey

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -112,6 +112,14 @@ h33H/Kz4yji7jPN6Uk9wMyG7XGqpjYAuKCd6V3HEHUiGJZzho/VBgb3TVnw=
 -----END RSA PRIVATE KEY-----
 """
 
+let sampleECPemKey = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMJZj2Qw9NGv83izxbgRr5xRvb0RHymOfl5hDJ/RPI2GoAoGCCqGSM49
+AwEHoUQDQgAEc5zHoemKB93GfO9MA/vLYEiYMtV3UWDIV88M/TP59R0dKIuPS2Dw
+EeAoz1vgyHNpgE73eYX8NII6U11Xv8Lmgg==
+-----END EC PRIVATE KEY-----
+"""
+
 let samplePemRSAEncryptedKey = """
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
@@ -209,6 +217,7 @@ let sampleDerCertSPKI = Array(Data(base64Encoded: """
 let samplePemCerts = "\(samplePemCert)\n\(samplePemCert)"
 let sampleDerCert = pemToDer(samplePemCert)
 let sampleDerKey = pemToDer(samplePemKey)
+let sampleECDerKey = pemToDer(sampleECPemKey)
 // No DER version of the private key becuase encrypted DERs aren't real.
 
 func pemToDer(_ pem: String) -> Data {

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -158,7 +158,9 @@ class SSLCertificateTest: XCTestCase {
         let cert2 = try NIOSSLCertificate(file: SSLCertificateTest.pemCertFilePath, format: .pem)
 
         XCTAssertEqual(cert1, cert2)
+        XCTAssertEqual(cert1.hashValue, cert2.hashValue)
         XCTAssertNotEqual(cert1, SSLCertificateTest.dynamicallyGeneratedCert)
+        XCTAssertNotEqual(cert1.hashValue, SSLCertificateTest.dynamicallyGeneratedCert.hashValue)
     }
 
     func testLoadingDerCertFromFile() throws {
@@ -166,7 +168,9 @@ class SSLCertificateTest: XCTestCase {
         let cert2 = try NIOSSLCertificate(file: SSLCertificateTest.derCertFilePath, format: .der)
 
         XCTAssertEqual(cert1, cert2)
+        XCTAssertEqual(cert1.hashValue, cert2.hashValue)
         XCTAssertNotEqual(cert1, SSLCertificateTest.dynamicallyGeneratedCert)
+        XCTAssertNotEqual(cert1.hashValue, SSLCertificateTest.dynamicallyGeneratedCert.hashValue)
     }
 
     func testDerAndPemAreIdentical() throws {
@@ -174,6 +178,7 @@ class SSLCertificateTest: XCTestCase {
         let cert2 = try NIOSSLCertificate(file: SSLCertificateTest.derCertFilePath, format: .der)
 
         XCTAssertEqual(cert1, cert2)
+        XCTAssertEqual(cert1.hashValue, cert2.hashValue)
     }
 
     func testLoadingPemCertFromMemory() throws {
@@ -181,6 +186,7 @@ class SSLCertificateTest: XCTestCase {
         let cert2 = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(cert1, cert2)
+        XCTAssertEqual(cert1.hashValue, cert2.hashValue)
     }
 
     func testPemLoadingMechanismsAreIdentical() throws {
@@ -188,6 +194,7 @@ class SSLCertificateTest: XCTestCase {
         let cert12 = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
 
         XCTAssertEqual(cert11, [cert12])
+        XCTAssertEqual(cert11.map { $0.hashValue }, [cert12.hashValue])
     }
 
     func testLoadingPemCertsFromMemory() throws {
@@ -196,6 +203,7 @@ class SSLCertificateTest: XCTestCase {
 
         XCTAssertEqual(certs1.count, 2)
         XCTAssertEqual(certs1, certs2)
+        XCTAssertEqual(certs1.map { $0.hashValue }, certs2.map { $0.hashValue })
     }
 
     func testLoadingPemCertsFromFile() throws {
@@ -204,6 +212,7 @@ class SSLCertificateTest: XCTestCase {
 
         XCTAssertEqual(certs1.count, 2)
         XCTAssertEqual(certs1, certs2)
+        XCTAssertEqual(certs1.map { $0.hashValue }, certs2.map { $0.hashValue })
     }
 
     func testLoadingDerCertFromMemory() throws {
@@ -212,6 +221,7 @@ class SSLCertificateTest: XCTestCase {
         let cert2 = try NIOSSLCertificate(bytes: certBytes, format: .der)
 
         XCTAssertEqual(cert1, cert2)
+        XCTAssertEqual(cert1.hashValue, cert2.hashValue)
     }
 
     func testLoadingGibberishFromMemoryAsPemFails() throws {

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests+XCTest.swift
@@ -51,6 +51,8 @@ extension SSLPrivateKeyTest {
                 ("testThrowingPassphraseCallback", testThrowingPassphraseCallback),
                 ("testWrongPassword", testWrongPassword),
                 ("testMissingPassword", testMissingPassword),
+                ("testECKeysWorkProperly", testECKeysWorkProperly),
+                ("testECKeysArentEqualToRSAKeys", testECKeysArentEqualToRSAKeys),
            ]
    }
 }

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
@@ -64,7 +64,9 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(file: SSLPrivateKeyTest.derKeyFilePath, format: .der)
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
         XCTAssertNotEqual(key1, SSLPrivateKeyTest.dynamicallyGeneratedKey)
+        XCTAssertNotEqual(key1.hashValue, SSLPrivateKeyTest.dynamicallyGeneratedKey.hashValue)
     }
 
     func testDerAndPemAreIdentical() throws {
@@ -72,6 +74,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(file: SSLPrivateKeyTest.derKeyFilePath, format: .der)
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingPemKeyFromMemory() throws {
@@ -79,6 +82,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingDerKeyFromMemory() throws {
@@ -87,6 +91,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(bytes: keyBytes, format: .der)
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingGibberishFromMemoryAsPemFails() throws {
@@ -192,6 +197,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(bytes: .init(samplePemRSAEncryptedKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingEncryptedRSAPKCS8KeyFromMemory() throws {
@@ -199,6 +205,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(bytes: .init(samplePKCS8PemPrivateKey.utf8), format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingEncryptedRSAKeyFromFile() throws {
@@ -206,6 +213,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(file: SSLPrivateKeyTest.passwordPemKeyFilePath, format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testLoadingEncryptedRSAPKCS8KeyFromFile() throws {
@@ -213,6 +221,7 @@ class SSLPrivateKeyTest: XCTestCase {
         let key2 = try NIOSSLPrivateKey(file: SSLPrivateKeyTest.passwordPKCS8PemKeyFilePath, format: .pem) { closure in closure("thisisagreatpassword".utf8) }
 
         XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
     }
 
     func testWildlyOverlongPassphraseRSAFromMemory() throws {
@@ -291,5 +300,24 @@ class SSLPrivateKeyTest: XCTestCase {
         XCTAssertThrowsError(try NIOSSLContext(configuration: configuration)) { error in
             XCTAssertEqual(.failedToLoadPrivateKey, error as? NIOSSLError)
         }
+    }
+
+    func testECKeysWorkProperly() throws {
+        let keyDerBytes = [UInt8](sampleECDerKey)
+        let keyPemBytes = [UInt8](sampleECPemKey.utf8)
+
+        let key1 = try assertNoThrowWithValue(NIOSSLPrivateKey(bytes: keyDerBytes, format: .der))
+        let key2 = try assertNoThrowWithValue(NIOSSLPrivateKey(bytes: keyPemBytes, format: .pem))
+
+        XCTAssertEqual(key1, key2)
+        XCTAssertEqual(key1.hashValue, key2.hashValue)
+    }
+
+    func testECKeysArentEqualToRSAKeys() throws {
+        let key1 = try NIOSSLPrivateKey(bytes: .init(samplePemKey.utf8), format: .pem)
+        let key2 = try NIOSSLPrivateKey(bytes: .init(sampleECPemKey.utf8), format: .pem)
+
+        XCTAssertNotEqual(key1, key2)
+        XCTAssertNotEqual(key1.hashValue, key2.hashValue)
     }
 }


### PR DESCRIPTION
Motivation:

When types are equatable its important to ask why they aren't hashable.
In the case of SSLCertificate and SSLPrivateKey there isn't any
particuarly good reason other than that their hashing implementations
are a bit fussy. We should support it, even if they're tricky.

Modifications:

Added Hashability to NIOSSLCertificate and NIOSSLPrivateKey.
Fixed NIOSSLPrivateKey equatable implementation.

Result:

Hashable keys and certs.