### PR TITLE
Fix doc generation and jazzy version (#1950)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,10 +20,9 @@ RUN apt-get update && apt-get install -y execstack
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
-# switch off gem docs building
-RUN echo "gem: --no-document" > ~/.gemrc
 # jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc ; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -39,7 +39,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
   mkdir -p "$root_path/.build/sourcekitten"
   for module in "${modules[@]}"; do
     if [[ ! -f "$root_path/.build/sourcekitten/$module.json" ]]; then
-      "$source_kitten_path/sourcekitten" doc --spm-module $module > "$root_path/.build/sourcekitten/$module.json"
+      "$source_kitten_path/sourcekitten" doc --module-name $module > "$root_path/.build/sourcekitten/$module.json"
     fi
   done
 fi


### PR DESCRIPTION
From: https://github.com/apple/swift-nio-extras/pull/141

Motivation:

The combination of Ruby and Jazzy are throwing up issues in CI on older
Ubuntu versions.

Modifications:

- Only install Jazzy on focal
- Fix doc generation script to use more recent source-kitten syntax

Results:

- CI doesn't complain
- Docs get built