### PR TITLE
Add `NIOSSLCertificate` debug description for useful debugging

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -437,8 +437,11 @@ internal class SubjectAltNameSequence: Sequence, IteratorProtocol {
 
 extension NIOSSLCertificate: CustomStringConvertible {
     
+    static let ipv4AddressLength = 16
+    static let ipv6AddressLength = 46
+    
     public var description: String {
-        var desc = "<"
+        var desc = "<NIOSSLCertificate"
         if let commonNameBytes = self.commonName() {
             let commonName = String(decoding: commonNameBytes, as: UTF8.self)
             desc += ";common_name=" + commonName
@@ -468,18 +471,26 @@ extension NIOSSLCertificate: CustomStringConvertible {
     
     private func ipv4ToString(_ address: in_addr) -> String {
         var address = address
-        let pointer = UnsafeMutableBufferPointer<CChar>.allocate(ipv4Len)
-        inet_ntop(AF_INET, &address, pointer, socklen_t(INET_ADDRSTRLEN))
-        let string = String(cString: pointer)
-        return string
+        let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: Self.ipv4AddressLength)
+        inet_ntop(AF_INET, &address, pointer, socklen_t(Self.ipv4AddressLength))
+        
+        defer {
+            pointer.deallocate()
+        }
+        
+        return String(cString: pointer)
     }
     
     private func ipv6ToString(_ address: in6_addr) -> String {
         var address = address
-        let pointer = malloc(Int(INET_ADDRSTRLEN)).assumingMemoryBound(to: CChar.self)
-        inet_ntop(AF_INET6, &address, pointer, socklen_t(INET6_ADDRSTRLEN))
-        let string = String(cString: pointer)
-        return string
+        let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: Self.ipv6AddressLength)
+        inet_ntop(AF_INET6, &address, pointer, socklen_t(Self.ipv6AddressLength))
+        
+        defer {
+            pointer.deallocate()
+        }
+        
+        return String(cString: pointer)
     }
     
 }

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -479,7 +479,8 @@ extension NIOSSLCertificate.IPAddress {
     private func ipv4ToString(_ address: in_addr) -> String {
         var address = address
         let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: Self.ipv4AddressLength)
-        inet_ntop(AF_INET, &address, pointer, socklen_t(Self.ipv4AddressLength))
+        let result = inet_ntop(AF_INET, &address, pointer, socklen_t(Self.ipv4AddressLength))
+        precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         
         defer {
             pointer.deallocate()
@@ -491,7 +492,8 @@ extension NIOSSLCertificate.IPAddress {
     private func ipv6ToString(_ address: in6_addr) -> String {
         var address = address
         let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: Self.ipv6AddressLength)
-        inet_ntop(AF_INET6, &address, pointer, socklen_t(Self.ipv6AddressLength))
+        let result = inet_ntop(AF_INET6, &address, pointer, socklen_t(Self.ipv6AddressLength))
+        precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         
         defer {
             pointer.deallocate()

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -488,7 +488,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     
     private func ipv6ToString(_ address: in6_addr) -> String {
         var address = address
-        var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv4AddressLength)
+        var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv6AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
             let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(pointer.count))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -490,7 +490,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
         var address = address
         var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv4AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
-            let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv6AddressLength))
+            let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(pointer.count))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         }
         return String(cString: &dest)

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -448,7 +448,7 @@ extension NIOSSLCertificate: CustomStringConvertible {
             for altName in alternativeName {
                 switch altName {
                 case .dnsName(let bytes):
-                    desc += "\(String(decoding: bytes, as: Unicode.UTF8.self)),"
+                    desc += "\(String(decoding: bytes, as: UTF8.self)),"
                 case .ipAddress(let address):
                     desc += "\(ipToString(address)),"
                 }

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -440,7 +440,7 @@ extension NIOSSLCertificate: CustomStringConvertible {
     public var description: String {
         var desc = "<"
         if let commonNameBytes = self.commonName() {
-            let commonName = String(decoding: commonNameBytes, as: Unicode.UTF8.self)
+            let commonName = String(decoding: commonNameBytes, as: UTF8.self)
             desc += ";common_name=" + commonName
         }
         if let alternativeName = self.subjectAlternativeNames() {

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -479,9 +479,9 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     private func ipv4ToString(_ address: in_addr) -> String {
         var address = address
         var dest: [CChar] = []
-        dest.reserveCapacity(Self.ipv4AddressLength)
+        dest.reserveCapacity(NIOSSLCertificate.IPAddress.ipv4AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
-            let result = inet_ntop(AF_INET, &address, pointer.baseAddress!, socklen_t(Self.ipv4AddressLength))
+            let result = inet_ntop(AF_INET, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv4AddressLength))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         }
         return String(cString: &dest)
@@ -490,9 +490,9 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     private func ipv6ToString(_ address: in6_addr) -> String {
         var address = address
         var dest: [CChar] = []
-        dest.reserveCapacity(Self.ipv6AddressLength)
+        dest.reserveCapacity(NIOSSLCertificate.IPAddress.ipv6AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
-            let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(Self.ipv6AddressLength))
+            let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv6AddressLength))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         }
         return String(cString: &dest)

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -464,7 +464,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     private static let ipv4AddressLength = 16
     private static let ipv6AddressLength = 46
     
-    /// A string representaion of the IP address.
+    /// A string representation of the IP address.
     /// E.g. IPv4: `192.168.0.1`
     /// E.g. IPv6: `2001:db8::1`
     public var description: String {

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -468,7 +468,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     /// E.g. IPv4: `192.168.0.1`
     /// E.g. IPv6: `2001:db8::1`
     public var description: String {
-        switch self{
+        switch self {
         case .ipv4(let addr):
             return self.ipv4ToString(addr)
         case .ipv6(let addr):

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -444,15 +444,15 @@ extension NIOSSLCertificate: CustomStringConvertible {
             desc += ";common_name=" + commonName
         }
         if let alternativeName = self.subjectAlternativeNames() {
-            desc += ";alternative_names="
-            for altName in alternativeName {
-                switch altName {
+            let altNames = alternativeName.map { name in
+                switch name {
                 case .dnsName(let bytes):
-                    desc += "\(String(decoding: bytes, as: UTF8.self)),"
+                    return String(decoding: bytes, as: UTF8.self)
                 case .ipAddress(let address):
-                    desc += "\(address.description),"
+                    return address.description
                 }
-            }
+            }.joined(separator: ",")
+            desc += ";alternative_names=\(altNames)"
         }
         return desc + ">"
     }
@@ -478,8 +478,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     
     private func ipv4ToString(_ address: in_addr) -> String {
         var address = address
-        var dest: [CChar] = []
-        dest.reserveCapacity(NIOSSLCertificate.IPAddress.ipv4AddressLength)
+        var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv4AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
             let result = inet_ntop(AF_INET, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv4AddressLength))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
@@ -489,8 +488,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
     
     private func ipv6ToString(_ address: in6_addr) -> String {
         var address = address
-        var dest: [CChar] = []
-        dest.reserveCapacity(NIOSSLCertificate.IPAddress.ipv6AddressLength)
+        var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv4AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
             let result = inet_ntop(AF_INET6, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv6AddressLength))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -449,7 +449,7 @@ extension NIOSSLCertificate: CustomStringConvertible {
                 case .dnsName(let bytes):
                     return String(decoding: bytes, as: UTF8.self)
                 case .ipAddress(let address):
-                    return address.description
+                    return String(describing: address)
                 }
             }.joined(separator: ",")
             desc += ";alternative_names=\(altNames)"

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -480,7 +480,7 @@ extension NIOSSLCertificate.IPAddress: CustomStringConvertible {
         var address = address
         var dest: [CChar] = Array(repeating: 0, count: NIOSSLCertificate.IPAddress.ipv4AddressLength)
         dest.withUnsafeMutableBufferPointer { pointer in
-            let result = inet_ntop(AF_INET, &address, pointer.baseAddress!, socklen_t(NIOSSLCertificate.IPAddress.ipv4AddressLength))
+            let result = inet_ntop(AF_INET, &address, pointer.baseAddress!, socklen_t(pointer.count))
             precondition(result != nil, "The IP address was invalid. This should never happen as we're within the IP address struct.")
         }
         return String(cString: &dest)

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -468,7 +468,7 @@ extension NIOSSLCertificate: CustomStringConvertible {
     
     private func ipv4ToString(_ address: in_addr) -> String {
         var address = address
-        let pointer = malloc(Int(INET_ADDRSTRLEN)).assumingMemoryBound(to: CChar.self)
+        let pointer = UnsafeMutableBufferPointer<CChar>.allocate(ipv4Len)
         inet_ntop(AF_INET, &address, pointer, socklen_t(INET_ADDRSTRLEN))
         let string = String(cString: pointer)
         return string

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -437,9 +437,6 @@ internal class SubjectAltNameSequence: Sequence, IteratorProtocol {
 
 extension NIOSSLCertificate: CustomStringConvertible {
     
-    static let ipv4AddressLength = 16
-    static let ipv6AddressLength = 46
-    
     public var description: String {
         var desc = "<NIOSSLCertificate"
         if let commonNameBytes = self.commonName() {
@@ -453,15 +450,25 @@ extension NIOSSLCertificate: CustomStringConvertible {
                 case .dnsName(let bytes):
                     desc += "\(String(decoding: bytes, as: UTF8.self)),"
                 case .ipAddress(let address):
-                    desc += "\(ipToString(address)),"
+                    desc += "\(address.stringValue),"
                 }
             }
         }
         return desc + ">"
     }
     
-    private func ipToString(_ address: IPAddress) -> String {
-        switch address{
+}
+
+extension NIOSSLCertificate.IPAddress {
+    
+    static let ipv4AddressLength = 16
+    static let ipv6AddressLength = 46
+    
+    /// A string representaion of the IP address.
+    /// E.g. IPv4: `192.168.0.1`
+    /// E.g. IPv6: `2001:db8::1`
+    public var stringValue: String {
+        switch self{
         case .ipv4(let addr):
             return ipv4ToString(addr)
         case .ipv6(let addr):

--- a/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
@@ -54,6 +54,8 @@ extension SSLCertificateTest {
                 ("testExtractingPublicKey", testExtractingPublicKey),
                 ("testDumpingPEMCert", testDumpingPEMCert),
                 ("testDumpingDERCert", testDumpingDERCert),
+                ("testPrintingDebugDetails_commonName", testPrintingDebugDetails_commonName),
+                ("testPrintingDebugDetails_alternativeName", testPrintingDebugDetails_alternativeName),
            ]
    }
 }

--- a/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
@@ -54,8 +54,8 @@ extension SSLCertificateTest {
                 ("testExtractingPublicKey", testExtractingPublicKey),
                 ("testDumpingPEMCert", testDumpingPEMCert),
                 ("testDumpingDERCert", testDumpingDERCert),
-                ("testPrintingDebugDetails_commonName", testPrintingDebugDetails_commonName),
-                ("testPrintingDebugDetails_alternativeName", testPrintingDebugDetails_alternativeName),
+                ("testPrintingDebugDetailsNoAlternativeNames", testPrintingDebugDetailsNoAlternativeNames),
+                ("testPrintingDebugDetailsWithAlternativeNames", testPrintingDebugDetailsWithAlternativeNames),
            ]
    }
 }

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -390,7 +390,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetails_alternativeName() throws {
-        let expectedDebugDescription = "<;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
+        let expectedDebugDescription = "<;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -380,4 +380,20 @@ class SSLCertificateTest: XCTestCase {
 
         XCTAssertEqual(certBytes, expectedCertBytes)
     }
+    
+    func testPrintingDebugDetails_commonName() throws {
+        let expectedDebugDescription = "<;common_name=robots.sanfransokyo.edu>"
+        let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem))
+        let debugString = String(describing: cert)
+
+        XCTAssertEqual(debugString, expectedDebugDescription)
+    }
+    
+    func testPrintingDebugDetails_alternativeName() throws {
+        let expectedDebugDescription = "<;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
+        let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
+        let debugString = String(describing: cert)
+
+        XCTAssertEqual(debugString, expectedDebugDescription)
+    }
 }

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -382,7 +382,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetails_commonName() throws {
-        let expectedDebugDescription = "<;common_name=robots.sanfransokyo.edu>"
+        let expectedDebugDescription = "<NIOSSLCertificate;common_name=robots.sanfransokyo.edu>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 
@@ -390,7 +390,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetails_alternativeName() throws {
-        let expectedDebugDescription = "<;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
+        let expectedDebugDescription = "<NIOSSLCertificate;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -381,7 +381,7 @@ class SSLCertificateTest: XCTestCase {
         XCTAssertEqual(certBytes, expectedCertBytes)
     }
     
-    func testPrintingDebugDetails_commonName() throws {
+    func testPrintingDebugDetailsNoAlternativeNames() throws {
         let expectedDebugDescription = "<NIOSSLCertificate;common_name=robots.sanfransokyo.edu>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem))
         let debugString = String(describing: cert)
@@ -389,8 +389,8 @@ class SSLCertificateTest: XCTestCase {
         XCTAssertEqual(debugString, expectedDebugDescription)
     }
     
-    func testPrintingDebugDetails_alternativeName() throws {
-        let expectedDebugDescription = "<NIOSSLCertificate;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1,>"
+    func testPrintingDebugDetailsWithAlternativeNames() throws {
+        let expectedDebugDescription = "<NIOSSLCertificate;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 


### PR DESCRIPTION
Printing a `NIOSSLCertificate` now gives the common and alternative names, useful for debugging which certificates are being handled.