### PR TITLE
Rebase: Added API for setting cipher suites in TLSConfiguration

### DIFF
--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -81,6 +81,45 @@ public enum NIOSSLAdditionalTrustRoots {
     case certificates([NIOSSLCertificate])
 }
 
+/// Available ciphers to use for TLS instead of a string based representation.
+public struct NIOTLSCipher: RawRepresentable, Hashable {
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+    
+    public init(_ rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+    
+    public var rawValue: UInt16
+    public typealias RawValue = UInt16
+    
+    public static let TLS_RSA_WITH_AES_128_CBC_SHA                    = NIOTLSCipher(rawValue: 0x2F)
+    public static let TLS_RSA_WITH_AES_256_CBC_SHA                    = NIOTLSCipher(rawValue: 0x35)
+    public static let TLS_RSA_WITH_AES_128_GCM_SHA256                 = NIOTLSCipher(rawValue: 0x9C)
+    public static let TLS_RSA_WITH_AES_256_GCM_SHA384                 = NIOTLSCipher(rawValue: 0x9D)
+    public static let TLS_AES_128_GCM_SHA256                          = NIOTLSCipher(rawValue: 0x1301)
+    public static let TLS_AES_256_GCM_SHA384                          = NIOTLSCipher(rawValue: 0x1302)
+    public static let TLS_CHACHA20_POLY1305_SHA256                    = NIOTLSCipher(rawValue: 0x1303)
+    public static let TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA            = NIOTLSCipher(rawValue: 0xC009)
+    public static let TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA            = NIOTLSCipher(rawValue: 0xC00A)
+    public static let TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA              = NIOTLSCipher(rawValue: 0xC013)
+    public static let TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA              = NIOTLSCipher(rawValue: 0xC014)
+    public static let TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256         = NIOTLSCipher(rawValue: 0xC02B)
+    public static let TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384         = NIOTLSCipher(rawValue: 0xC02C)
+    public static let TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           = NIOTLSCipher(rawValue: 0xC02F)
+    public static let TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384           = NIOTLSCipher(rawValue: 0xC030)
+    public static let TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     = NIOTLSCipher(rawValue: 0xCCA8)
+    public static let TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256   = NIOTLSCipher(rawValue: 0xCCA9)
+    
+    var standardName: String {
+        get {
+            let boringSSLCipher = CNIOBoringSSL_SSL_get_cipher_by_value(self.rawValue)
+            return String(cString: CNIOBoringSSL_SSL_CIPHER_standard_name(boringSSLCipher))
+        }
+    }
+}
+
 /// Formats NIOSSL supports for serializing keys and certificates.
 public enum NIOSSLSerializationFormats {
     case pem
@@ -200,7 +239,21 @@ public struct TLSConfiguration {
 
     /// The pre-TLS1.3 cipher suites supported by this handler. This uses the OpenSSL cipher string format.
     /// TLS 1.3 cipher suites cannot be configured.
-    public var cipherSuites: String
+    public var cipherSuites: String = defaultCipherSuites
+    
+    /// Public property used to set the internal cipherSuiteFormattedString from NIOTLSCipher.
+    public var cipherSuite: [NIOTLSCipher] {
+        get {
+            guard let sslConext = try? NIOSSLContext(configuration: self) else {
+                return []
+            }
+            return sslConext.cipherSuites
+        }
+        set {
+            let assignedCiphers = newValue.map { $0.standardName }
+            cipherSuites = assignedCiphers.joined(separator: ":")
+        }
+    }
 
     /// Allowed algorithms to verify signatures. Passing nil means, that a built-in set of algorithms will be used.
     public var verifySignatureAlgorithms : [SignatureAlgorithm]?
@@ -281,6 +334,70 @@ public struct TLSConfiguration {
         self.renegotiationSupport = renegotiationSupport
         self.applicationProtocols = applicationProtocols
         self.keyLogCallback = keyLogCallback
+    }
+    
+    private init(cipherSuites: [NIOTLSCipher],
+                 verifySignatureAlgorithms: [SignatureAlgorithm]?,
+                 signingSignatureAlgorithms: [SignatureAlgorithm]?,
+                 minimumTLSVersion: TLSVersion,
+                 maximumTLSVersion: TLSVersion?,
+                 certificateVerification: CertificateVerification,
+                 trustRoots: NIOSSLTrustRoots,
+                 certificateChain: [NIOSSLCertificateSource],
+                 privateKey: NIOSSLPrivateKeySource?,
+                 applicationProtocols: [String],
+                 shutdownTimeout: TimeAmount,
+                 keyLogCallback: NIOSSLKeyLogCallback?,
+                 renegotiationSupport: NIORenegotiationSupport,
+                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots]) {
+        self.verifySignatureAlgorithms = verifySignatureAlgorithms
+        self.signingSignatureAlgorithms = signingSignatureAlgorithms
+        self.minimumTLSVersion = minimumTLSVersion
+        self.maximumTLSVersion = maximumTLSVersion
+        self.certificateVerification = certificateVerification
+        self.trustRoots = trustRoots
+        self.additionalTrustRoots = additionalTrustRoots
+        self.certificateChain = certificateChain
+        self.privateKey = privateKey
+        self.encodedApplicationProtocols = []
+        self.shutdownTimeout = shutdownTimeout
+        self.renegotiationSupport = renegotiationSupport
+        self.applicationProtocols = applicationProtocols
+        self.keyLogCallback = keyLogCallback
+        self.cipherSuite = cipherSuites
+    }
+    
+    /// Create a TLS configuration for use with server-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `forClient` instead.
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: [NIOTLSCipher],
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: additionalTrustRoots)
     }
 
     /// Create a TLS configuration for use with server-side contexts.
