### PR TITLE
Explicit `time_t` import

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -20,6 +20,11 @@ import CNIOBoringSSL
 import CNIOBoringSSLShims
 #endif
 import NIO
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import struct Darwin.time_t
+#elseif canImport(Glibc)
+import struct Glibc.time_t
+#endif
 
 /// A reference to a BoringSSL Certificate object (`X509 *`).
 ///


### PR DESCRIPTION
W/o this `time_t` is only available as an implicit import via `CNIOBoringSSL`, which is `@_implementionOnly`.

The issue popped up in `swift-lambda`: https://github.com/SwiftXcode/swift-lambda/issues/6

I suspect it is due to slightly different import ordering (which makes the compiler pickup the alias). It probably is not specific to SPMDestinations, the import order is just undefined?