### PR TITLE
Stop using commonName to validate certificates.

### DIFF
--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -213,7 +213,8 @@ internal final class SSLConnection {
 
         guard try validIdentityForService(serverHostname: self.expectedHostname,
                                           socketAddress: address,
-                                          leafCertificate: peerCert) else {
+                                          leafCertificate: peerCert,
+                                          includeCommonName: self.parentContext.configuration.trustCommonName) else {
             throw NIOSSLExtraError.failedToValidateHostname(expectedName: self.expectedHostname ?? "<none>")
         }
     }

--- a/Tests/NIOSSLTests/IdentityVerificationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest+XCTest.swift
@@ -51,6 +51,8 @@ extension IdentityVerificationTest {
                 ("testDoesNotMatchSANWithEmbeddedNULL", testDoesNotMatchSANWithEmbeddedNULL),
                 ("testFallsBackToCommonName", testFallsBackToCommonName),
                 ("testLowercasesForCommonName", testLowercasesForCommonName),
+                ("testDoesNotFallBackToCommonName", testDoesNotFallBackToCommonName),
+                ("testNoLowercasesForCommonName", testNoLowercasesForCommonName),
                 ("testRejectsUnicodeCommonNameWithUnencodedIDNALabel", testRejectsUnicodeCommonNameWithUnencodedIDNALabel),
                 ("testRejectsUnicodeCommonNameWithEncodedIDNALabel", testRejectsUnicodeCommonNameWithEncodedIDNALabel),
                 ("testHandlesMissingCommonName", testHandlesMissingCommonName),

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -75,7 +75,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -83,7 +84,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -91,7 +93,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "example.com.",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -99,7 +102,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "LoCaLhOsT",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -107,7 +111,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "httpbin.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -115,7 +120,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: try .makeAddressResolvingHost("192.168.0.1", port: 443),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -127,7 +133,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: ipv6Address,
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -135,7 +142,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: try .makeAddressResolvingHost("192.168.0.2", port: 443),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -146,7 +154,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: nil,
                                                   socketAddress: ipv6Address,
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -154,7 +163,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "this.wildcard.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -162,7 +172,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "foo.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -170,7 +181,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "bar.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -178,7 +190,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "baz.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -186,7 +199,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "trailing.period.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -195,7 +209,8 @@ class IdentityVerificationTest: XCTestCase {
 
         XCTAssertThrowsError(try validIdentityForService(serverHostname: "straße.unicode.example.com",
                            socketAddress: try .init(unixDomainSocketPath: "/path"),
-                           leafCertificate: cert)) { error in
+                           leafCertificate: cert,
+                           includeCommonName: false)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname straße.unicode.example.com cannot be matched due to containing non-DNS characters")
@@ -207,7 +222,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--strae-oqa.unicode.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -215,7 +231,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--xx-gia.unicode.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -223,7 +240,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "weirdwildcard.nomatch.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -231,7 +249,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "one.two.double.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -240,7 +259,8 @@ class IdentityVerificationTest: XCTestCase {
 
         XCTAssertThrowsError(try validIdentityForService(serverHostname: "foo.straße.example.com",
                                 socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                leafCertificate: cert)) { error in
+                                leafCertificate: cert,
+                                includeCommonName: false)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname foo.straße.example.com cannot be matched due to containing non-DNS characters")
@@ -251,7 +271,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "foo.xn--strae-oqa.example.com",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertTrue(matched)
     }
 
@@ -260,7 +281,8 @@ class IdentityVerificationTest: XCTestCase {
 
        XCTAssertThrowsError(try validIdentityForService(serverHostname: "nul\u{0000}l.example.com",
                                socketAddress: try .init(unixDomainSocketPath: "/path"),
-                               leafCertificate: cert)) { error in
+                               leafCertificate: cert,
+                               includeCommonName: false)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname nul\u{0000}l.example.com cannot be matched due to containing non-DNS characters")
@@ -271,7 +293,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: true)
         XCTAssertTrue(matched)
     }
 
@@ -279,8 +302,27 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "LoCaLhOsT",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: true)
         XCTAssertTrue(matched)
