### PR TITLE
Fix threading violation in KeyLogCallbackManager

### DIFF
--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -40,6 +40,7 @@ extension TLSConfigurationTest {
                 ("testMatchingCompatibleSignatures", testMatchingCompatibleSignatures),
                 ("testNonexistentFileObject", testNonexistentFileObject),
                 ("testComputedApplicationProtocols", testComputedApplicationProtocols),
+                ("testKeyLogManagerOverlappingAccess", testKeyLogManagerOverlappingAccess),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

The KeyLogCallbackManager belongs on an SSLContext, and so may be
invoked from multiple threads. However, it incorrectly cached a
ByteBuffer on its storage, leading to thread unsafety. This tends to
manifest in assertion failures, but could lead to arbitrary data
corruption or double frees.

Modifications:

- Remove the cached bytebuffer.
- Add probabilistic test.

Result:

No more thread-safety violations.