### PR TITLE
Removed explicit Equatable implementations.

### DIFF
--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -205,4 +205,8 @@ extension NIOSSLExtraError: CustomStringConvertible {
     }
 }
 
-extension NIOSSLExtraError: Equatable {}
+extension NIOSSLExtraError: Equatable {
+    public static func ==(lhs: NIOSSLExtraError, rhs: NIOSSLExtraError) -> Bool {
+        return lhs.baseError == rhs.baseError
+    }
+}

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -38,11 +38,6 @@ public struct BoringSSLInternalError: Equatable, CustomStringConvertible {
     init(errorCode: UInt32) {
         self.errorCode = errorCode
     }
-
-    public static func ==(lhs: BoringSSLInternalError, rhs: BoringSSLInternalError) -> Bool {
-        return lhs.errorCode == rhs.errorCode
-    }
-
 }
 
 /// A representation of BoringSSL's internal error stack: a list of BoringSSL errors.
@@ -91,27 +86,6 @@ public enum BoringSSLError: Error {
 
 extension BoringSSLError: Equatable {}
 
-public func ==(lhs: BoringSSLError, rhs: BoringSSLError) -> Bool {
-    switch (lhs, rhs) {
-    case (.noError, .noError),
-         (.zeroReturn, .zeroReturn),
-         (.wantRead, .wantRead),
-         (.wantWrite, .wantWrite),
-         (.wantConnect, .wantConnect),
-         (.wantAccept, .wantAccept),
-         (.wantX509Lookup, .wantX509Lookup),
-         (.wantCertificateVerify, .wantCertificateVerify),
-         (.syscallError, .syscallError):
-        return true
-    case (.sslError(let e1), .sslError(let e2)),
-         (.unknownError(let e1), .unknownError(let e2)),
-         (.invalidSNIName(let e1), .invalidSNIName(let e2)),
-         (.failedToSetALPN(let e1), .failedToSetALPN(let e2)):
-        return e1 == e2
-    default:
-        return false
-    }
-}
 
 internal extension BoringSSLError {
     static func fromSSLGetErrorResult(_ result: CInt) -> BoringSSLError? {
@@ -231,8 +205,4 @@ extension NIOSSLExtraError: CustomStringConvertible {
     }
 }
 
-extension NIOSSLExtraError: Equatable {
-    public static func ==(lhs: NIOSSLExtraError, rhs: NIOSSLExtraError) -> Bool {
-        return lhs.baseError == rhs.baseError
-    }
-}
+extension NIOSSLExtraError: Equatable {}


### PR DESCRIPTION
Motivation:

Finished removing explicit Equatable implementations
on BoringSSLError and NIOSSLExtraError.  Fixes #164 

Modifications:

Removed explicit Equatable implementations.

Result:

Will allow Swift to synthesize equatable conformance for
BoringSSLError and NIOSSLExtraError.