### PR TITLE
Clean up new hashable implementation.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
 MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.15.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.19.0"),
     ],
     targets: [
         .target(name: "CNIOBoringSSL"),

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -73,7 +73,7 @@ public enum NIOSSLTrustRoots: Hashable {
 }
 
 /// Places NIOSSL can obtain additional trust roots from.
-public enum NIOSSLAdditionalTrustRoots {
+public enum NIOSSLAdditionalTrustRoots: Hashable {
     /// See `NIOSSLTrustRoots.file`
     case file(String)
 
@@ -651,9 +651,9 @@ extension TLSConfiguration {
             self.signingSignatureAlgorithms == comparing.signingSignatureAlgorithms &&
             self.certificateVerification == comparing.certificateVerification &&
             self.trustRoots == comparing.trustRoots &&
+            self.additionalTrustRoots == comparing.additionalTrustRoots &&
             self.certificateChain == comparing.certificateChain &&
             self.privateKey == comparing.privateKey &&
-            self.applicationProtocols == comparing.applicationProtocols &&
             self.encodedApplicationProtocols == comparing.encodedApplicationProtocols &&
             self.shutdownTimeout == comparing.shutdownTimeout &&
             isKeyLoggerCallbacksEqual &&
@@ -673,9 +673,9 @@ extension TLSConfiguration {
         hasher.combine(signingSignatureAlgorithms)
         hasher.combine(certificateVerification)
         hasher.combine(trustRoots)
+        hasher.combine(additionalTrustRoots)
         hasher.combine(certificateChain)
         hasher.combine(privateKey)
-        hasher.combine(applicationProtocols)
         hasher.combine(encodedApplicationProtocols)
         hasher.combine(shutdownTimeout)
         withUnsafeBytes(of: keyLogCallback) { closureBits in

--- a/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest+XCTest.swift
@@ -58,6 +58,7 @@ extension TLSConfigurationTest {
                 ("testSettingCiphersWithCipherSuiteValues", testSettingCiphersWithCipherSuiteValues),
                 ("testSettingCiphersWithCipherSuitesString", testSettingCiphersWithCipherSuitesString),
                 ("testDefaultCipherSuiteValues", testDefaultCipherSuiteValues),
+                ("testBestEffortEquatableHashableDifferences", testBestEffortEquatableHashableDifferences),
            ]
    }
 }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -714,4 +714,45 @@ class TLSConfigurationTest: XCTestCase {
         // Note that this includes the PSK values as well.
         XCTAssertEqual(defaultCipherSuiteValuesFromString, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA:TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA:TLS_RSA_WITH_AES_128_GCM_SHA256:TLS_RSA_WITH_AES_256_GCM_SHA384:TLS_RSA_WITH_AES_128_CBC_SHA:TLS_RSA_WITH_AES_256_CBC_SHA")
     }
+
+    func testBestEffortEquatableHashableDifferences() {
+        let first = TLSConfiguration.forClient()
+
+        let transforms: [(inout TLSConfiguration) -> Void] = [
+            { $0.minimumTLSVersion = .tlsv13 },
+            { $0.maximumTLSVersion = .tlsv12 },
+            { $0.cipherSuites = "AES" },
+            { $0.cipherSuiteValues = [.TLS_RSA_WITH_AES_256_CBC_SHA] },
+            { $0.verifySignatureAlgorithms = [.ed25519] },
+            { $0.signingSignatureAlgorithms = [.ed25519] },
+            { $0.certificateVerification = .noHostnameVerification },
+            { $0.trustRoots = .certificates([TLSConfigurationTest.cert1]) },
+            { $0.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert1])] },
+            { $0.certificateChain = [.certificate(TLSConfigurationTest.cert1)] },
+            { $0.privateKey = .privateKey(TLSConfigurationTest.key1) },
+            { $0.applicationProtocols = ["h2"] },
+            { $0.shutdownTimeout = .seconds((60 * 24 * 24) + 1) },
+            { $0.keyLogCallback = { _ in } },
+            { $0.renegotiationSupport = .always },
+        ]
+
+        for (index, transform) in transforms.enumerated() {
+            var transformed = first
+            transform(&transformed)
+            XCTAssertNotEqual(Wrapper(config: first), Wrapper(config: transformed), "Should have compared not equal in index \(index)")
+            XCTAssertEqual(Set([Wrapper(config: first), Wrapper(config: transformed)]).count, 2, "Should have hashed non-equal in index \(index)")
+        }
+    }
+}
+
+struct Wrapper: Hashable {
+    var config: TLSConfiguration
+
+    static func ==(lhs: Wrapper, rhs: Wrapper) -> Bool {
+        return lhs.config.bestEffortEquals(rhs.config)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        self.config.bestEffortHash(into: &hasher)
+    }
 }


### PR DESCRIPTION
Motivation:

The new hashable implementation was missing some fields. I've added
them, and added testing. It also needed to raise the minimum NIO
version.

Modifications:

- Raised the minimum NIO version.
- Fixed the comparison.
- Added fields.

Result:

The code is right. Fixes #296. Fixes #297.