### PR TITLE
tell github that Sources/CNIOBoringSSL is vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Sources/CNIOBoringSSL/* linguist-vendored


### PR DESCRIPTION
Motivation:

Telling Github what's vendored makes all stats better.

Modifications:

Tell github that Sources/CNIOBoringSSL is vendored.

Result:

Better stats.