### PR TITLE
Use 'AnyObject' for class-constrained protocols

### DIFF
--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -51,7 +51,7 @@ public typealias NIOSSLPassphraseSetter<Bytes: Collection> = (Bytes) -> Void whe
 /// `globalBoringSSLPassphraseCallback` is not. Thus, rather than try to hold the actual specific `BoringSSLPassphraseManager`,
 /// we can hold it inside a protocol existential instead, so long as that protocol existential gives us the correct
 /// function to call. Hence: `CallbackManagerProtocol`, a private protocol with a single conforming type.
-internal protocol CallbackManagerProtocol: class {
+internal protocol CallbackManagerProtocol: AnyObject {
     func invoke(buffer: UnsafeMutableBufferPointer<CChar>) -> CInt
 }
 

--- a/Sources/NIOSSLPerformanceTester/Benchmark.swift
+++ b/Sources/NIOSSLPerformanceTester/Benchmark.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-protocol Benchmark: class {
+protocol Benchmark: AnyObject {
     func setUp() throws
     func tearDown()
     func run() throws -> Int


### PR DESCRIPTION
Motivation:

Using the 'class' keyword to constrain a protocol to a class is
deprecated in favour of 'AnyObject' and recent compilers emit warnings
about this.

Modifications:

- Use 'AnyObject' to constrain the 'CallbackManagerProtocol' instead

Result:

- Fewer warnings.