### PR TITLE
Get rid of `do { ... } catch { ... }` for expected errors 

### DIFF
--- a/Tests/NIOSSLTests/ClientSNITests.swift
+++ b/Tests/NIOSSLTests/ClientSNITests.swift
@@ -79,23 +79,17 @@ class ClientSNITests: XCTestCase {
 
     func testSNIIsRejectedForIPv4Addresses() throws {
         let context = try configuredSSLContext()
-
-        do {
-            _ = try NIOSSLClientHandler(context: context, serverHostname: "192.168.0.1")
-            XCTFail("Created client handler with invalid SNI name")
-        } catch let err as NIOSSLExtraError where err == NIOSSLExtraError.cannotUseIPAddressInSNI {
-            // All fine.
+        
+        XCTAssertThrowsError(try NIOSSLClientHandler(context: context, serverHostname: "192.168.0.1")){ error in
+            XCTAssertEqual(.cannotUseIPAddressInSNI, error as? NIOSSLExtraError)
         }
     }
 
     func testSNIIsRejectedForIPv6Addresses() throws {
         let context = try configuredSSLContext()
-
-        do {
-            _ = try NIOSSLClientHandler(context: context, serverHostname: "fe80::200:f8ff:fe21:67cf")
-            XCTFail("Created client handler with invalid SNI name")
-        } catch let err as NIOSSLExtraError where err == NIOSSLExtraError.cannotUseIPAddressInSNI {
-            // All fine.
+        
+        XCTAssertThrowsError(try NIOSSLClientHandler(context: context, serverHostname: "fe80::200:f8ff:fe21:67cf")){ error in
+            XCTAssertEqual(.cannotUseIPAddressInSNI, error as? NIOSSLExtraError)
         }
     }
 }

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -192,18 +192,15 @@ class IdentityVerificationTest: XCTestCase {
 
     func testRejectsEncodedIDNALabel() throws {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
-        do {
-            _ = try validIdentityForService(serverHostname: "straße.unicode.example.com",
-                                            socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                            leafCertificate: cert)
-        } catch {
+
+        XCTAssertThrowsError(try validIdentityForService(serverHostname: "straße.unicode.example.com",
+                           socketAddress: try .init(unixDomainSocketPath: "/path"),
+                           leafCertificate: cert)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname straße.unicode.example.com cannot be matched due to containing non-DNS characters")
-            return
         }
 
-        XCTFail("Did not throw")
     }
 
     func testMatchesUnencodedIDNALabel() throws {
@@ -240,17 +237,14 @@ class IdentityVerificationTest: XCTestCase {
 
     func testRejectsWildcardBeforeUnencodedIDNALabel() throws {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
-        do {
-            _ = try validIdentityForService(serverHostname: "foo.straße.example.com",
-                                            socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                            leafCertificate: cert)
-        } catch {
+
+        XCTAssertThrowsError(try validIdentityForService(serverHostname: "foo.straße.example.com",
+                                socketAddress: try .init(unixDomainSocketPath: "/path"),
+                                leafCertificate: cert)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname foo.straße.example.com cannot be matched due to containing non-DNS characters")
-            return
         }
-        XCTFail("Did not throw")
     }
 
     func testMatchesWildcardBeforeEncodedIDNALabel() throws {
@@ -263,18 +257,14 @@ class IdentityVerificationTest: XCTestCase {
 
     func testDoesNotMatchSANWithEmbeddedNULL() throws {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
-        do {
-            _ = try validIdentityForService(serverHostname: "nul\u{0000}l.example.com",
-                                            socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                            leafCertificate: cert)
-        } catch {
+
+       XCTAssertThrowsError(try validIdentityForService(serverHostname: "nul\u{0000}l.example.com",
+                               socketAddress: try .init(unixDomainSocketPath: "/path"),
+                               leafCertificate: cert)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname nul\u{0000}l.example.com cannot be matched due to containing non-DNS characters")
-            return
         }
-
-        XCTFail("Did not throw")
     }
 
     func testFallsBackToCommonName() throws {
@@ -295,18 +285,14 @@ class IdentityVerificationTest: XCTestCase {
 
     func testRejectsUnicodeCommonNameWithUnencodedIDNALabel() throws {
         let cert = try NIOSSLCertificate(bytes: .init(unicodeCNCert.utf8), format: .pem)
-        do {
-            _ = try validIdentityForService(serverHostname: "straße.org",
-                                            socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                            leafCertificate: cert)
-        } catch {
+
+        XCTAssertThrowsError(try validIdentityForService(serverHostname: "straße.org",
+                                socketAddress: try .init(unixDomainSocketPath: "/path"),
+                                leafCertificate: cert)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname straße.org cannot be matched due to containing non-DNS characters")
-            return
         }
-
-        XCTFail("Did not throw" )
     }
 
     func testRejectsUnicodeCommonNameWithEncodedIDNALabel() throws {

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -611,6 +611,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         for promise in promises {
             // This should never block, but it may throw because the I/O is complete.
+            // Suppress all errors, they're fine.
             _ = try? promise.futureResult.wait()
         }
     }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -611,11 +611,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         for promise in promises {
             // This should never block, but it may throw because the I/O is complete.
-            do {
-                _ = try promise.futureResult.wait()
-            } catch {
-                // Suppress all errors, they're fine.
-            }
+            _ = try? promise.futureResult.wait()
         }
     }
 
@@ -1023,19 +1019,10 @@ class NIOSSLIntegrationTest: XCTestCase {
             serverChannel.pipeline.fireChannelReadComplete()
         }
 
-        do {
-            try serverChannel.throwIfErrorCaught()
-        } catch {
-            XCTFail("Already has error: \(error)")
-        }
-
-        do {
-            try interactInMemory(clientChannel: clientChannel, serverChannel: serverChannel)
-            XCTFail("Did not cause error")
-        } catch NIOSSLError.readInInvalidTLSState {
-            // Nothing to do here.
-        } catch {
-            XCTFail("Encountered unexpected error: \(error)")
+        XCTAssertNoThrow(try serverChannel.throwIfErrorCaught())
+        
+        XCTAssertThrowsError(try interactInMemory(clientChannel: clientChannel, serverChannel: serverChannel)) { error in
+            XCTAssertEqual(.readInInvalidTLSState, error as? NIOSSLError)
         }
     }
     

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -226,34 +226,24 @@ class SSLCertificateTest: XCTestCase {
 
     func testLoadingGibberishFromMemoryAsPemFails() throws {
         let keyBytes: [UInt8] = [1, 2, 3]
-
-        do {
-            _ = try NIOSSLCertificate(bytes: keyBytes, format: .pem)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        
+        XCTAssertThrowsError(try NIOSSLCertificate(bytes: keyBytes, format: .pem)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
     func testLoadingGibberishFromPEMBufferFails() throws {
         let keyBytes: [UInt8] = [1, 2, 3]
-
-        do {
-            _ = try NIOSSLCertificate.fromPEMBytes(keyBytes)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        XCTAssertThrowsError(try NIOSSLCertificate.fromPEMBytes(keyBytes)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
     func testLoadingGibberishFromMemoryAsDerFails() throws {
         let keyBytes: [UInt8] = [1, 2, 3]
 
-        do {
-            _ = try NIOSSLCertificate(bytes: keyBytes, format: .der)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        XCTAssertThrowsError(try NIOSSLCertificate(bytes: keyBytes, format: .der)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
@@ -262,12 +252,9 @@ class SSLCertificateTest: XCTestCase {
         defer {
             _ = tempFile.withCString { unlink($0) }
         }
-
-        do {
-            _ = try NIOSSLCertificate(file: tempFile, format: .pem)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        
+        XCTAssertThrowsError(try NIOSSLCertificate(file: tempFile, format: .pem)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
@@ -277,11 +264,8 @@ class SSLCertificateTest: XCTestCase {
             _ = tempFile.withCString { unlink($0) }
         }
 
-        do {
-            _ = try NIOSSLCertificate.fromPEMFile(tempFile)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        XCTAssertThrowsError(try NIOSSLCertificate.fromPEMFile(tempFile)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
@@ -291,42 +275,26 @@ class SSLCertificateTest: XCTestCase {
             _ = tempFile.withCString { unlink($0) }
         }
 
-        do {
-            _ = try NIOSSLCertificate(file: tempFile, format: .der)
-            XCTFail("Gibberish successfully loaded")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        XCTAssertThrowsError(try NIOSSLCertificate(file: tempFile, format: .der)) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
     func testLoadingNonexistentFileAsPem() throws {
-        do {
-            _ = try NIOSSLCertificate(file: "/nonexistent/path", format: .pem)
-            XCTFail("Did not throw")
-        } catch let error as IOError {
-            XCTAssertEqual(error.errnoCode, ENOENT)
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try NIOSSLCertificate(file: "/nonexistent/path", format: .pem)) {error in
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
         }
     }
 
     func testLoadingNonexistentPEMFile() throws {
-        do {
-            _ = try NIOSSLCertificate.fromPEMFile("/nonexistent/path")
-            XCTFail("Did not throw")
-        } catch NIOSSLError.failedToLoadCertificate {
-            // Do nothing.
+        XCTAssertThrowsError(try NIOSSLCertificate.fromPEMFile("/nonexistent/path")) {error in
+            XCTAssertEqual(.failedToLoadCertificate, error as? NIOSSLError)
         }
     }
 
     func testLoadingNonexistentFileAsDer() throws {
-        do {
-            _ = try NIOSSLCertificate(file: "/nonexistent/path", format: .der)
-            XCTFail("Did not throw")
-        } catch let error as IOError {
-            XCTAssertEqual(error.errnoCode, ENOENT)
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try NIOSSLCertificate(file: "/nonexistent/path", format: .der)) {error in
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
         }
     }
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -282,7 +282,7 @@ class SSLCertificateTest: XCTestCase {
 
     func testLoadingNonexistentFileAsPem() throws {
         XCTAssertThrowsError(try NIOSSLCertificate(file: "/nonexistent/path", format: .pem)) {error in
-            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode })
         }
     }
 
@@ -294,7 +294,7 @@ class SSLCertificateTest: XCTestCase {
 
     func testLoadingNonexistentFileAsDer() throws {
         XCTAssertThrowsError(try NIOSSLCertificate(file: "/nonexistent/path", format: .der)) {error in
-            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode })
         }
     }
 

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
@@ -495,13 +495,8 @@ class SSLPKCS12BundleTest: XCTestCase {
     }
 
     func testDecodingNonExistentPKCS12File() throws {
-        do {
-            _ = try NIOSSLPKCS12Bundle(file: "/nonexistent/path")
-            XCTFail("Did not throw")
-        } catch let error as IOError {
-            XCTAssertEqual(error.errnoCode, ENOENT)
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try NIOSSLPKCS12Bundle(file: "/nonexistent/path")){ error in
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
         }
     }
 }

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
@@ -496,7 +496,7 @@ class SSLPKCS12BundleTest: XCTestCase {
 
     func testDecodingNonExistentPKCS12File() throws {
         XCTAssertThrowsError(try NIOSSLPKCS12Bundle(file: "/nonexistent/path")){ error in
-            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode }))
+            XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode })
         }
     }
 }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -275,13 +275,8 @@ class TLSConfigurationTest: XCTestCase {
     func testNonexistentFileObject() throws {
         let clientConfig = TLSConfiguration.forClient(trustRoots: .file("/thispathbetternotexist/bogus.foo"))
 
-        do {
-            _ = try NIOSSLContext(configuration: clientConfig)
-            XCTFail("Did not throw")
-        } catch NIOSSLError.noSuchFilesystemObject {
-            // This is fine
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        XCTAssertThrowsError(try NIOSSLContext(configuration: clientConfig)) {error in
+            XCTAssertEqual(.noSuchFilesystemObject, error as? NIOSSLError)
         }
     }
     

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -484,7 +484,7 @@ final class UnwrappingTests: XCTestCase {
         clientHandler.stopTLS(promise: stopPromise)
         
         XCTAssertThrowsError(try stopPromise.futureResult.wait()) { error in
-            XCTAssertEqual(.alreadyClosed, error as? NIOTLSUnwrappingError)
+            XCTAssertEqual(.some(.alreadyClosed), error as? NIOTLSUnwrappingError)
         }
     }
 

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -547,7 +547,7 @@ final class UnwrappingTests: XCTestCase {
             try clientChannel.writeInbound(buffer)
         } catch {
             switch error as? NIOSSLError {
-            case .shutdownFailed :
+            case .some(.shutdownFailed) :
                 // Expected
                 break
             default:

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -542,10 +542,8 @@ final class UnwrappingTests: XCTestCase {
         // of a CLOSE_NOTIFY.
         var buffer = clientChannel.allocator.buffer(capacity: 1024)
         buffer.writeStaticString("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
-        
-        do {
-            try clientChannel.writeInbound(buffer)
-        } catch {
+
+        XCTAssertThrowsError(try clientChannel.writeInbound(buffer)) {error in
             switch error as? NIOSSLError {
             case .some(.shutdownFailed) :
                 // Expected

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -544,7 +544,11 @@ final class UnwrappingTests: XCTestCase {
         buffer.writeStaticString("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
         
         XCTAssertThrowsError(try clientChannel.writeInbound(buffer)) { error in
-            XCTAssertEqual(.shutdownFailed, error as? NIOSSLError)
+            if case .shutdownFailed = error as? NIOSSLError {
+                // Okay
+            } else {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
 
         // The client should have errored out now. The handler should still be there, as unwrapping

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -482,14 +482,9 @@ final class UnwrappingTests: XCTestCase {
         // We haven't spun the event loop, so the handlers are still in the pipeline. Now attempt to unwrap.
         let stopPromise: EventLoopPromise<Void> = clientChannel.eventLoop.makePromise()
         clientHandler.stopTLS(promise: stopPromise)
-
-        do {
-            try stopPromise.futureResult.wait()
-            XCTFail("Did not throw")
-        } catch NIOTLSUnwrappingError.alreadyClosed {
-            // expected
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        
+        XCTAssertThrowsError(try stopPromise.futureResult.wait()) { error in
+            XCTAssertEqual(.alreadyClosed, error as? NIOTLSUnwrappingError)
         }
     }
 
@@ -547,14 +542,9 @@ final class UnwrappingTests: XCTestCase {
         // of a CLOSE_NOTIFY.
         var buffer = clientChannel.allocator.buffer(capacity: 1024)
         buffer.writeStaticString("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
-
-        do {
-            try clientChannel.writeInbound(buffer)
-            XCTFail("Did not error")
-        } catch NIOSSLError.shutdownFailed {
-            // expected
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+        
+        XCTAssertThrowsError(try clientChannel.writeInbound(buffer)) { error in
+            XCTAssertEqual(.shutdownFailed, error as? NIOSSLError)
         }
 
         // The client should have errored out now. The handler should still be there, as unwrapping

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -543,10 +543,14 @@ final class UnwrappingTests: XCTestCase {
         var buffer = clientChannel.allocator.buffer(capacity: 1024)
         buffer.writeStaticString("GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
         
-        XCTAssertThrowsError(try clientChannel.writeInbound(buffer)) { error in
-            if case .shutdownFailed = error as? NIOSSLError {
-                // Okay
-            } else {
+        do {
+            try clientChannel.writeInbound(buffer)
+        } catch {
+            switch error as? NIOSSLError {
+            case .shutdownFailed :
+                // Expected
+                break
+            default:
                 XCTFail("Unexpected error: \(error)")
             }
         }


### PR DESCRIPTION

### Motivation:

Get rid of `do { ... } catch { ... }` for expected errors

### Modifications:

Replacing all uses of this pattern in Tests/**.

```
do {
    try someOperation()
XCTFail("should throw") // easy to forget
} catch error as SomethingError {
    XCTAssertEqual(.something, error as? SomethingError)
} catch {
    XCTFail("wrong error")
}
```

with 

```
XCTAssertThrowsError(try someOperation) { error in
    XCTAssertEqual(.something, error as? SomethingError)
}
```


### Result:

Fixes https://github.com/apple/swift-nio-ssl/issues/196