### PR TITLE
Rationalise TLSConfiguration construction.

### DIFF
--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_many_writes.swift
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_many_writes.swift
@@ -16,12 +16,18 @@ import NIO
 import NIOSSL
 
 func run(identifier: String) {
-    let serverContext = try! NIOSSLContext(configuration: .forServer(certificateChain: [.certificate(.forTesting())], privateKey: .privateKey(.forTesting())))
-    let clientContext = try! NIOSSLContext(configuration: .forClient(trustRoots: .certificates([.forTesting()])))
+    let serverContext = try! NIOSSLContext(configuration: .makeServerConfiguration(
+        certificateChain: [.certificate(.forTesting())],
+        privateKey: .privateKey(.forTesting())
+    ))
+
+    var clientConfig = TLSConfiguration.makeClientConfiguration()
+    clientConfig.trustRoots = try! .certificates([.forTesting()])
+    let clientContext = try! NIOSSLContext(configuration: clientConfig)
 
     let dummyAddress = try! SocketAddress(ipAddress: "1.2.3.4", port: 5678)
     let backToBack = BackToBackEmbeddedChannel()
-    let serverHandler = try! NIOSSLServerHandler(context: serverContext)
+    let serverHandler = NIOSSLServerHandler(context: serverContext)
     let clientHandler = try! NIOSSLClientHandler(context: clientContext, serverHostname: "localhost")
     try! backToBack.client.pipeline.addHandler(clientHandler).wait()
     try! backToBack.server.pipeline.addHandler(serverHandler).wait()

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ To secure a server connection, you will need a X.509 certificate chain in a file
 For example:
 
 ```swift
-let configuration = TLSConfiguration.forServer(certificateChain: try NIOSSLCertificate.fromPEMFile("cert.pem").map { .certificate($0) },
-                                               privateKey: .file("key.pem"))
+let configuration = TLSConfiguration.makeServerConfiguration(
+    certificateChain: try NIOSSLCertificate.fromPEMFile("cert.pem").map { .certificate($0) },
+    privateKey: .file("key.pem")
+)
 let sslContext = try NIOSSLContext(configuration: configuration)
 
 let server = ServerBootstrap(group: group)
@@ -35,7 +37,7 @@ let server = ServerBootstrap(group: group)
 For clients, it is a bit simpler as there is no need to have a certificate chain or private key (though clients *may* have these things). Setup for clients may be done like this:
 
 ```swift
-let configuration = TLSConfiguration.forClient()
+let configuration = TLSConfiguration.makeClientConfiguration()
 let sslContext = try NIOSSLContext(configuration: configuration)
 
 let client = ClientBootstrap(group: group)

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -37,8 +37,10 @@ import NIO
 /// If you have a PKCS12 bundle, you configure a `TLSConfiguration` like this:
 ///
 ///     let p12Bundle = NIOSSLPKCS12Bundle(file: pathToMyP12)
-///     let config = TLSConfiguration.forServer(certificateChain: p12Bundle.certificateChain,
-///                                             privateKey: p12Bundle.privateKey)
+///     let config = TLSConfiguration.makeServerConfiguration(
+///         certificateChain: p12Bundle.certificateChain,
+///         privateKey: p12Bundle.privateKey
+///     )
 ///
 /// The created `TLSConfiguration` can then be safely used for your endpoint.
 public struct NIOSSLPKCS12Bundle {

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -227,7 +227,7 @@ internal func decodeALPNIdentifier(identifier: [UInt8]) -> String {
 /// Manages configuration of TLS for SwiftNIO programs.
 public struct TLSConfiguration {
     /// A default TLS configuration for client use.
-    public static let clientDefault = TLSConfiguration.forClient()
+    public static let clientDefault = TLSConfiguration.makeClientConfiguration()
 
     /// The minimum TLS version to allow in negotiation. Defaults to tlsv1.
     public var minimumTLSVersion: TLSVersion
@@ -337,297 +337,6 @@ public struct TLSConfiguration {
             self.cipherSuiteValues = cipherSuiteValues
         }
     }
-    
-    /// Create a TLS configuration for use with server-side contexts. This allows setting the `NIOTLSCipher` property specifically.
-    ///
-    /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `forClient` instead.
-    public static func forServer(certificateChain: [NIOSSLCertificateSource],
-                                 privateKey: NIOSSLPrivateKeySource,
-                                 cipherSuites: [NIOTLSCipher],
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .none,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuiteValues: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
-                                additionalTrustRoots: additionalTrustRoots)
-    }
-
-    /// Create a TLS configuration for use with server-side contexts.
-    ///
-    /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `forClient` instead.
-    public static func forServer(certificateChain: [NIOSSLCertificateSource],
-                                 privateKey: NIOSSLPrivateKeySource,
-                                 cipherSuites: String = defaultCipherSuites,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .none,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: nil,
-                                signingSignatureAlgorithms: nil,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
-                                additionalTrustRoots: [])
-    }
-
-    /// Create a TLS configuration for use with server-side contexts.
-    ///
-    /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `forClient` instead.
-    public static func forServer(certificateChain: [NIOSSLCertificateSource],
-                                 privateKey: NIOSSLPrivateKeySource,
-                                 cipherSuites: String = defaultCipherSuites,
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .none,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
-                                additionalTrustRoots: [])
-    }
-
-    /// Create a TLS configuration for use with server-side contexts.
-    ///
-    /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `forClient` instead.
-    public static func forServer(certificateChain: [NIOSSLCertificateSource],
-                                 privateKey: NIOSSLPrivateKeySource,
-                                 cipherSuites: String = defaultCipherSuites,
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .none,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots]) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
-                                additionalTrustRoots: additionalTrustRoots)
-    }
-    
-    /// Creates a TLS configuration for use with client-side contexts. This allows setting the `NIOTLSCipher` property specifically.
-    ///
-    /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `forServer` instead.
-    public static func forClient(cipherSuites: [NIOTLSCipher],
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .fullVerification,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 certificateChain: [NIOSSLCertificateSource] = [],
-                                 privateKey: NIOSSLPrivateKeySource? = nil,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 renegotiationSupport: NIORenegotiationSupport = .none,
-                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuiteValues: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: renegotiationSupport,
-                                additionalTrustRoots: additionalTrustRoots)
-    }
-
-    /// Creates a TLS configuration for use with client-side contexts.
-    ///
-    /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `forServer` instead.
-    public static func forClient(cipherSuites: String = defaultCipherSuites,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .fullVerification,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 certificateChain: [NIOSSLCertificateSource] = [],
-                                 privateKey: NIOSSLPrivateKeySource? = nil,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: nil,
-                                signingSignatureAlgorithms: nil,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: .none,  // Default value is here for backward-compatibility.
-                                additionalTrustRoots: [])
-    }
-
-
-    /// Creates a TLS configuration for use with client-side contexts.
-    ///
-    /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `forServer` instead.
-    public static func forClient(cipherSuites: String = defaultCipherSuites,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .fullVerification,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 certificateChain: [NIOSSLCertificateSource] = [],
-                                 privateKey: NIOSSLPrivateKeySource? = nil,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 renegotiationSupport: NIORenegotiationSupport) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: nil,
-                                signingSignatureAlgorithms: nil,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: renegotiationSupport,
-                                additionalTrustRoots: [])
-    }
-    
-    /// Creates a TLS configuration for use with client-side contexts.
-    ///
-    /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `forServer` instead.
-    public static func forClient(cipherSuites: String = defaultCipherSuites,
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .fullVerification,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 certificateChain: [NIOSSLCertificateSource] = [],
-                                 privateKey: NIOSSLPrivateKeySource? = nil,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 renegotiationSupport: NIORenegotiationSupport) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: renegotiationSupport,
-                                additionalTrustRoots: [])
-    }
-
-    /// Creates a TLS configuration for use with client-side contexts.
-    ///
-    /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `forServer` instead.
-    public static func forClient(cipherSuites: String = defaultCipherSuites,
-                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
-                                 minimumTLSVersion: TLSVersion = .tlsv1,
-                                 maximumTLSVersion: TLSVersion? = nil,
-                                 certificateVerification: CertificateVerification = .fullVerification,
-                                 trustRoots: NIOSSLTrustRoots = .default,
-                                 certificateChain: [NIOSSLCertificateSource] = [],
-                                 privateKey: NIOSSLPrivateKeySource? = nil,
-                                 applicationProtocols: [String] = [],
-                                 shutdownTimeout: TimeAmount = .seconds(5),
-                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
-                                 renegotiationSupport: NIORenegotiationSupport = .none,
-                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots]) -> TLSConfiguration {
-        return TLSConfiguration(cipherSuites: cipherSuites,
-                                verifySignatureAlgorithms: verifySignatureAlgorithms,
-                                signingSignatureAlgorithms: signingSignatureAlgorithms,
-                                minimumTLSVersion: minimumTLSVersion,
-                                maximumTLSVersion: maximumTLSVersion,
-                                certificateVerification: certificateVerification,
-                                trustRoots: trustRoots,
-                                certificateChain: certificateChain,
-                                privateKey: privateKey,
-                                applicationProtocols: applicationProtocols,
-                                shutdownTimeout: shutdownTimeout,
-                                keyLogCallback: keyLogCallback,
-                                renegotiationSupport: renegotiationSupport,
-                                additionalTrustRoots: additionalTrustRoots)
-    }
 }
 
 // MARK: BestEffortHashable
