### PR TITLE
Bug fix to replace uncleanShutdown with handshakeFailed during TLS failure.

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -98,25 +98,35 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
         // keeping track of the state we're in properly before we do anything else.
         let oldState = state
         state = .closed
+        var channelError: NIOSSLError
 
         switch oldState {
         case .closed, .idle:
             // Nothing to do, but discard any buffered writes we still have.
             discardBufferedWrites(reason: ChannelError.ioOnClosedChannel)
+            // Return early
+            context.fireChannelInactive()
+            return
+        case .handshaking:
+            // In this case the channel is going through the doHandshake steps and
+            // a channelInactive is fired taking down the connection.
+            // This case propogates a .handshakeFailed instead of an .uncleanShutdown.
+            channelError = NIOSSLError.handshakeFailed(.sslError(BoringSSLError.buildErrorStack()))
         default:
             // This is a ragged EOF: we weren't sent a CLOSE_NOTIFY. We want to send a user
             // event to notify about this before we propagate channelInactive. We also want to fail all
             // these writes.
-            let shutdownPromise = self.shutdownPromise
-            self.shutdownPromise = nil
-            let closePromise = self.closePromise
-            self.closePromise = nil
-
-            shutdownPromise?.fail(NIOSSLError.uncleanShutdown)
-            closePromise?.fail(NIOSSLError.uncleanShutdown)
-            context.fireErrorCaught(NIOSSLError.uncleanShutdown)
-            discardBufferedWrites(reason: NIOSSLError.uncleanShutdown)
+            channelError = NIOSSLError.uncleanShutdown
         }
+        let shutdownPromise = self.shutdownPromise
+        self.shutdownPromise = nil
+        let closePromise = self.closePromise
+        self.closePromise = nil
+
+        shutdownPromise?.fail(channelError)
+        closePromise?.fail(channelError)
+        context.fireErrorCaught(channelError)
+        discardBufferedWrites(reason: channelError)
 
         context.fireChannelInactive()
     }

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -98,7 +98,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
         // keeping track of the state we're in properly before we do anything else.
         let oldState = state
         state = .closed
-        var channelError: NIOSSLError
+        let channelError: NIOSSLError
 
         switch oldState {
         case .closed, .idle:

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -403,6 +403,9 @@ internal final class SSLConnection {
 
         // Also drop the reference to the parent channel handler, which is a trivial reference cycle.
         self.parentHandler = nil
+
+        // And finally drop the data stored by the bytebuffer BIO
+        self.bio?.close()
     }
 
     /// Retrieves any inbound data that has not been processed by BoringSSL.

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -29,8 +29,10 @@ final class ByteBufferBIOTest: XCTestCase {
         }
     }
 
+    /// This leaks on purpose!
     private func retainedBIO() -> UnsafeMutablePointer<BIO> {
         let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        swiftBIO.close()
         return swiftBIO.retainedBIO()
     }
 
@@ -39,6 +41,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
@@ -60,6 +63,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
@@ -85,6 +89,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var targetBuffer = [UInt8](repeating: 0, count: 512)
@@ -100,6 +105,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var inboundBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -129,6 +135,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var inboundBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -181,6 +188,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var targetBuffer = [UInt8](repeating: 0, count: 512)
@@ -194,6 +202,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
@@ -227,6 +236,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         let firstAddress = writeAddress(swiftBIO: swiftBIO, cBIO: cBIO)
@@ -244,6 +254,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var bytesToWrite: [UInt8] = [1, 2, 3, 4, 5]
@@ -266,6 +277,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         XCTAssertNil(swiftBIO.outboundCiphertext())
@@ -286,6 +298,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
@@ -306,6 +319,7 @@ final class ByteBufferBIOTest: XCTestCase {
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
         }
 
         let originalShutdown = CNIOBoringSSL_BIO_ctrl(cBIO, BIO_CTRL_GET_CLOSE, 0, nil)

--- a/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
@@ -43,6 +43,7 @@ extension UnwrappingTests {
                 ("testUnwrappingTimeout", testUnwrappingTimeout),
                 ("testSuccessfulUnwrapCancelsTimeout", testSuccessfulUnwrapCancelsTimeout),
                 ("testUnwrappingAndClosingShareATimeout", testUnwrappingAndClosingShareATimeout),
+                ("testChannelInactiveDuringHandshake", testChannelInactiveDuringHandshake),
            ]
    }
 }


### PR DESCRIPTION
Bug fix to replace uncleanShutdown with handshakeFailed during TLS failure.

Motivation:

To address https://github.com/apple/swift-nio-ssl/issues/253

Modifications:

When channelInactive is called during a handshake failure it currently defaults to uncleanShutdown.
This bugfix and test is to report handshakeFailed instead of uncleanShutdown.

Added the handshaking case to the channelInactive function to report handshakeFailed.
Added a new test case, testChannelInactiveDuringHandshake, in UnwrappingTests to test this fix.

Result:

Fix of #253 