### PR TITLE
Add option to specify signining and verification algorithms

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -163,7 +163,25 @@ public final class NIOSSLContext {
         try NIOSSLContext.configureCertificateValidation(context: context,
                                                       verification: configuration.certificateVerification,
                                                       trustRoots: configuration.trustRoots)
-
+        
+        // Configure verification algorithms
+        returnCode = configuration
+            .verifySignatureAlgorithms
+            .map{ $0.rawValue }
+            .withUnsafeBufferPointer { algo in
+            CNIOBoringSSL_SSL_CTX_set_verify_algorithm_prefs(context, algo.baseAddress, algo.count)
+        }
+        precondition(1 == returnCode)
+        
+        // Configure signing algorithms
+        returnCode = configuration
+            .signSignatureAlgorithms
+            .map{ $0.rawValue }
+            .withUnsafeBufferPointer { algo in
+            CNIOBoringSSL_SSL_CTX_set_signing_algorithm_prefs(context, algo.baseAddress, algo.count)
+        }
+        precondition(1 == returnCode)
+        
         // If we were given a certificate chain to use, load it and its associated private key. Before
         // we do, set up a passphrase callback if we need to.
         if let callbackManager = callbackManager {

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -171,7 +171,10 @@ public final class NIOSSLContext {
                 .withUnsafeBufferPointer { algo in
                     CNIOBoringSSL_SSL_CTX_set_verify_algorithm_prefs(context, algo.baseAddress, algo.count)
             }
-            precondition(1 == returnCode)
+            if returnCode != 1 {
+                let errorStack = BoringSSLError.buildErrorStack()
+                throw BoringSSLError.unknownError(errorStack)
+            }
         }
         
         // Configure signing algorithms
@@ -181,7 +184,10 @@ public final class NIOSSLContext {
                 .withUnsafeBufferPointer { algo in
                     CNIOBoringSSL_SSL_CTX_set_signing_algorithm_prefs(context, algo.baseAddress, algo.count)
             }
-            precondition(1 == returnCode)
+            if returnCode != 1 {
+                let errorStack = BoringSSLError.buildErrorStack()
+                throw BoringSSLError.unknownError(errorStack)
+            }
         }
         
         // If we were given a certificate chain to use, load it and its associated private key. Before

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -165,22 +165,24 @@ public final class NIOSSLContext {
                                                       trustRoots: configuration.trustRoots)
         
         // Configure verification algorithms
-        returnCode = configuration
-            .verifySignatureAlgorithms
-            .map{ $0.rawValue }
-            .withUnsafeBufferPointer { algo in
-            CNIOBoringSSL_SSL_CTX_set_verify_algorithm_prefs(context, algo.baseAddress, algo.count)
+        if let verifySignatureAlgorithms = configuration.verifySignatureAlgorithms {
+            returnCode = verifySignatureAlgorithms
+                .map { $0.rawValue }
+                .withUnsafeBufferPointer { algo in
+                    CNIOBoringSSL_SSL_CTX_set_verify_algorithm_prefs(context, algo.baseAddress, algo.count)
+            }
+            precondition(1 == returnCode)
         }
-        precondition(1 == returnCode)
         
         // Configure signing algorithms
-        returnCode = configuration
-            .signSignatureAlgorithms
-            .map{ $0.rawValue }
-            .withUnsafeBufferPointer { algo in
-            CNIOBoringSSL_SSL_CTX_set_signing_algorithm_prefs(context, algo.baseAddress, algo.count)
+        if let signingSignatureAlgorithms = configuration.signingSignatureAlgorithms {
+            returnCode = signingSignatureAlgorithms
+                .map { $0.rawValue }
+                .withUnsafeBufferPointer { algo in
+                    CNIOBoringSSL_SSL_CTX_set_signing_algorithm_prefs(context, algo.baseAddress, algo.count)
+            }
+            precondition(1 == returnCode)
         }
-        precondition(1 == returnCode)
         
         // If we were given a certificate chain to use, load it and its associated private key. Before
         // we do, set up a passphrase callback if we need to.

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -85,7 +85,7 @@ public enum NIORenegotiationSupport {
 }
 
 /// Signature algorithms. The values are defined as in TLS 1.3
-public struct SignatureAlgorithm : RawRepresentable {
+public struct SignatureAlgorithm : RawRepresentable, Hashable {
     
     public typealias RawValue = UInt16
     public var rawValue: UInt16
@@ -248,6 +248,35 @@ public struct TLSConfiguration {
     public static func forServer(certificateChain: [NIOSSLCertificateSource],
                                  privateKey: NIOSSLPrivateKeySource,
                                  cipherSuites: String = defaultCipherSuites,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none)  // Servers never support renegotiation: there's no point.
+    }
+
+    /// Create a TLS configuration for use with server-side contexts.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `forClient` instead.
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: String = defaultCipherSuites,
                                  verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
                                  signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
                                  minimumTLSVersion: TLSVersion = .tlsv1,
@@ -272,14 +301,11 @@ public struct TLSConfiguration {
                                 renegotiationSupport: .none)  // Servers never support renegotiation: there's no point.
     }
 
-
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
     /// contexts, you should use `forServer` instead.
     public static func forClient(cipherSuites: String = defaultCipherSuites,
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
                                  minimumTLSVersion: TLSVersion = .tlsv1,
                                  maximumTLSVersion: TLSVersion? = nil,
                                  certificateVerification: CertificateVerification = .fullVerification,
@@ -290,8 +316,8 @@ public struct TLSConfiguration {
                                  shutdownTimeout: TimeAmount = .seconds(5),
                                  keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
         return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
                                 minimumTLSVersion: minimumTLSVersion,
                                 maximumTLSVersion: maximumTLSVersion,
                                 certificateVerification: certificateVerification,
@@ -305,6 +331,36 @@ public struct TLSConfiguration {
     }
 
 
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `forServer` instead.
+    public static func forClient(cipherSuites: String = defaultCipherSuites,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport)
+    }
+    
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side

--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -35,6 +35,9 @@ extension TLSConfigurationTest {
                 ("testMutualValidation", testMutualValidation),
                 ("testMutualValidationRequiresClientCertificatePreTLS13", testMutualValidationRequiresClientCertificatePreTLS13),
                 ("testMutualValidationRequiresClientCertificatePostTLS13", testMutualValidationRequiresClientCertificatePostTLS13),
+                ("testIncompatibleSignatures", testIncompatibleSignatures),
+                ("testCompatibleSignatures", testCompatibleSignatures),
+                ("testMatchingCompatibleSignatures", testMatchingCompatibleSignatures),
                 ("testNonexistentFileObject", testNonexistentFileObject),
                 ("testComputedApplicationProtocols", testComputedApplicationProtocols),
            ]


### PR DESCRIPTION
Motivation:

BoringSSLs built-in list of valid signing and verification algortihms is not
always the one you actually would like to use. For example adding or removing
algorithms from this list might increase compatibility as well as security

Modifications:

Add an option to set CNIOBoringSSL_SSL_CTX_set_verify_algorithm_prefs
and CNIOBoringSSL_SSL_CTX_set_signing_algorithm_prefs

Result:

The user can set signing and verification algortihms at their will