@@ -682,5 +391,358 @@ extension TLSConfiguration {
             hasher.combine(bytes: closureBits)
         }
         hasher.combine(renegotiationSupport)
+    }
+
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    ///
+    /// For customising fields, modify the returned TLSConfiguration object.
+    public static func makeClientConfiguration() -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: defaultCipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: .tlsv1,
+                                maximumTLSVersion: nil,
+                                certificateVerification: .fullVerification,
+                                trustRoots: .default,
+                                certificateChain: [],
+                                privateKey: nil,
+                                applicationProtocols: [],
+                                shutdownTimeout: .seconds(5),
+                                keyLogCallback: nil,
+                                renegotiationSupport: .none,
+                                additionalTrustRoots: [])
+    }
+
+    /// Create a TLS configuration for use with server-side contexts.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    ///
+    /// For customising fields, modify the returned TLSConfiguration object.
+    public static func makeServerConfiguration(
+        certificateChain: [NIOSSLCertificateSource],
+        privateKey: NIOSSLPrivateKeySource
+    ) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: defaultCipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: .tlsv1,
+                                maximumTLSVersion: nil,
+                                certificateVerification: .none,
+                                trustRoots: .default,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: [],
+                                shutdownTimeout: .seconds(5),
+                                keyLogCallback: nil,
+                                renegotiationSupport: .none,
+                                additionalTrustRoots: [])
+    }
+}
+
+// MARK: Deprecated constructors.
+
+extension TLSConfiguration {
+    /// Create a TLS configuration for use with server-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: [NIOTLSCipher],
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuiteValues: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: additionalTrustRoots)
+    }
+
+    /// Create a TLS configuration for use with server-side contexts.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: String = defaultCipherSuites,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: [])
+    }
+
+    /// Create a TLS configuration for use with server-side contexts.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: String = defaultCipherSuites,
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: [])
+    }
+
+    /// Create a TLS configuration for use with server-side contexts.
+    ///
+    /// This provides sensible defaults while requiring that you provide any data that is necessary
+    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
+    public static func forServer(certificateChain: [NIOSSLCertificateSource],
+                                 privateKey: NIOSSLPrivateKeySource,
+                                 cipherSuites: String = defaultCipherSuites,
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .none,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots]) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Servers never support renegotiation: there's no point.
+                                additionalTrustRoots: additionalTrustRoots)
+    }
+
+    /// Creates a TLS configuration for use with client-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    @available(*, deprecated, renamed: "makeClientConfiguration()")
+    public static func forClient(cipherSuites: [NIOTLSCipher],
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport = .none,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots] = []) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuiteValues: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport,
+                                additionalTrustRoots: additionalTrustRoots)
+    }
+
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    @available(*, deprecated, renamed: "makeClientConfiguration()")
+    public static func forClient(cipherSuites: String = defaultCipherSuites,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: .none,  // Default value is here for backward-compatibility.
+                                additionalTrustRoots: [])
+    }
+
+
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    @available(*, deprecated, renamed: "makeClientConfiguration()")
+    public static func forClient(cipherSuites: String = defaultCipherSuites,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: nil,
+                                signingSignatureAlgorithms: nil,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport,
+                                additionalTrustRoots: [])
+    }
+
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    @available(*, deprecated, renamed: "makeClientConfiguration()")
+    public static func forClient(cipherSuites: String = defaultCipherSuites,
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport,
+                                additionalTrustRoots: [])
+    }
+
+    /// Creates a TLS configuration for use with client-side contexts.
+    ///
+    /// This provides sensible defaults, and can be used without customisation. For server-side
+    /// contexts, you should use `makeServerConfiguration` instead.
+    @available(*, deprecated, renamed: "makeClientConfiguration()")
+    public static func forClient(cipherSuites: String = defaultCipherSuites,
+                                 verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 signingSignatureAlgorithms: [SignatureAlgorithm]? = nil,
+                                 minimumTLSVersion: TLSVersion = .tlsv1,
+                                 maximumTLSVersion: TLSVersion? = nil,
+                                 certificateVerification: CertificateVerification = .fullVerification,
+                                 trustRoots: NIOSSLTrustRoots = .default,
+                                 certificateChain: [NIOSSLCertificateSource] = [],
+                                 privateKey: NIOSSLPrivateKeySource? = nil,
+                                 applicationProtocols: [String] = [],
+                                 shutdownTimeout: TimeAmount = .seconds(5),
+                                 keyLogCallback: NIOSSLKeyLogCallback? = nil,
+                                 renegotiationSupport: NIORenegotiationSupport = .none,
+                                 additionalTrustRoots: [NIOSSLAdditionalTrustRoots]) -> TLSConfiguration {
+        return TLSConfiguration(cipherSuites: cipherSuites,
+                                verifySignatureAlgorithms: verifySignatureAlgorithms,
+                                signingSignatureAlgorithms: signingSignatureAlgorithms,
+                                minimumTLSVersion: minimumTLSVersion,
+                                maximumTLSVersion: maximumTLSVersion,
+                                certificateVerification: certificateVerification,
+                                trustRoots: trustRoots,
+                                certificateChain: certificateChain,
+                                privateKey: privateKey,
+                                applicationProtocols: applicationProtocols,
+                                shutdownTimeout: shutdownTimeout,
+                                keyLogCallback: keyLogCallback,
+                                renegotiationSupport: renegotiationSupport,
+                                additionalTrustRoots: additionalTrustRoots)
     }
 }

