### PR TITLE
Silence #file/#filePath warnings in XCTest

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -27,7 +27,7 @@ public func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defau
     do {
         return try body()
     } catch {
-        XCTFail("unexpected error \(error) thrown", file: file, line: line)
+        XCTFail("unexpected error \(error) thrown", file: (file), line: line)
         if let defaultValue = defaultValue {
             return defaultValue
         } else {

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -129,12 +129,12 @@ class TLSConfigurationTest: XCTestCase {
             switch eventHandler.errors[0] {
             case .handshakeFailed(.sslError(let errs)):
                 let correctError: Bool = messages.map { errs[0].description.contains($0) }.reduce(false) { $0 || $1 }
-                XCTAssert(correctError, errs[0].description, file: file, line: line)
+                XCTAssert(correctError, errs[0].description, file: (file), line: line)
             default:
-                XCTFail("Unexpected error: \(eventHandler.errors[0])", file: file, line: line)
+                XCTFail("Unexpected error: \(eventHandler.errors[0])", file: (file), line: line)
             }
 
-            XCTAssertFalse(handshakeHandler.handshakeSucceeded, file: file, line: line)
+            XCTAssertFalse(handshakeHandler.handshakeSucceeded, file: (file), line: line)
         }
         try clientChannel.closeFuture.wait()
     }
@@ -159,18 +159,18 @@ class TLSConfigurationTest: XCTestCase {
 
         // We expect the channel to be closed fairly swiftly as the handshake should fail.
         clientChannel.closeFuture.whenComplete { _ in
-            XCTAssertEqual(eventHandler.errors.count, 1, file: file, line: line)
+            XCTAssertEqual(eventHandler.errors.count, 1, file: (file), line: line)
 
             switch eventHandler.errors[0] {
             case .sslError(let errs):
-                XCTAssertEqual(errs.count, 1, file: file, line: line)
+                XCTAssertEqual(errs.count, 1, file: (file), line: line)
                 let correctError: Bool = messages.map { errs[0].description.contains($0) }.reduce(false) { $0 || $1 }
-                XCTAssert(correctError, errs[0].description, file: file, line: line)
+                XCTAssert(correctError, errs[0].description, file: (file), line: line)
             default:
-                XCTFail("Unexpected error: \(eventHandler.errors[0])", file: file, line: line)
+                XCTFail("Unexpected error: \(eventHandler.errors[0])", file: (file), line: line)
             }
 
-            XCTAssertTrue(handshakeHandler.handshakeSucceeded, file: file, line: line)
+            XCTAssertTrue(handshakeHandler.handshakeSucceeded, file: (file), line: line)
         }
         try clientChannel.closeFuture.wait()
     }

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -29,14 +29,14 @@ extension ChannelPipeline {
         do {
             _ = try self.context(handler: handler).wait()
         } catch {
-            XCTFail("Handler \(handler) missing from \(self)", file: file, line: line)
+            XCTFail("Handler \(handler) missing from \(self)", file: (file), line: line)
         }
     }
 
     func assertDoesNotContain(handler: ChannelHandler, file: StaticString = #file, line: UInt = #line) {
         do {
             _ = try self.context(handler: handler).wait()
-            XCTFail("Handler \(handler) present in \(self)", file: file, line: line)
+            XCTFail("Handler \(handler) present in \(self)", file: (file), line: line)
         } catch {
             // Expected
         }


### PR DESCRIPTION
Motivation:

Swift 5.3 warns when `#file` is passed to a function expecting
`#filePath` even though the values are currently the same.

- apple/swift#32445
- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

Modifications:

- Wrap `file` in parentheses to silence warnings.

Result:

- No warnings, uglier code