### PR TITLE
Allow warnings when building Podspecs

### DIFF
--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -132,13 +132,8 @@ EOF
   pod repo update # last chance of getting the latest versions of previous pushed pods
   if $upload; then
     echo "Uploading ${tmpdir}/${target}.podspec"
-    # CNIOBoringSSL emits build warnings
-    if [ "$target" == "CNIOBoringSSL" ]; then
-      pod trunk push --allow-warnings --synchronous "${tmpdir}/${target}.podspec"
-    else
-      pod trunk push  --synchronous "${tmpdir}/${target}.podspec"
-    fi
-
+    # CNIOBoringSSL and SwiftNIOSSL emit build warnings
+    pod trunk push --allow-warnings --synchronous "${tmpdir}/${target}.podspec"
   fi
 
 done


### PR DESCRIPTION
Motivation:

When pushing Cocoapods a warning is emitted for SwiftNIOSSL
('SecTrustEvaluateAsync' was deprecated in watchOS 6.0). Pushing the
pods fails as a result.

Modifications:

Allow warnings when pushing pods.

Result:

Pods can be pushed with warnings.