### PR TITLE
Swapped applicationProtocols check for encodedApplicationProtocols.

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -196,7 +196,7 @@ public final class NIOSSLContext {
             }
         }
 
-        if configuration.applicationProtocols.count > 0 {
+        if configuration.encodedApplicationProtocols.count > 0 {
             try NIOSSLContext.setAlpnProtocols(configuration.encodedApplicationProtocols, context: context)
             NIOSSLContext.setAlpnCallback(context: context)
         }

--- a/Sources/NIOSSLHTTP1Client/README.md
+++ b/Sources/NIOSSLHTTP1Client/README.md
@@ -1,10 +1,10 @@
-NIOHTTP1Client
+NIOSSLHTTP1Client
 ---
 
-This sample application provides a http client. Invoke it using one of the following syntaxes.
+This sample application provides a https client. Invoke it using one of the following syntaxes.
 
 ```bash
-swift run NIOHTTP1Client # Gets a content on a server on ::1, port 4433, using SSL/TLS
-swift run NIOHTTP1Client "https://example.com" # Gets a content on a server on example.com, port 443, using SSL/TLS 
-swift run NIOHTTP1Client "https://example.com:4433" # Gets a content on a server on example.com, port 4433, using SSL/TLS
+swift run NIOSSLHTTP1Client # Gets a content on a server on ::1, port 4433, using SSL/TLS
+swift run NIOSSLHTTP1Client "https://example.com" # Gets a content on a server on example.com, port 443, using SSL/TLS 
+swift run NIOSSLHTTP1Client "https://example.com:4433" # Gets a content on a server on example.com, port 4433, using SSL/TLS
 ```

--- a/Sources/NIOTLSServer/README.md
+++ b/Sources/NIOTLSServer/README.md
@@ -1,0 +1,9 @@
+# NIOTLSServer
+---
+
+This sample application provides a TLS server. Invoke it with the following syntax.
+
+```bash
+swift run NIOTLSServer # Gets a content on a server on ::1, port 4433, using TLS
+
+```


### PR DESCRIPTION
Motivation:

Resolution on issue-151.
Adding a README for NIOTLSServer.

Modifications:

Swapped applicationProtocols check with encodedApplicationProtocols.
Added a README for NIOTLSServer.
Altered the README for NIOSSLHTTP1Client.

Result:

Updated documentation and swapped ALPN checks during SSLContext
initialization.