### PR TITLE
Unwrapping TLS should still time out.

### DIFF
--- a/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
@@ -40,6 +40,9 @@ extension UnwrappingTests {
                 ("testPendingWritesFailOnUnwrap", testPendingWritesFailOnUnwrap),
                 ("testPendingWritesFailWhenFlushedOnUnwrap", testPendingWritesFailWhenFlushedOnUnwrap),
                 ("testDataReceivedAfterCloseNotifyIsPassedDownThePipeline", testDataReceivedAfterCloseNotifyIsPassedDownThePipeline),
+                ("testUnwrappingTimeout", testUnwrappingTimeout),
+                ("testSuccessfulUnwrapCancelsTimeout", testSuccessfulUnwrapCancelsTimeout),
+                ("testUnwrappingAndClosingShareATimeout", testUnwrappingAndClosingShareATimeout),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When we added TLS "unwrapping" support (that is, taking a NIOSSLHandler)
and removing it from a pipeline without killing it, we never plumbed
through the timeout behaviour from close. This can lead to permanently
delayed unwraps where the unwrap never completes.

Modifications:

Take the existing support for timed out shutdown and plumb it through to
unwrapping as well.

Result:

Unwrapping TLS cannot get stuck.