### PR TITLE
Allow double-setting the custom verify callback.

### DIFF
--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -164,10 +164,11 @@ internal final class SSLConnection {
         // Store the verification callback. We need to do this to keep it alive throughout the connection.
         // We'll drop this when we're told that it's no longer needed to ensure we break the reference cycles
         // that this callback inevitably produces.
-        assert(self.customVerificationManager == nil)
         self.customVerificationManager = callbackManager
 
         // We need to know what the current mode is.
+        // Note that this also has the effect of ensuring that if we disabled certificate validation
+        // it actually _stays_ disabled: if the verify mode is no-verification, this callback never gets called.
         let currentMode = CNIOBoringSSL_SSL_get_verify_mode(self.ssl)
         CNIOBoringSSL_SSL_set_custom_verify(self.ssl, currentMode) { ssl, outAlert in
             guard let unwrappedSSL = ssl else {

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -52,6 +52,8 @@ extension NIOSSLIntegrationTest {
                 ("testErroringNewVerificationCallback", testErroringNewVerificationCallback),
                 ("testNewCallbackCanDelayHandshake", testNewCallbackCanDelayHandshake),
                 ("testExtractingCertificatesNewCallback", testExtractingCertificatesNewCallback),
+                ("testNewCallbackCombinedWithDefaultTrustStore", testNewCallbackCombinedWithDefaultTrustStore),
+                ("testMacOSVerificationCallbackIsNotUsedIfVerificationDisabled", testMacOSVerificationCallbackIsNotUsedIfVerificationDisabled),
                 ("testRepeatedClosure", testRepeatedClosure),
                 ("testClosureTimeout", testClosureTimeout),
                 ("testReceivingGibberishAfterAttemptingToClose", testReceivingGibberishAfterAttemptingToClose),


### PR DESCRIPTION
Motivation:

An unnecessary assertion prevented us double-setting the custom verify
callback. This had the effect of making the custom verify callback
unusable on Apple platforms in debug mode only. The actual code
tolerates a double-setting of the custom verify callback just fine, but
the assertion prevents it for no good reason.

Modifications:

- Removed an assertion.
- Added some tests to confirm it's all fine.

Result:

Users won't get crashes when they try to use the custom verify callback.
Fixes #223.