--- a/Sources/NIOSSL/UniversalBootstrapSupport.swift
+++ b/Sources/NIOSSL/UniversalBootstrapSupport.swift
@@ -19,7 +19,7 @@ import NIO
 /// Example:
 ///
 ///     // TLS setup.
-///     let configuration = TLSConfiguration.forClient()
+///     let configuration = TLSConfiguration.makeClientConfiguration()
 ///     let sslContext = try NIOSSLContext(configuration: configuration)
 ///
 ///     // Creating the "universal bootstrap" with the `NIOSSLClientTLSProvider`.

--- a/Sources/NIOSSLHTTP1Client/main.swift
+++ b/Sources/NIOSSLHTTP1Client/main.swift
@@ -94,7 +94,12 @@ defer {
     try! eventLoopGroup.syncShutdownGracefully()
 }
 
-let tlsConfiguration = TLSConfiguration.forClient(trustRoots: trustRoot, certificateChain: cert, privateKey: key, renegotiationSupport: .once)
+var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+tlsConfiguration.trustRoots = trustRoot
+tlsConfiguration.certificateChain = cert
+tlsConfiguration.privateKey = key
+tlsConfiguration.renegotiationSupport = .once
+
 let sslContext = try! NIOSSLContext(configuration: tlsConfiguration)
 
 let bootstrap = ClientBootstrap(group: eventLoopGroup)

