### PR TITLE
Use welcoming language

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -87,7 +87,7 @@ private func alpnCallback(ssl: OpaquePointer?,
                           in: UnsafePointer<UInt8>?,
                           inlen: UInt32,
                           appData: UnsafeMutableRawPointer?) -> CInt {
-    // Perform some sanity checks. We don't want NULL pointers around here.
+    // Perform some soundness checks. We don't want NULL pointers around here.
     guard let ssl = ssl, let out = out, let outlen = outlen, let `in` = `in` else {
         return SSL_TLSEXT_ERR_NOACK
     }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,9 +22,9 @@ services:
       - CAP_NET_RAW
       - CAP_NET_BIND_SERVICE
 
-  sanity:
+  soundness:
     <<: *common
-    command: /bin/bash -xcl "./scripts/sanity.sh"
+    command: /bin/bash -xcl "./scripts/soundness.sh"
 
   unit-tests:
     <<: *common

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -33,8 +33,25 @@ else
   printf "\033[0;32mokay.\033[0m\n"
 fi
 
+printf "=> Checking for unacceptable language... "
+# This greps for unacceptable terminology. The square bracket[s] are so that
+# "git grep" doesn't find the lines that greps :).
+# We exclude the vendored BoringSSL copy from this check.
+unacceptable_terms=(
+    -e blacklis[t]
+    -e whitelis[t]
+    -e slav[e]
+    -e sanit[y]
+)
+if git grep --color=never -i "${unacceptable_terms[@]}" ':(exclude)Sources/CNIOBoring*' > /dev/null; then
+    printf "\033[0;31mUnacceptable language found.\033[0m\n"
+    git grep -i "${unacceptable_terms[@]}" ':(exclude)Sources/CNIOBoring*'
+    exit 1
+fi
+printf "\033[0;32mokay.\033[0m\n"
+
 printf "=> Checking license headers... "
-tmp=$(mktemp /tmp/.swift-nio-sanity_XXXXXX)
+tmp=$(mktemp /tmp/.swift-nio-soundness_XXXXXX)
 
 for language in swift-or-c bash dtrace python; do
   declare -a matching_files


### PR DESCRIPTION
To comply with the new [Swift code of conduct](https://swift.org/code-of-conduct/), let's make the language a little more welcoming.

### Modifications:

- Replaced usages of "sanity" with "soundness"
- Added "sanity" to the list of unacceptable terms.
- **We check for usages of unacceptable language in our own code but not in the vendored BoringSSL code**
- Changed the CI name to `soundness` to comply with the changes already made by @tomerd: https://github.com/apple/swift-nio/pull/1732#issuecomment-765131877

### Result:

- Swift NIO SSL is nicer.