### PR TITLE
Add NIOSSLCertificate serial number var, and add to description

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -48,12 +48,13 @@ public class NIOSSLCertificate {
     }
     
     public lazy var serialNumber: String = {
-        let sn = CNIOBoringSSL_X509_get_serialNumber(self.ref)
+        let serialNumber = CNIOBoringSSL_X509_get_serialNumber(self.ref)
         var bn = BIGNUM()
-        CNIOBoringSSL_ASN1_INTEGER_to_BN(sn, &bn)
-        let result = CNIOBoringSSL_BN_bn2hex(&bn)
-        precondition(result != nil, "Failed to convert bignum to hex")
-        return String(cString: result!)
+        CNIOBoringSSL_ASN1_INTEGER_to_BN(serialNumber, &bn)
+        guard let result = CNIOBoringSSL_BN_bn2hex(&bn) else {
+            preconditionFailure("Failed to convert bignum to hex")
+        }
+        return String(cString: result)
     }()
 
     private init(withOwnedReference ref: UnsafeMutablePointer<X509>) {

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -47,14 +47,14 @@ public class NIOSSLCertificate {
         case ipv6(in6_addr)
     }
     
-    public var serialNumber: String {
+    public lazy var serialNumber: String = {
         let sn = CNIOBoringSSL_X509_get_serialNumber(self.ref)
         var bn = BIGNUM()
         CNIOBoringSSL_ASN1_INTEGER_to_BN(sn, &bn)
         let result = CNIOBoringSSL_BN_bn2hex(&bn)
         precondition(result != nil, "Failed to convert bignum to hex")
         return String(cString: result!)
-    }
+    }()
 
     private init(withOwnedReference ref: UnsafeMutablePointer<X509>) {
         self._ref = UnsafeMutableRawPointer(ref) // erasing the type for @_implementationOnly import CNIOBoringSSL

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -390,7 +390,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetailsWithAlternativeNames() throws {
-        let expectedDebugDescription = "<NIOSSLCertificateserial_number=46231a526848d57af4999e29f89988d178d94da2;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1>"
+        let expectedDebugDescription = "<NIOSSLCertificate;serial_number=46231a526848d57af4999e29f89988d178d94da2;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -382,7 +382,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetailsNoAlternativeNames() throws {
-        let expectedDebugDescription = "<NIOSSLCertificate;common_name=robots.sanfransokyo.edu>"
+        let expectedDebugDescription = "<NIOSSLCertificate;serial_number=9fd7d05a34ca7984;common_name=robots.sanfransokyo.edu>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 
@@ -390,7 +390,7 @@ class SSLCertificateTest: XCTestCase {
     }
     
     func testPrintingDebugDetailsWithAlternativeNames() throws {
-        let expectedDebugDescription = "<NIOSSLCertificate;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1>"
+        let expectedDebugDescription = "<NIOSSLCertificateserial_number=46231a526848d57af4999e29f89988d178d94da2;common_name=localhost;alternative_names=localhost,example.com,192.168.0.1,2001:db8::1>"
         let cert = try assertNoThrowWithValue(NIOSSLCertificate(bytes: .init(multiSanCert.utf8), format: .pem))
         let debugString = String(describing: cert)
 


### PR DESCRIPTION
It's now possible to get the serial number for any given NIOSSLCertificate using the new `serialNumber` variable. This has also been added to the beginning of the certificate description.

Implemented as a lazy var, also possible to compute in the initialiser, take your pick.