### PR TITLE
Bug fix to replace uncleanShutdown with handshakeFailed during TLS failure.

### DIFF
--- a/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests+XCTest.swift
@@ -43,6 +43,7 @@ extension UnwrappingTests {
                 ("testUnwrappingTimeout", testUnwrappingTimeout),
                 ("testSuccessfulUnwrapCancelsTimeout", testSuccessfulUnwrapCancelsTimeout),
                 ("testUnwrappingAndClosingShareATimeout", testUnwrappingAndClosingShareATimeout),
+                ("testChannelInactiveDuringHandshake", testChannelInactiveDuringHandshake),
            ]
    }
 }


### PR DESCRIPTION
(**Manually rebased**) Bug fix to replace uncleanShutdown with handshakeFailed during TLS failure.

Motivation:

To address #253

Modifications:

When channelInactive is called during a handshake failure it currently defaults to uncleanShutdown.
This bugfix and test is to report handshakeFailed instead of uncleanShutdown.

Added the handshaking case to the channelInactive function to report handshakeFailed.
Added a new test case, testChannelInactiveDuringHandshake, in UnwrappingTests to test this fix.

Result:

Fix of #253