--- a/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
@@ -27,8 +27,15 @@ final class BenchManyWrites: Benchmark {
     init(loopCount: Int, writeSizeInBytes writeSize: Int) throws {
         self.loopCount = loopCount
         self.writeSize = writeSize
-        self.serverContext = try NIOSSLContext(configuration: .forServer(certificateChain: [.certificate(.forTesting())], privateKey: .privateKey(.forTesting())))
-        self.clientContext = try NIOSSLContext(configuration: .forClient(trustRoots: .certificates([.forTesting()])))
+        self.serverContext = try NIOSSLContext(configuration: .makeServerConfiguration(
+            certificateChain: [.certificate(.forTesting())],
+            privateKey: .privateKey(.forTesting())
+        ))
+
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.trustRoots = try .certificates([.forTesting()])
+        self.clientContext = try NIOSSLContext(configuration: clientConfig)
+
         self.dummyAddress = try SocketAddress(ipAddress: "1.2.3.4", port: 5678)
         self.backToBack = BackToBackEmbeddedChannel()
     }

--- a/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
@@ -23,9 +23,15 @@ final class BenchRepeatedHandshakes: Benchmark {
 
     init(loopCount: Int) throws {
         self.loopCount = loopCount
-        self.serverContext = try NIOSSLContext(configuration: .forServer(certificateChain: [.certificate(.forTesting())], privateKey: .privateKey(.forTesting())))
-        self.clientContext = try NIOSSLContext(configuration: .forClient(trustRoots: .certificates([.forTesting()])))
         self.dummyAddress = try SocketAddress(ipAddress: "1.2.3.4", port: 5678)
+        self.serverContext = try NIOSSLContext(configuration: .makeServerConfiguration(
+            certificateChain: [.certificate(.forTesting())],
+            privateKey: .privateKey(.forTesting())
+        ))
+
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.trustRoots = try .certificates([.forTesting()])
+        self.clientContext = try NIOSSLContext(configuration: clientConfig)
     }
 
     func setUp() { }

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -29,7 +29,10 @@ private final class EchoHandler: ChannelInboundHandler {
 }
 
 let certificateChain = try NIOSSLCertificate.fromPEMFile("cert.pem")
-let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.forServer(certificateChain: certificateChain.map { .certificate($0) }, privateKey: .file("key.pem")))
+let sslContext = try! NIOSSLContext(configuration: TLSConfiguration.makeServerConfiguration(
+    certificateChain: certificateChain.map { .certificate($0) },
+    privateKey: .file("key.pem"))
+)
 
 
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/NIOSSLTests/ClientSNITests.swift
+++ b/Tests/NIOSSLTests/ClientSNITests.swift
@@ -30,9 +30,11 @@ class ClientSNITests: XCTestCase {
     }
 
     private func configuredSSLContext() throws -> NIOSSLContext {
-        let config = TLSConfiguration.forServer(certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
-                                                privateKey: .privateKey(NIOSSLIntegrationTest.key),
-                                                trustRoots: .certificates([NIOSSLIntegrationTest.cert]))
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
+            privateKey: .privateKey(NIOSSLIntegrationTest.key)
+        )
+        config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
         let context = try NIOSSLContext(configuration: config)
         return context
     }

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -35,10 +35,12 @@ class NIOSSLALPNTest: XCTestCase {
     }
 
     private func configuredSSLContextWithAlpnProtocols(protocols: [String]) throws -> NIOSSLContext {
-        let config = TLSConfiguration.forServer(certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
-                                                privateKey: .privateKey(NIOSSLIntegrationTest.key),
-                                                trustRoots: .certificates([NIOSSLIntegrationTest.cert]),
-                                                applicationProtocols: protocols)
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
+            privateKey: .privateKey(NIOSSLIntegrationTest.key)
+        )
+        config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
+        config.applicationProtocols = protocols
         return try NIOSSLContext(configuration: config)
     }
 

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
@@ -238,8 +238,10 @@ class SSLPrivateKeyTest: XCTestCase {
     }
 
     func testMissingPassword() {
-        let configuration = TLSConfiguration.forServer(certificateChain: [],
-                                                       privateKey: .file(SSLPrivateKeyTest.passwordPemKeyFilePath))
+        let configuration = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [],
+            privateKey: .file(SSLPrivateKeyTest.passwordPemKeyFilePath)
+        )
 
         XCTAssertThrowsError(try NIOSSLContext(configuration: configuration)) { error in
             XCTAssertEqual(.failedToLoadPrivateKey, error as? NIOSSLError)

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -275,8 +275,6 @@ class TLSConfigurationTest: XCTestCase {
         clientConfig.cipherSuiteValues = [.TLS_RSA_WITH_AES_128_CBC_SHA]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
-
-
         var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -259,9 +259,11 @@ class TLSConfigurationTest: XCTestCase {
         var clientConfig = TLSConfiguration.clientDefault
         clientConfig.minimumTLSVersion = .tlsv11
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      maximumTLSVersion: .tlsv1)
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.maximumTLSVersion = .tlsv1
 
         try assertHandshakeError(withClientConfig: clientConfig,
                                  andServerConfig: serverConfig,
@@ -269,139 +271,162 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testNonOverlappingCipherSuitesPreTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: [.TLS_RSA_WITH_AES_256_CBC_SHA],
-                                                      maximumTLSVersion: .tlsv12)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_RSA_WITH_AES_128_CBC_SHA]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuiteValues = [.TLS_RSA_WITH_AES_256_CBC_SHA]
+        serverConfig.maximumTLSVersion = .tlsv12
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
     }
 
     func testCannotVerifySelfSigned() throws {
-        let clientConfig = TLSConfiguration.forClient()
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1))
+        let clientConfig = TLSConfiguration.makeClientConfiguration()
+        let serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "CERTIFICATE_VERIFY_FAILED")
     }
 
     func testServerCannotValidateClientPreTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(maximumTLSVersion: .tlsv12,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key2))
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.certificateChain = [.certificate(TLSConfigurationTest.cert2)]
+        clientConfig.privateKey = .privateKey(TLSConfigurationTest.key2)
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .noHostnameVerification
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["ALERT_UNKNOWN_CA", "ALERT_CERTIFICATE_UNKNOWN"])
     }
 
     func testServerCannotValidateClientPostTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(minimumTLSVersion: .tlsv13,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key2))
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      minimumTLSVersion: .tlsv13,
-                                                      certificateVerification: .noHostnameVerification)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.certificateChain = [.certificate(TLSConfigurationTest.cert2)]
+        clientConfig.privateKey = .privateKey(TLSConfigurationTest.key2)
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .noHostnameVerification
 
         try assertPostHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["ALERT_UNKNOWN_CA", "ALERT_CERTIFICATE_UNKNOWN"])
     }
 
     func testMutualValidationRequiresClientCertificatePreTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(maximumTLSVersion: .tlsv12, certificateVerification: .none)
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert2]))
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .noHostnameVerification
+        serverConfig.trustRoots = .certificates([TLSConfigurationTest.cert2])
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["ALERT_HANDSHAKE_FAILURE"])
     }
 
     func testMutualValidationRequiresClientCertificatePostTLS13() throws {
-        let clientConfig = TLSConfiguration.forClient(minimumTLSVersion: .tlsv13, certificateVerification: .none)
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      minimumTLSVersion: .tlsv13,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert2]))
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .noHostnameVerification
+        serverConfig.trustRoots = .certificates([TLSConfigurationTest.cert2])
 
         try assertPostHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["CERTIFICATE_REQUIRED"])
     }
     
     func testIncompatibleSignatures() throws {
-        let clientConfig = TLSConfiguration.forClient(
-            verifySignatureAlgorithms: [.ecdsaSecp384R1Sha384],
-            minimumTLSVersion: .tlsv13,
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([TLSConfigurationTest.cert1]),
-            renegotiationSupport: .none
-        )
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.verifySignatureAlgorithms = [.ecdsaSecp384R1Sha384]
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
 
-        let serverConfig = TLSConfiguration.forServer(
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-            privateKey: .privateKey(TLSConfigurationTest.key1),
-            signingSignatureAlgorithms: [.rsaPssRsaeSha256],
-            minimumTLSVersion: .tlsv13,
-            certificateVerification: .none)
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.signingSignatureAlgorithms = [.rsaPssRsaeSha256]
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .none
 
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
     }
 
     func testCompatibleSignatures() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
 
