### PR TITLE
Stop guarding implementationOnly

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 #else

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 #else

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLInit.swift
+++ b/Sources/NIOSSL/SSLInit.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIO
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -14,7 +14,7 @@
 
 import XCTest
 import NIO
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1) && compiler(<5.4)
+#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else
 import CNIOBoringSSL


### PR DESCRIPTION
Motivation:

When we added support for implementationOnly imports, we guarded them
behind a maximum compiler version to prevent the possibility of the
spelling breaking in a future compiler release. This was pessimistic and
largely unnecessary. If the spelling does change in a future compiler
release, we can always ship a patch update that adds the compiler guard
to fix older versions. The solution, as it stands, will require trivial
patches every six months to maintain, which is much messier than just
removing the upper bound.

Modifications:

- Remove the upper bound on the compiler version for
  `@_implementationOnly` import.

Result:

Fewer trivial patches.