### PR TITLE
Allow testing deprecated functions.

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -25,17 +25,28 @@ import XCTest
 #if os(Linux) || os(FreeBSD)
    @testable import NIOSSLTests
 
-   XCTMain([
-         testCase(ByteBufferBIOTest.allTests),
-         testCase(CertificateVerificationTests.allTests),
-         testCase(ClientSNITests.allTests),
-         testCase(IdentityVerificationTest.allTests),
-         testCase(NIOSSLALPNTest.allTests),
-         testCase(NIOSSLIntegrationTest.allTests),
-         testCase(SSLCertificateTest.allTests),
-         testCase(SSLPKCS12BundleTest.allTests),
-         testCase(SSLPrivateKeyTest.allTests),
-         testCase(TLSConfigurationTest.allTests),
-         testCase(UnwrappingTests.allTests),
-    ])
+// This protocol is necessary to we can call the 'run' method (on an existential of this protocol)
+// without the compiler noticing that we're calling a deprecated function.
+// This hack exists so we can deprecate individual tests which test deprecated functionality without
+// getting a compiler warning...
+protocol LinuxMainRunner { func run() }
+class LinuxMainRunnerImpl: LinuxMainRunner {
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
+   func run() {
+       XCTMain([
+             testCase(ByteBufferBIOTest.allTests),
+             testCase(CertificateVerificationTests.allTests),
+             testCase(ClientSNITests.allTests),
+             testCase(IdentityVerificationTest.allTests),
+             testCase(NIOSSLALPNTest.allTests),
+             testCase(NIOSSLIntegrationTest.allTests),
+             testCase(SSLCertificateTest.allTests),
+             testCase(SSLPKCS12BundleTest.allTests),
+             testCase(SSLPrivateKeyTest.allTests),
+             testCase(TLSConfigurationTest.allTests),
+             testCase(UnwrappingTests.allTests),
+        ])
+    }
+}
+(LinuxMainRunnerImpl() as LinuxMainRunner).run()
 #endif