@@ -375,6 +492,40 @@ public struct TLSConfiguration {
                                 shutdownTimeout: shutdownTimeout,
                                 keyLogCallback: keyLogCallback,
                                 renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: additionalTrustRoots)
+    }
+    
+    /// Creates a TLS configuration for use with client-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `forServer` instead.
+    public static func forClient(cipherSuites: [NIOTLSCipher],
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport = .none,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport,
                                 additionalTrustRoots: additionalTrustRoots)
     }
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -46,6 +46,15 @@ extension TLSConfigurationTest {
                 ("testTheSameHashValue", testTheSameHashValue),
                 ("testDifferentHashValues", testDifferentHashValues),
                 ("testDifferentCallbacksNotEqual", testDifferentCallbacksNotEqual),
+                ("testCompatibleCipherSuite", testCompatibleCipherSuite),
+                ("testNonCompatibleCipherSuite", testNonCompatibleCipherSuite),
+                ("testDefaultWithRSACipherSuite", testDefaultWithRSACipherSuite),
+                ("testDefaultWithECDHERSACipherSuite", testDefaultWithECDHERSACipherSuite),
+                ("testStringBasedCipherSuite", testStringBasedCipherSuite),
+                ("testMultipleCompatibleCipherSuites", testMultipleCompatibleCipherSuites),
+                ("testMultipleCompatibleCipherSuitesWithStringBasedCipher", testMultipleCompatibleCipherSuitesWithStringBasedCipher),
+                ("testMultipleClientCipherSuitesWithDefaultCipher", testMultipleClientCipherSuitesWithDefaultCipher),
+                ("testNonCompatibleClientCiphersWithServerStringBasedCiphers", testNonCompatibleClientCiphersWithServerStringBasedCiphers),
            ]
    }
 }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -269,12 +269,12 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testNonOverlappingCipherSuitesPreTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES128",
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA],
                                                       maximumTLSVersion: .tlsv12,
                                                       trustRoots: .certificates([TLSConfigurationTest.cert1]))
         let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
                                                       privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: "AES256",
