### PR TITLE
improve 5.3 docker setup

### DIFF
--- a/docker/docker-compose.1804.53.yaml
+++ b/docker/docker-compose.1804.53.yaml
@@ -6,7 +6,7 @@ services:
     image: swift-nio-ssl:18.04-5.3
     build:
       args:
-        base_image: "swiftlang/swift:nightly-master-bionic"
+        base_image: "swiftlang/swift:nightly-5.3-bionic"
 
   unit-tests:
     image: swift-nio-ssl:18.04-5.3


### PR DESCRIPTION
motivation: pin to 5.3 nighties 

changes: use swiftlang/swift:nightly-5.3-master-bionic instead of swiftlang/swift:nightly-master-bionic