### PR TITLE
Add API for dumping certificate bytes.

### DIFF
--- a/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
@@ -52,6 +52,8 @@ extension SSLCertificateTest {
                 ("testNoCommonName", testNoCommonName),
                 ("testUnicodeCommonName", testUnicodeCommonName),
                 ("testExtractingPublicKey", testExtractingPublicKey),
+                ("testDumpingPEMCert", testDumpingPEMCert),
+                ("testDumpingDERCert", testDumpingDERCert),
            ]
    }
 }

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -386,4 +386,20 @@ class SSLCertificateTest: XCTestCase {
 
         XCTAssertEqual(spkiBytes, sampleDerCertSPKI)
     }
+
+    func testDumpingPEMCert() throws {
+        let expectedCertBytes = [UInt8](sampleDerCert)
+        let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem))
+        let certBytes = try assertNoThrowWithValue(cert.toDERBytes())
+
+        XCTAssertEqual(certBytes, expectedCertBytes)
+    }
+
+    func testDumpingDERCert() throws {
+        let expectedCertBytes = [UInt8](sampleDerCert)
+        let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: expectedCertBytes, format: .der))
+        let certBytes = try assertNoThrowWithValue(cert.toDERBytes())
+
+        XCTAssertEqual(certBytes, expectedCertBytes)
+    }
 }


### PR DESCRIPTION
Motivation:

In some cases it's useful to be able to ask questions about what the
certificate looks like. We don't have a full X509 API, so the best way
to handle this for now is to allow users to extract the bytes of the
certificate so they can use other libraries to do the job.

Modifications:

- Added a function for dumping certificate bytes.

Result:

Users can have the certificate bytes.