### PR TITLE
Resolve exclusivity violation on connection teardown.

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -600,8 +600,9 @@ extension NIOSSLHandler {
     }
 
     private func discardBufferedWrites(reason: Error) {
-        self.bufferedWrites.forEachRemoving {
-            $0.promise?.fail(reason)
+        while self.bufferedWrites.count > 0 {
+            let bufferedWrite = self.bufferedWrites.removeFirst()
+            bufferedWrite.promise?.fail(reason)
         }
     }
 
@@ -669,12 +670,6 @@ fileprivate extension MarkedCircularBuffer {
         // do something about that, we just have to live with this.
         while try self.hasMark && callback(self.first!) {
             _ = self.removeFirst()
-        }
-    }
-
-    mutating func forEachRemoving(callback: (Element) -> Void) {
-        while self.count > 0 {
-            callback(self.removeFirst())
         }
     }
 }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -59,6 +59,7 @@ extension NIOSSLIntegrationTest {
                 ("testChannelInactiveAfterCloseNotify", testChannelInactiveAfterCloseNotify),
                 ("testKeyLoggingClientAndServer", testKeyLoggingClientAndServer),
                 ("testLoadsOfCloses", testLoadsOfCloses),
+                ("testWriteFromFailureOfWrite", testWriteFromFailureOfWrite),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

When we're failing promises on channelInactive, we do so while holding
the write buffer mutably. This means that if anyone calls write() on us,
we'll explode, as we enqueue the write into the buffer.

Modifications:

- Rewrote the close loop to not hold the write buffer mutably.
- Added a regression test.

Result:

No crashes in production.