--- a/Tests/NIOSSLTests/ByteBufferBIOTest+XCTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ByteBufferBIOTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ByteBufferBIOTest) -> () throws -> Void)] {
       return [
                 ("testExtractingBIOWrite", testExtractingBIOWrite),

--- a/Tests/NIOSSLTests/CertificateVerificationTests+XCTest.swift
+++ b/Tests/NIOSSLTests/CertificateVerificationTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension CertificateVerificationTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (CertificateVerificationTests) -> () throws -> Void)] {
       return [
                 ("testCanFindCAFileOnLinux", testCanFindCAFileOnLinux),

--- a/Tests/NIOSSLTests/ClientSNITests+XCTest.swift
+++ b/Tests/NIOSSLTests/ClientSNITests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension ClientSNITests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (ClientSNITests) -> () throws -> Void)] {
       return [
                 ("testSNIIsTransmitted", testSNIIsTransmitted),

--- a/Tests/NIOSSLTests/IdentityVerificationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension IdentityVerificationTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (IdentityVerificationTest) -> () throws -> Void)] {
       return [
                 ("testCanValidateHostnameInFirstSan", testCanValidateHostnameInFirstSan),

--- a/Tests/NIOSSLTests/NIOSSLALPNTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension NIOSSLALPNTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (NIOSSLALPNTest) -> () throws -> Void)] {
       return [
                 ("testBasicALPNNegotiation", testBasicALPNNegotiation),

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension NIOSSLIntegrationTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (NIOSSLIntegrationTest) -> () throws -> Void)] {
       return [
                 ("testSimpleEcho", testSimpleEcho),

--- a/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension SSLCertificateTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (SSLCertificateTest) -> () throws -> Void)] {
       return [
                 ("testLoadingPemCertFromFile", testLoadingPemCertFromFile),

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension SSLPKCS12BundleTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (SSLPKCS12BundleTest) -> () throws -> Void)] {
       return [
                 ("testDecodingSimpleP12FromMemory", testDecodingSimpleP12FromMemory),

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension SSLPrivateKeyTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (SSLPrivateKeyTest) -> () throws -> Void)] {
       return [
                 ("testLoadingPemKeyFromFile", testLoadingPemKeyFromFile),

--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension TLSConfigurationTest {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (TLSConfigurationTest) -> () throws -> Void)] {
       return [
                 ("testNonOverlappingTLSVersions", testNonOverlappingTLSVersions),

--- a/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
@@ -24,6 +24,7 @@ import XCTest
 
 extension UnwrappingTests {
 
+   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")
    static var allTests : [(String, (UnwrappingTests) -> () throws -> Void)] {
       return [
                 ("testSimpleUnwrapping", testSimpleUnwrapping),

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -74,6 +74,7 @@ def createExtensionFile(fileName, classes)
 
          for classArray in classes
              file.write "extension " + classArray[0] + " {\n\n"
+             file.write '   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")' +"\n"
              file.write "   static var allTests : [(String, (" + classArray[0] + ") -> () throws -> Void)] {\n"
              file.write "      return [\n"
 
@@ -92,31 +93,41 @@ def createLinuxMain(testsDirectory, allTestSubDirectories, files)
     fileName = testsDirectory + "/LinuxMain.swift"
     print "Creating file: " + fileName + "\n"
 
-    File.open(fileName, 'w') { |file|
+    File.open(fileName, 'w') do |file|
+      file.write header(fileName)
+      file.write "\n"
 
-        file.write header(fileName)
-        file.write "\n"
+      file.write "#if os(Linux) || os(FreeBSD)\n"
+      for testSubDirectory in allTestSubDirectories.sort { |x, y| x <=> y }
+        file.write '   @testable import ' + testSubDirectory + "\n"
+      end
+      file.write "\n"
+      file.write "// This protocol is necessary to we can call the 'run' method (on an existential of this protocol)\n"
+      file.write "// without the compiler noticing that we're calling a deprecated function.\n"
+      file.write "// This hack exists so we can deprecate individual tests which test deprecated functionality without\n"
+      file.write "// getting a compiler warning...\n"
+      file.write "protocol LinuxMainRunner { func run() }\n"
+      file.write "class LinuxMainRunnerImpl: LinuxMainRunner {\n"
+      file.write '   @available(*, deprecated, message: "not actually deprecated. Just deprecated to allow deprecated tests (which test deprecated functionality) without warnings")' + "\n"
+      file.write "   func run() {\n"
+      file.write "       XCTMain([\n"
 
-        file.write "#if os(Linux) || os(FreeBSD)\n"
-        for testSubDirectory in allTestSubDirectories.sort { |x,y| x <=> y }
-            file.write "   @testable import " + testSubDirectory + "\n"
+      testCases = []
+      for classes in files
+        for classArray in classes
+          testCases << classArray[0]
         end
-        file.write "\n"
-        file.write "   XCTMain([\n"
+      end
 
-        testCases = []
-        for classes in files
-            for classArray in classes
-                testCases << classArray[0]
-            end
-        end
-
-        for testCase in testCases.sort { |x,y| x <=> y }
-            file.write "         testCase(" + testCase + ".allTests),\n"
-        end
-        file.write"    ])\n"
-        file.write "#endif"
-    }
+      for testCase in testCases.sort { |x, y| x <=> y }
+        file.write '             testCase(' + testCase + ".allTests),\n"
+      end
+      file.write "        ])\n"
+      file.write "    }\n"
+      file.write "}\n"
+      file.write "(LinuxMainRunnerImpl() as LinuxMainRunner).run()\n"
+      file.write "#endif\n"
+    end
 end
 
 def parseSourceFile(fileName)


### PR DESCRIPTION
Motivation:

If we want to deprecate anything, we either have to remove the tests or
enable testing deprecated functionality without warnings. Conveniently,
@weissi has already written a patch that enables this for swift-nio in
apple/swift-nio@c2c7250, so we can just port that across.

Modifications:

Port Johannes' patch and run it.

Result:

We can test deprecated code.