### PR TITLE
Add watchOS deployment to PodSpec build script

### DIFF
--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -119,6 +119,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '6.0'
 
   s.source_files = 'Sources/${target#Swift}/**/*.{swift,c,h,cc,S}'
   $public_header_files


### PR DESCRIPTION
Motivation:

We support watchOS 6+ with SwiftNIO Transport Services; as such we should
include watchOS as a deployment target for our CocoaPods.

Modifications:

- Add a watchOS deployment target to `build_podspecs.sh`

Result:

Users can deploy to watchOS 6+ with CocoaPods.