+                                                      cipherSuites: [.TLS_RSA_WITH_AES_256_CBC_SHA],
                                                       maximumTLSVersion: .tlsv12)
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
@@ -410,6 +410,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func testMutualValidationSuccessWithDefaultAndAdditionalTrustRoots() throws {
         let clientConfig = TLSConfiguration.forClient(
+            cipherSuites: defaultCipherSuites,
             certificateVerification:.noHostnameVerification,
             trustRoots: .default,
             renegotiationSupport: .none,
@@ -418,6 +419,7 @@ class TLSConfigurationTest: XCTestCase {
         let serverConfig = TLSConfiguration.forServer(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1),
+            cipherSuites: defaultCipherSuites,
             trustRoots: .default,
             additionalTrustRoots: [.certificates([TLSConfigurationTest.cert2])])
 
@@ -426,6 +428,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func testMutualValidationSuccessWithOnlyAdditionalTrustRoots() throws {
         let clientConfig = TLSConfiguration.forClient(
+            cipherSuites: defaultCipherSuites,
             certificateVerification:.noHostnameVerification,
             trustRoots: .certificates([]),
             renegotiationSupport: .none,
@@ -434,6 +437,7 @@ class TLSConfigurationTest: XCTestCase {
         let serverConfig = TLSConfiguration.forServer(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1),
+            cipherSuites: defaultCipherSuites,
             trustRoots: .certificates([]),
             additionalTrustRoots: [.certificates([TLSConfigurationTest.cert2])])
 
@@ -518,5 +522,161 @@ class TLSConfigurationTest: XCTestCase {
         let config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"], keyLogCallback: { _ in })
         let differentConfig = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"], keyLogCallback: { _ in })
         XCTAssertFalse(config.bestEffortEquals(differentConfig))
+    }
+    
+    func testCompatibleCipherSuite() throws {
+        // ECDHE_RSA is used here because the public key in .cert1 is derived from a RSA private key.
+        // These could also be RSA based, but cannot be ECDHE_ECDSA.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testNonCompatibleCipherSuite() throws {
+        // This test fails more importantly because ECDHE_ECDSA is being set with a public key that is RSA based.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: [.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
+    }
+    
+    func testDefaultWithRSACipherSuite() throws {
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: defaultCipherSuites,
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testDefaultWithECDHERSACipherSuite() throws {
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: defaultCipherSuites,
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testStringBasedCipherSuite() throws {
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES256",
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: "AES256",
+                                                      maximumTLSVersion: .tlsv12)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testMultipleCompatibleCipherSuites() throws {
+        // This test is for multiple ECDHE_RSA based ciphers on the server side.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                                                                .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testMultipleCompatibleCipherSuitesWithStringBasedCipher() throws {
+        // This test is for using multiple server side ciphers with the client side string based cipher.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES256",
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                                                .TLS_RSA_WITH_AES_256_CBC_SHA,
+                                                                .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                                                                .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testMultipleClientCipherSuitesWithDefaultCipher() throws {
+        // Client ciphers should match one of the default ciphers.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                                                .TLS_RSA_WITH_AES_256_CBC_SHA,
+                                                                .TLS_RSA_WITH_AES_128_GCM_SHA256,
+                                                                .TLS_RSA_WITH_AES_256_GCM_SHA384,
+                                                                .TLS_AES_128_GCM_SHA256,
+                                                                .TLS_AES_256_GCM_SHA384,
+                                                                .TLS_CHACHA20_POLY1305_SHA256,
+                                                                .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+                                                                .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+                                                                .TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                                                                .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: defaultCipherSuites,
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .none)
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    
+    func testNonCompatibleClientCiphersWithServerStringBasedCiphers() throws {
+        // This test should fail on client hello negotiation.
+        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_AES_128_GCM_SHA256,
+                                                                .TLS_AES_256_GCM_SHA384,
+                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
+                                                      maximumTLSVersion: .tlsv12,
+                                                      certificateVerification: .noHostnameVerification,
+                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
+                                                      renegotiationSupport: .none)
+        
+        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
+                                                      cipherSuites: "AES256",
+                                                      maximumTLSVersion: .tlsv12)
+        try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
     }
 }


### PR DESCRIPTION
Motivation:

Issue-207 for adding an API for setting a cipher suite while also preserving the string based declaration.
Additions to TLSConfiguration and SSLContext to allow safe access to ciphers on a context.

Modifications:

Additions to TLSConfiguration and SSLContext to allow safe access to ciphers on a context.
Added test cases in TLSConfigurationTest.

Result:

Additional API for Issue-207.
Simplified and safer access to STACK_OF(SSL_CIPHER) on a context.

Rebased from (https://github.com/apple/swift-nio-ssl/pull/290)