### PR TITLE
Avoid curried thunks (workaround SR-12115)

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -167,7 +167,7 @@ public final class NIOSSLContext {
         // If we were given a certificate chain to use, load it and its associated private key. Before
         // we do, set up a passphrase callback if we need to.
         if let callbackManager = callbackManager {
-            CNIOBoringSSL_SSL_CTX_set_default_passwd_cb(context, globalBoringSSLPassphraseCallback(buf:size:rwflag:u:))
+            CNIOBoringSSL_SSL_CTX_set_default_passwd_cb(context, { globalBoringSSLPassphraseCallback(buf: $0, size: $1, rwflag: $2, u: $3) })
             CNIOBoringSSL_SSL_CTX_set_default_passwd_cb_userdata(context, Unmanaged.passUnretained(callbackManager as AnyObject).toOpaque())
         }
 
@@ -253,7 +253,7 @@ public final class NIOSSLContext {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         switch self.configuration.trustRoots {
         case .some(.default), .none:
-            conn.setCustomVerificationCallback(CustomVerifyManager(callback: conn.performSecurityFrameworkValidation(promise:)))
+            conn.setCustomVerificationCallback(CustomVerifyManager(callback: { conn.performSecurityFrameworkValidation(promise: $0) }))
         case .some(.certificates), .some(.file):
             break
         }
@@ -451,7 +451,7 @@ extension Optional where Wrapped == String {
     internal func withCString<Result>(_ body: (UnsafePointer<CChar>?) throws -> Result) rethrows -> Result {
         switch self {
         case .some(let s):
-            return try s.withCString(body)
+            return try s.withCString({ try body($0 ) })
         case .none:
             return try body(nil)
         }

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -209,7 +209,7 @@ extension Collection where Element == UInt8 {
 internal extension Optional where Wrapped: Collection, Wrapped.Element == UInt8 {
     func withSecureCString<T>(_ block: (UnsafePointer<Int8>?) throws -> T) throws -> T {
         if let `self` = self {
-            return try self.withSecureCString(block)
+            return try self.withSecureCString({ try block($0) })
         } else {
             return try block(nil)
         }

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -147,7 +147,7 @@ public class NIOSSLPrivateKey {
                 // This annoying conditional binding is used to work around the fact that I cannot pass
                 // a variable to a function pointer argument.
                 if let callbackManager = callbackManager {
-                    return CNIOBoringSSL_PEM_read_PrivateKey(fileObject, nil, globalBoringSSLPassphraseCallback(buf:size:rwflag:u:), Unmanaged.passUnretained(callbackManager as AnyObject).toOpaque())
+                    return CNIOBoringSSL_PEM_read_PrivateKey(fileObject, nil, { globalBoringSSLPassphraseCallback(buf: $0, size: $1, rwflag: $2, u: $3) }, Unmanaged.passUnretained(callbackManager as AnyObject).toOpaque())
                 } else {
                     return CNIOBoringSSL_PEM_read_PrivateKey(fileObject, nil, nil, nil)
                 }
@@ -177,7 +177,7 @@ public class NIOSSLPrivateKey {
                     if let callbackManager = callbackManager {
                         // This annoying conditional binding is used to work around the fact that I cannot pass
                         // a variable to a function pointer argument.
-                        return CNIOBoringSSL_PEM_read_bio_PrivateKey(bio, nil, globalBoringSSLPassphraseCallback(buf:size:rwflag:u:), Unmanaged.passUnretained(callbackManager as AnyObject).toOpaque())
+                        return CNIOBoringSSL_PEM_read_bio_PrivateKey(bio, nil, { globalBoringSSLPassphraseCallback(buf: $0, size: $1, rwflag: $2, u: $3) }, Unmanaged.passUnretained(callbackManager as AnyObject).toOpaque())
                     } else {
                         return CNIOBoringSSL_PEM_read_bio_PrivateKey(bio, nil, nil, nil)
                     }


### PR DESCRIPTION
Calling `function(otherFunction)` allocates, but
`function({ otherFunction($0) }` does not.

See: SR-12115 and SR-12116.

Modifications:

Avoid passing functions directly; pass them in new closures instead.

Result:

Fewer allocations.