### PR TITLE
Update NIO dependency to 2.30.0 and later

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
 MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.19.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
     ],
     targets: [
         .target(name: "CNIOBoringSSL"),


### PR DESCRIPTION
NIO 2.30.0 is Swift 5.2 and above only.