### PR TITLE
Replace NIOSSLError.unableToAllocateBoringSSLObject with fatalError

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -38,7 +38,7 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
     @available(*, deprecated, renamed: "init(context:serverHostname:customVerificationCallback:)")
     public init(context: NIOSSLContext, serverHostname: String?, verificationCallback: NIOSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to create new connection in NIOSSLContext")
         }
 
         connection.setConnectState()
@@ -66,7 +66,7 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
     // This exists to handle the explosion of initializers we got when I tried to deprecate the first one. At least they all pass through one path now.
     private init(context: NIOSSLContext, serverHostname: String?, optionalCustomVerificationCallback: NIOSSLCustomVerificationCallback?) throws {
         guard let connection = context.createConnection() else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to create new connection in NIOSSLContext")
         }
 
         connection.setConnectState()

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -20,7 +20,7 @@ import NIO
 public final class NIOSSLServerHandler: NIOSSLHandler {
     public init(context: NIOSSLContext, verificationCallback: NIOSSLVerificationCallback? = nil) throws {
         guard let connection = context.createConnection() else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to create new connection in NIOSSLContext")
         }
 
         connection.setAcceptState()

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -222,7 +222,7 @@ extension NIOSSLCertificate {
     /// - throws: If an error is encountered extracting the key.
     public func extractPublicKey() throws -> NIOSSLPublicKey {
         guard let key = CNIOBoringSSL_X509_get_pubkey(self.ref) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to extract a public key reference")
         }
 
         return NIOSSLPublicKey.fromInternalPointer(takingOwnership: key)
@@ -277,7 +277,7 @@ extension NIOSSLCertificate {
         }
 
         guard let bio = CNIOBoringSSL_BIO_new(CNIOBoringSSL_BIO_s_file()) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to create a BIO handle to read a PEM file")
         }
         defer {
             CNIOBoringSSL_BIO_free(bio)
@@ -321,7 +321,7 @@ extension NIOSSLCertificate {
     /// The pointer provided to the closure is not valid beyond the lifetime of this method call.
     private func withUnsafeDERCertificateBuffer<T>(_ body: (UnsafeRawBufferPointer) throws -> T) throws -> T {
         guard let bio = CNIOBoringSSL_BIO_new(CNIOBoringSSL_BIO_s_mem()) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to malloc for a BIO handler")
         }
 
         defer {
@@ -338,7 +338,7 @@ extension NIOSSLCertificate {
         let length = CNIOBoringSSL_BIO_get_mem_data(bio, &dataPtr)
 
         guard let bytes = dataPtr.map({ UnsafeRawBufferPointer(start: $0, count: length) }) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to map bytes from a certificate")
         }
 
         return try body(bytes)

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -123,7 +123,7 @@ public final class NIOSSLContext {
     /// configuration.
     internal init(configuration: TLSConfiguration, callbackManager: CallbackManagerProtocol?) throws {
         guard boringSSLIsInitialized else { fatalError("Failed to initialize BoringSSL") }
-        guard let context = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_method()) else { throw NIOSSLError.unableToAllocateBoringSSLObject }
+        guard let context = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_method()) else { fatalError("Failed to create new BoringSSL context") }
 
         let minTLSVersion: CInt
         switch configuration.minimumTLSVersion {

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -52,7 +52,7 @@ public typealias NIOBoringSSLErrorStack = [BoringSSLInternalError]
 /// Errors that can be raised by NIO's BoringSSL wrapper.
 public enum NIOSSLError: Error {
     case writeDuringTLSShutdown
-    @available(*, deprecated, message: "unableToAllocateBoringSSLObject is no longer available.")
+    @available(*, deprecated, message: "unableToAllocateBoringSSLObject can no longer be thrown")
     case unableToAllocateBoringSSLObject
     case noSuchFilesystemObject
     case failedToLoadCertificate
@@ -67,28 +67,7 @@ public enum NIOSSLError: Error {
     case uncleanShutdown
 }
 
-extension NIOSSLError: Equatable {
-    public static func ==(lhs: NIOSSLError, rhs: NIOSSLError) -> Bool {
-        switch (lhs, rhs) {
-        case (.writeDuringTLSShutdown, .writeDuringTLSShutdown),
-             (.noSuchFilesystemObject, .noSuchFilesystemObject),
-             (.failedToLoadCertificate, .failedToLoadCertificate),
-             (.failedToLoadPrivateKey, .failedToLoadPrivateKey),
-             (.cannotMatchULabel, .cannotMatchULabel),
-             (.noCertificateToValidate, .noCertificateToValidate),
-             (.unableToValidateCertificate, .unableToValidateCertificate),
-             (.cannotFindPeerIP, .cannotFindPeerIP),
-             (.readInInvalidTLSState, .readInInvalidTLSState),
-             (.uncleanShutdown, .uncleanShutdown):
-            return true
-        case (.handshakeFailed(let err1), .handshakeFailed(let err2)),
-             (.shutdownFailed(let err1), .shutdownFailed(let err2)):
-            return err1 == err2
-        default:
-            return false
-        }
-    }
-}
+extension NIOSSLError: Equatable {}
 
 /// Closing the TLS channel cleanly timed out, so it was closed uncleanly.
 public struct NIOSSLCloseTimedOutError: Error {}

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -52,6 +52,7 @@ public typealias NIOBoringSSLErrorStack = [BoringSSLInternalError]
 /// Errors that can be raised by NIO's BoringSSL wrapper.
 public enum NIOSSLError: Error {
     case writeDuringTLSShutdown
+    @available(*, deprecated, message: "unableToAllocateBoringSSLObject is no longer available.")
     case unableToAllocateBoringSSLObject
     case noSuchFilesystemObject
     case failedToLoadCertificate
@@ -70,7 +71,6 @@ extension NIOSSLError: Equatable {
     public static func ==(lhs: NIOSSLError, rhs: NIOSSLError) -> Bool {
         switch (lhs, rhs) {
         case (.writeDuringTLSShutdown, .writeDuringTLSShutdown),
-             (.unableToAllocateBoringSSLObject, .unableToAllocateBoringSSLObject),
              (.noSuchFilesystemObject, .noSuchFilesystemObject),
              (.failedToLoadCertificate, .failedToLoadCertificate),
              (.failedToLoadPrivateKey, .failedToLoadPrivateKey),

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -60,10 +60,6 @@ public struct NIOSSLPKCS12Bundle {
         // Successfully parsed, let's unpack. The key and cert are mandatory,
         // the ca stack is not.
         guard let actualCert = cert, let actualKey = pkey else {
-            // Free the pointers that we have.
-            cert.map { CNIOBoringSSL_X509_free($0) }
-            pkey.map { CNIOBoringSSL_EVP_PKEY_free($0) }
-            caCerts.map { CNIOBoringSSL_sk_X509_pop_free($0, CNIOBoringSSL_X509_free) }
             fatalError("Failed to obtain cert and pkey from a PKC12 file")
         }
 

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -64,7 +64,7 @@ public struct NIOSSLPKCS12Bundle {
             cert.map { CNIOBoringSSL_X509_free($0) }
             pkey.map { CNIOBoringSSL_EVP_PKEY_free($0) }
             caCerts.map { CNIOBoringSSL_sk_X509_pop_free($0, CNIOBoringSSL_X509_free) }
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to obtain cert and pkey from a PKC12 file")
         }
 
         let certStackSize = caCerts.map { CNIOBoringSSL_sk_X509_num($0) } ?? 0

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -299,7 +299,7 @@ extension NIOSSLPrivateKey {
     /// The pointer provided to the closure is not valid beyond the lifetime of this method call.
     private func withUnsafeDERBuffer<T>(_ body: (UnsafeRawBufferPointer) throws -> T) throws -> T {
         guard let bio = CNIOBoringSSL_BIO_new(CNIOBoringSSL_BIO_s_mem()) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to malloc for a BIO handler")
         }
 
         defer {
@@ -316,7 +316,7 @@ extension NIOSSLPrivateKey {
         let length = CNIOBoringSSL_BIO_get_mem_data(bio, &dataPtr)
 
         guard let bytes = dataPtr.map({ UnsafeRawBufferPointer(start: $0, count: length) }) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to map bytes from a private key")
         }
 
         return try body(bytes)

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -64,7 +64,7 @@ extension NIOSSLPublicKey {
     /// - throws: If an error occurred while serializing the key.
     public func toSPKIBytes() throws -> [UInt8] {
         guard let bio = CNIOBoringSSL_BIO_new(CNIOBoringSSL_BIO_s_mem()) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to malloc for a BIO handler")
         }
 
         defer {
@@ -81,7 +81,7 @@ extension NIOSSLPublicKey {
         let length = CNIOBoringSSL_BIO_get_mem_data(bio, &dataPtr)
 
         guard let bytes = dataPtr.map({ UnsafeMutableRawBufferPointer(start: $0, count: length) }) else {
-            throw NIOSSLError.unableToAllocateBoringSSLObject
+            fatalError("Failed to map bytes from a public key")
         }
 
         return Array(bytes)


### PR DESCRIPTION
Motivation:

Provides a resolution to issue-173.
deprecate & remove throw NIOSSLError.unableToAllocateBoringSSLObject;
replace by crash #173

Modifications:

Removed all NIOSSLError.unableToAllocateBoringSSLObject and replaced
with fatalError to force a crash.

Result:

- In critical points where execution should not continue a fatalError will be thrown instead of an NIOSSLError.unableToAllocateBoringSSLObject.
- fixes #173 