-        let clientConfig = TLSConfiguration.forClient(
-            minimumTLSVersion: .tlsv13,
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([TLSConfigurationTest.cert1])
-        )
-
-        let serverConfig = TLSConfiguration.forServer(
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-            privateKey: .privateKey(TLSConfigurationTest.key1),
-            signingSignatureAlgorithms:  [.rsaPssRsaeSha256],
-            minimumTLSVersion: .tlsv13,
-            certificateVerification: .none)
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.signingSignatureAlgorithms = [.rsaPssRsaeSha256]
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .none
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
 
     func testMatchingCompatibleSignatures() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.verifySignatureAlgorithms = [.rsaPssRsaeSha256]
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
 
-        let clientConfig = TLSConfiguration.forClient(
-            verifySignatureAlgorithms: [.rsaPssRsaeSha256],
-            minimumTLSVersion: .tlsv13,
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([TLSConfigurationTest.cert1]),
-            renegotiationSupport: .none
-        )
-
-        let serverConfig = TLSConfiguration.forServer(
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-            privateKey: .privateKey(TLSConfigurationTest.key1),
-            signingSignatureAlgorithms: [.rsaPssRsaeSha256],
-            minimumTLSVersion: .tlsv13,
-            certificateVerification: .none)
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.signingSignatureAlgorithms = [.rsaPssRsaeSha256]
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .none
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
 
 
     func testMutualValidationSuccessNoAdditionalTrustRoots() throws {
-        let clientConfig = TLSConfiguration.forClient(
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([TLSConfigurationTest.cert1]),
-            renegotiationSupport: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
 
-        let serverConfig = TLSConfiguration.forServer(
+        let serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1))
 
@@ -409,39 +434,42 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testMutualValidationSuccessWithDefaultAndAdditionalTrustRoots() throws {
-        let clientConfig = TLSConfiguration.forClient(
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .default,
-            renegotiationSupport: .none,
-            additionalTrustRoots: [.certificates([TLSConfigurationTest.cert1])])
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .default
+        clientConfig.renegotiationSupport = .none
+        clientConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert1])]
 
