### PR TITLE
Add support for custom verify callback to servers.

### DIFF
--- a/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
@@ -34,7 +34,7 @@ final class BenchManyWrites: Benchmark {
     }
 
     func setUp() throws {
-        let serverHandler = try NIOSSLServerHandler(context: self.serverContext)
+        let serverHandler = NIOSSLServerHandler(context: self.serverContext)
         let clientHandler = try NIOSSLClientHandler(context: self.clientContext, serverHostname: "localhost")
         try self.backToBack.client.pipeline.addHandler(clientHandler).wait()
         try self.backToBack.server.pipeline.addHandler(serverHandler).wait()

--- a/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
@@ -35,7 +35,7 @@ final class BenchRepeatedHandshakes: Benchmark {
     func run() throws -> Int {
         for _ in 0..<self.loopCount {
             let backToBack = BackToBackEmbeddedChannel()
-            let serverHandler = try NIOSSLServerHandler(context: self.serverContext)
+            let serverHandler = NIOSSLServerHandler(context: self.serverContext)
             let clientHandler = try NIOSSLClientHandler(context: self.clientContext, serverHostname: "localhost")
             try backToBack.client.pipeline.addHandler(clientHandler).wait()
             try backToBack.server.pipeline.addHandler(serverHandler).wait()

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -40,7 +40,7 @@ let bootstrap = ServerBootstrap(group: group)
 
     // Set the handlers that are applied to the accepted channels.
     .childChannelInitializer { channel in
-        return channel.pipeline.addHandler(try! NIOSSLServerHandler(context: sslContext)).flatMap {
+        return channel.pipeline.addHandler(NIOSSLServerHandler(context: sslContext)).flatMap {
             channel.pipeline.addHandler(EchoHandler())
         }
     }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -54,6 +54,7 @@ extension NIOSSLIntegrationTest {
                 ("testExtractingCertificatesNewCallback", testExtractingCertificatesNewCallback),
                 ("testNewCallbackCombinedWithDefaultTrustStore", testNewCallbackCombinedWithDefaultTrustStore),
                 ("testMacOSVerificationCallbackIsNotUsedIfVerificationDisabled", testMacOSVerificationCallbackIsNotUsedIfVerificationDisabled),
+                ("testServerHasNewCallbackCalledToo", testServerHasNewCallbackCalledToo),
                 ("testRepeatedClosure", testRepeatedClosure),
                 ("testClosureTimeout", testClosureTimeout),
                 ("testReceivingGibberishAfterAttemptingToClose", testReceivingGibberishAfterAttemptingToClose),


### PR DESCRIPTION
Motivation:

In #171 when we worked on providing access to the better verification
callback, we managed to entirely miss that we had not provided that
access to servers. This meant they were stuck only with the
substantially-less-useful old-school callback, instead of the much
better new-school one.

While we're here, as we had to add multiple new initializers to
NIOSSLServerHandler, I took the opportunity to also resolve the server
handler portion of #147. The issue itself is still open because the
client handlers still have throwing inits, but all "preferred"
initializers on NIOSSLServerHandler no longer throw.

Modifications:

- Deprecated NIOSSLServerHandler.init(context:verificationCallback:)
- Implemented two new initializers on NIOSSLServerHandler.
- Added tests to verify that the NIOSSLServerHandler verification
  callback is actually called.
- Removed all now-unnecessary try keywords.

Result:

Users will be able to provide custom verification callbacks that work
much better than they currently can when on the server, and the server
is now back into feature parity with the client.