### PR TITLE
@_implementationOnly also for Swift 5.3

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 #else

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 #else

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLInit.swift
+++ b/Sources/NIOSSL/SSLInit.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIO
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import NIO
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.3)
+#if compiler(>=5.1) && compiler(<5.4)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL


### PR DESCRIPTION
Motivation:

@_implementationOnly also works in Swift 5.3, let's use it.

Modification:

Use @_implementationOnly for Swift 5.1 ... 5.3

Result:

Proper 5.3 support.