### PR TITLE
resolves #254

### DIFF
--- a/Sources/CNIOBoringSSL/include/CNIOBoringSSL_span.h
+++ b/Sources/CNIOBoringSSL/include/CNIOBoringSSL_span.h
@@ -24,6 +24,7 @@ extern "C++" {
 #include <algorithm>
 #include <cstdlib>
 #include <type_traits>
+#include <stdlib.h>
 
 BSSL_NAMESPACE_BEGIN
 


### PR DESCRIPTION
This resolves the following error that I get when I compile the project with Swift 5.3-dev

```
139:7: error: missing '#include <stdlib.h>'; 'abort' must be declared before it is used
      abort();
```