-        let serverConfig = TLSConfiguration.forServer(
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-            privateKey: .privateKey(TLSConfigurationTest.key1),
-            trustRoots: .default,
-            additionalTrustRoots: [.certificates([TLSConfigurationTest.cert2])])
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.trustRoots = .default
+        serverConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert2])]
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
 
     func testMutualValidationSuccessWithOnlyAdditionalTrustRoots() throws {
-        let clientConfig = TLSConfiguration.forClient(
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([]),
-            renegotiationSupport: .none,
-            additionalTrustRoots: [.certificates([TLSConfigurationTest.cert1])])
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([])
+        clientConfig.renegotiationSupport = .none
+        clientConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert1])]
 
-        let serverConfig = TLSConfiguration.forServer(
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-            privateKey: .privateKey(TLSConfigurationTest.key1),
-            trustRoots: .certificates([]),
-            additionalTrustRoots: [.certificates([TLSConfigurationTest.cert2])])
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.trustRoots = .certificates([])
+        serverConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert2])]
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
 
     func testNonexistentFileObject() throws {
-        let clientConfig = TLSConfiguration.forClient(trustRoots: .file("/thispathbetternotexist/bogus.foo"))
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.trustRoots = .file("/thispathbetternotexist/bogus.foo")
 
         XCTAssertThrowsError(try NIOSSLContext(configuration: clientConfig)) {error in
             XCTAssertEqual(.noSuchFilesystemObject, error as? NIOSSLError)
@@ -449,7 +477,8 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testComputedApplicationProtocols() throws {
-        var config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"])
+        var config = TLSConfiguration.makeServerConfiguration(certificateChain: [], privateKey: .file("fake.file"))
+        config.applicationProtocols = ["http/1.1"]
         XCTAssertEqual(config.applicationProtocols, ["http/1.1"])
         XCTAssertEqual(config.encodedApplicationProtocols, [[8, 104, 116, 116, 112, 47, 49, 46, 49]])
         config.applicationProtocols.insert("h2", at: 0)
@@ -498,8 +527,9 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     func testTheSameHashValue() {
-        let config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"])
-        let theSameConfig  = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"])
+        var config = TLSConfiguration.makeServerConfiguration(certificateChain: [], privateKey: .file("fake.file"))
+        config.applicationProtocols = ["http/1.1"]
+        let theSameConfig = config
         var hasher = Hasher()
         var hasher2 = Hasher()
         config.bestEffortHash(into: &hasher)
@@ -509,190 +539,240 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     func testDifferentHashValues() {
-        let config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"])
-        let differentConfig = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake2.file"), applicationProtocols: ["http/1.1"])
+        var config = TLSConfiguration.makeServerConfiguration(certificateChain: [], privateKey: .file("fake.file"))
+        config.applicationProtocols = ["http/1.1"]
+        var differentConfig = config
+        differentConfig.privateKey = .file("fake2.file")
         XCTAssertFalse(config.bestEffortEquals(differentConfig))
     }
     
     func testDifferentCallbacksNotEqual() {
-        let config = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"], keyLogCallback: { _ in })
-        let differentConfig = TLSConfiguration.forServer(certificateChain: [], privateKey: .file("fake.file"), applicationProtocols: ["http/1.1"], keyLogCallback: { _ in })
+        var config = TLSConfiguration.makeServerConfiguration(certificateChain: [], privateKey: .file("fake.file"))
+        config.applicationProtocols = ["http/1.1"]
+        config.keyLogCallback = { _ in }
+        var differentConfig = config
+        differentConfig.keyLogCallback = { _ in }
         XCTAssertFalse(config.bestEffortEquals(differentConfig))
     }
     
     func testCompatibleCipherSuite() throws {
         // ECDHE_RSA is used here because the public key in .cert1 is derived from a RSA private key.
         // These could also be RSA based, but cannot be ECDHE_ECDSA.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
         
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testNonCompatibleCipherSuite() throws {
         // This test fails more importantly because ECDHE_ECDSA is being set with a public key that is RSA based.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: [.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_RSA_WITH_AES_128_GCM_SHA256]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuiteValues = [.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256]
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
     }
     
     func testDefaultWithRSACipherSuite() throws {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: defaultCipherSuites,
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_RSA_WITH_AES_128_GCM_SHA256]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuites = defaultCipherSuites
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testDefaultWithECDHERSACipherSuite() throws {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: defaultCipherSuites,
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuites = defaultCipherSuites
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
+
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testStringBasedCipherSuite() throws {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES256",
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: "AES256",
-                                                      maximumTLSVersion: .tlsv12)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuites = "AES256"
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuites = "AES256"
+        serverConfig.maximumTLSVersion = .tlsv12
+
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testMultipleCompatibleCipherSuites() throws {
         // This test is for multiple ECDHE_RSA based ciphers on the server side.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                                                                .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuiteValues = [
+            .TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ]
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
+
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testMultipleCompatibleCipherSuitesWithStringBasedCipher() throws {
         // This test is for using multiple server side ciphers with the client side string based cipher.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES256",
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA,
-                                                                .TLS_RSA_WITH_AES_256_CBC_SHA,
-                                                                .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                                                                .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuites = "AES256"
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuiteValues = [
+            .TLS_RSA_WITH_AES_128_CBC_SHA,
+            .TLS_RSA_WITH_AES_256_CBC_SHA,
+            .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+        ]
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
+
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testMultipleClientCipherSuitesWithDefaultCipher() throws {
         // Client ciphers should match one of the default ciphers.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_RSA_WITH_AES_128_CBC_SHA,
-                                                                .TLS_RSA_WITH_AES_256_CBC_SHA,
-                                                                .TLS_RSA_WITH_AES_128_GCM_SHA256,
-                                                                .TLS_RSA_WITH_AES_256_GCM_SHA384,
-                                                                .TLS_AES_128_GCM_SHA256,
-                                                                .TLS_AES_256_GCM_SHA384,
-                                                                .TLS_CHACHA20_POLY1305_SHA256,
-                                                                .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-                                                                .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-                                                                .TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-                                                                .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: defaultCipherSuites,
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [
+            .TLS_RSA_WITH_AES_128_CBC_SHA,
+            .TLS_RSA_WITH_AES_256_CBC_SHA,
+            .TLS_RSA_WITH_AES_128_GCM_SHA256,
+            .TLS_RSA_WITH_AES_256_GCM_SHA384,
+            .TLS_AES_128_GCM_SHA256,
+            .TLS_AES_256_GCM_SHA384,
+            .TLS_CHACHA20_POLY1305_SHA256,
+            .TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            .TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+            .TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            .TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuites = defaultCipherSuites
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .none
+
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
     
     func testNonCompatibleClientCiphersWithServerStringBasedCiphers() throws {
         // This test should fail on client hello negotiation.
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_AES_128_GCM_SHA256,
-                                                                .TLS_AES_256_GCM_SHA384,
-                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [
+            .TLS_AES_128_GCM_SHA256,
+            .TLS_AES_256_GCM_SHA384,
+            .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.cipherSuites = "AES256"
+        serverConfig.maximumTLSVersion = .tlsv12
         
-        let serverConfig = TLSConfiguration.forServer(certificateChain: [.certificate(TLSConfigurationTest.cert1)],
-                                                      privateKey: .privateKey(TLSConfigurationTest.key1),
-                                                      cipherSuites: "AES256",
-                                                      maximumTLSVersion: .tlsv12)
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
     }
     
     func testSettingCiphersWithCipherSuiteValues() {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: [.TLS_AES_128_GCM_SHA256,
-                                                                .TLS_AES_256_GCM_SHA384,
-                                                                .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256],
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]),
-                                                      renegotiationSupport: .none)
-        print("clientConfig.cipherSuites: \(clientConfig.cipherSuites)")
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuiteValues = [
+            .TLS_AES_128_GCM_SHA256,
+            .TLS_AES_256_GCM_SHA384,
+            .TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ]
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
+        clientConfig.renegotiationSupport = .none
+
         XCTAssertEqual(clientConfig.cipherSuites, "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
     }
     
     func testSettingCiphersWithCipherSuitesString() {
-        let clientConfig = TLSConfiguration.forClient(cipherSuites: "AES256",
-                                                      maximumTLSVersion: .tlsv12,
-                                                      certificateVerification: .noHostnameVerification,
-                                                      trustRoots: .certificates([TLSConfigurationTest.cert1]))
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.cipherSuites = "AES256"
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
         
         let assignedCiphers = clientConfig.cipherSuiteValues.map { $0.standardName }
         let createdCipherSuiteValuesFromString = assignedCiphers.joined(separator: ":")
@@ -701,12 +781,11 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     func testDefaultCipherSuiteValues() {
-        
-        let clientConfig = TLSConfiguration.forClient(
-            certificateVerification:.noHostnameVerification,
-            trustRoots: .certificates([]),
-            renegotiationSupport: .none,
-            additionalTrustRoots: [.certificates([TLSConfigurationTest.cert1])])
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([])
+        clientConfig.renegotiationSupport = .none
+        clientConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert1])]
         XCTAssertEqual(clientConfig.cipherSuites, defaultCipherSuites)
         
         let assignedCiphers = clientConfig.cipherSuiteValues.map { $0.standardName }
@@ -716,7 +795,7 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testBestEffortEquatableHashableDifferences() {
-        let first = TLSConfiguration.forClient()
+        let first = TLSConfiguration.makeClientConfiguration()
 
         let transforms: [(inout TLSConfiguration) -> Void] = [
             { $0.minimumTLSVersion = .tlsv13 },

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -61,9 +61,11 @@ final class UnwrappingTests: XCTestCase {
     }
 
     private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOSSLContext {
-        let config = TLSConfiguration.forServer(certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
-                                                privateKey: .privateKey(NIOSSLIntegrationTest.key),
-                                                trustRoots: .certificates([NIOSSLIntegrationTest.cert]))
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
+            privateKey: .privateKey(NIOSSLIntegrationTest.key)
+        )
+        config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
         return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
 


### PR DESCRIPTION
Motivation:

Currently whenever we add new config to TLSConfiguration, we add a new
static factory function that needs to provide the field. This is because
we currently allow configuration primarily by way of initializers. This
is increasingly not scaling, leading to a proliferation of almost
identical static factory functions.

We can replace this proliferation by having only "default" constructions
that default basically everything, and then having users use
getters/setters to initialize things. This also works well when we have
multiple ways of interacting with config, e.g. with the various cipher
suite operations.

Modifications:

- Deprecate all existing factory functions.
- Replace with two: forClient() and
  forServer(certificateChain:privateKey:). These configure only the
  mandatory things for each mode.
- Replace all uses of the deprecated initializers with the new ones,
  configuring fields manually as needed.

Result:

More consistent configuration objects.