### PR TITLE
Provide notValidBefore and notValidAfter.

### DIFF
--- a/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest+XCTest.swift
@@ -56,6 +56,9 @@ extension SSLCertificateTest {
                 ("testDumpingDERCert", testDumpingDERCert),
                 ("testPrintingDebugDetailsNoAlternativeNames", testPrintingDebugDetailsNoAlternativeNames),
                 ("testPrintingDebugDetailsWithAlternativeNames", testPrintingDebugDetailsWithAlternativeNames),
+                ("testNotValidBefore", testNotValidBefore),
+                ("testNotValidAfter", testNotValidAfter),
+                ("testNotBeforeAfterGeneratedCert", testNotBeforeAfterGeneratedCert),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In some cases it's useful to know when a certificate's validity dates
are. This is not always terribly straightforward to calculate, so we can
encapsulate that math within the library.

Modifications:

- Add NIOSSLCertificate.notValidBefore
- Add NIOSSLCertificate.notValidAfter

Result:

Users will be able to ask what certificate validity dates are.