+    }
+
+    func testDoesNotFallBackToCommonName() throws {
+        let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
+        let matched = try validIdentityForService(serverHostname: "localhost",
+                                                  socketAddress: try .init(unixDomainSocketPath: "/path"),
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
+        XCTAssertFalse(matched)
+    }
+
+    func testNoLowercasesForCommonName() throws {
+        let cert = try NIOSSLCertificate(bytes: .init(multiCNCert.utf8), format: .pem)
+        let matched = try validIdentityForService(serverHostname: "LoCaLhOsT",
+                                                  socketAddress: try .init(unixDomainSocketPath: "/path"),
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
+        XCTAssertFalse(matched)
     }
 
     func testRejectsUnicodeCommonNameWithUnencodedIDNALabel() throws {
@@ -288,7 +330,8 @@ class IdentityVerificationTest: XCTestCase {
 
         XCTAssertThrowsError(try validIdentityForService(serverHostname: "straße.org",
                                 socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                leafCertificate: cert)) { error in
+                                leafCertificate: cert,
+                                includeCommonName: false)) { error in
             XCTAssertEqual(error as? NIOSSLExtraError, .serverHostnameImpossibleToMatch)
             XCTAssertEqual(String(describing: error),
                            "NIOSSLExtraError.serverHostnameImpossibleToMatch: The server hostname straße.org cannot be matched due to containing non-DNS characters")
@@ -299,7 +342,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(unicodeCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "xn--strae-oqa.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -307,7 +351,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(noCNCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "localhost",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 
@@ -315,7 +360,8 @@ class IdentityVerificationTest: XCTestCase {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
         let matched = try validIdentityForService(serverHostname: "httpbin.org",
                                                   socketAddress: try .init(unixDomainSocketPath: "/path"),
-                                                  leafCertificate: cert)
+                                                  leafCertificate: cert,
+                                                  includeCommonName: false)
         XCTAssertFalse(matched)
     }
 }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -64,6 +64,8 @@ extension NIOSSLIntegrationTest {
                 ("testLoadsOfCloses", testLoadsOfCloses),
                 ("testWriteFromFailureOfWrite", testWriteFromFailureOfWrite),
                 ("testTrustedFirst", testTrustedFirst),
+                ("testCommonNameFails", testCommonNameFails),
+                ("testCommonNameSucceedsIfOverrideApplied", testCommonNameSucceedsIfOverrideApplied),
            ]
    }
 }

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -432,7 +432,7 @@ func addExtension(x509: UnsafeMutablePointer<X509>, nid: CInt, value: String) {
     CNIOBoringSSL_X509_EXTENSION_free(ext)
 }
 
-func generateSelfSignedCert() -> (NIOSSLCertificate, NIOSSLPrivateKey) {
+func generateSelfSignedCert(withSAN: Bool = true) -> (NIOSSLCertificate, NIOSSLPrivateKey) {
     let pkey = generateRSAPrivateKey()
     let x = CNIOBoringSSL_X509_new()!
     CNIOBoringSSL_X509_set_version(x, 2)
@@ -456,7 +456,7 @@ func generateSelfSignedCert() -> (NIOSSLCertificate, NIOSSLPrivateKey) {
     
     CNIOBoringSSL_X509_set_pubkey(x, pkey)
     
-    let commonName = "localhost"
+    let commonName = "camembert"
     let name = CNIOBoringSSL_X509_get_subject_name(x)
     commonName.withCString { (pointer: UnsafePointer<Int8>) -> Void in
         pointer.withMemoryRebound(to: UInt8.self, capacity: commonName.lengthOfBytes(using: .utf8)) { (pointer: UnsafePointer<UInt8>) -> Void in
@@ -473,7 +473,10 @@ func generateSelfSignedCert() -> (NIOSSLCertificate, NIOSSLPrivateKey) {
     
     addExtension(x509: x, nid: NID_basic_constraints, value: "critical,CA:FALSE")
     addExtension(x509: x, nid: NID_subject_key_identifier, value: "hash")
-    addExtension(x509: x, nid: NID_subject_alt_name, value: "DNS:localhost")
+
+    if withSAN {
+        addExtension(x509: x, nid: NID_subject_alt_name, value: "DNS:localhost")
+    }
     
     CNIOBoringSSL_X509_sign(x, pkey, CNIOBoringSSL_EVP_sha256())
     

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -339,7 +339,7 @@ class SSLCertificateTest: XCTestCase {
     }
 
     func testCommonNameForGeneratedCert() throws {
-        XCTAssertEqual([UInt8]("localhost".utf8), SSLCertificateTest.dynamicallyGeneratedCert.commonName()!)
+        XCTAssertEqual([UInt8]("camembert".utf8), SSLCertificateTest.dynamicallyGeneratedCert.commonName()!)
     }
 
     func testMultipleCommonNames() throws {


### PR DESCRIPTION
Motivation:

CommonName as part of certificate hostname verification has been
deprecated for more than two decades. Browsers have finally stopped
using the commonName as part of verification, and the WebPKI forbids
putting names into the commonName that are not also part of the
subjectAlternativeName extension.

Continuing to trust the commonName as part of the certificate hostname
will put us in a weaker position than most of the browser ecosystem.
That's not a good place to be, so we should flip our default to not
trusting the commonName any longer.

For pragmatic reasons, we do allow an override, but the default
configuration is off. Users using this override will likely find
themselves disappointed when we remove it at some point in the future.

Modifications:

- Added TLSConfiguration options to enable trusting commonName fields
  for hostname verification.
- Made investigating the commonName field optional during hostname
  verification.
- Tests to validate the new behaviour.

Result:

No trusting common names by default anymore.