### PR TITLE
Clean up imports and dependencies

### DIFF
--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/run-nio-ssl-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/run-nio-ssl-alloc-counter-tests.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the SwiftNIO open source project
 ##
-## Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+## Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -45,9 +45,11 @@ fi
 
 "$nio_checkout/swift-nio/IntegrationTests/allocation-counter-tests-framework/run-allocation-counter.sh" \
     -p "$here/../../.." \
-    -m NIO \
+    -m NIOCore \
+    -m NIOPosix \
+    -m NIOEmbedded
     -m NIOSSL \
     -s "$here/shared.swift" \
     -t "$tmp_dir" \
-    -d <( echo '.package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),' ) \
+    -d <( echo '.package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),' ) \
     "${tests_to_run[@]}"

--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/run-nio-ssl-alloc-counter-tests.sh
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/run-nio-ssl-alloc-counter-tests.sh
@@ -47,7 +47,7 @@ fi
     -p "$here/../../.." \
     -m NIOCore \
     -m NIOPosix \
-    -m NIOEmbedded
+    -m NIOEmbedded \
     -m NIOSSL \
     -s "$here/shared.swift" \
     -t "$tmp_dir" \

--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/shared.swift
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/shared.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOSSL
 
 class BackToBackEmbeddedChannel {

--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_many_writes.swift
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_many_writes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOSSL
 
 func run(identifier: String) {

--- a/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_simple_handshake.swift
+++ b/IntegrationTests/tests_02_allocation_counters/test_01_resources/test_simple_handshake.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOSSL
 
 func run(identifier: String) {

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
         ]
     } else {
         return [
@@ -69,6 +69,7 @@ MANGLE_END */
                 "CNIOBoringSSL",
                 "CNIOBoringSSLShims",
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
             ]),
@@ -76,14 +77,16 @@ MANGLE_END */
             name: "NIOTLSServer",
             dependencies: [
                 "NIOSSL",
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
             ]),
         .target(
             name: "NIOSSLHTTP1Client",
             dependencies: [
                 "NIOSSL",
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ]),
@@ -91,13 +94,17 @@ MANGLE_END */
             name: "NIOSSLPerformanceTester",
             dependencies: [
                 "NIOSSL",
-                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
             ]),
         .testTarget(
             name: "NIOSSLTests",
             dependencies: [
                 "NIOSSL",
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
             ]),
     ],

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -19,6 +19,14 @@ import NIOCore
 import CNIOBoringSSL
 #endif
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+#error("unsupported os")
+#endif
+
 
 /// The BoringSSL entry point to write to the `ByteBufferBIO`. This thunk unwraps the user data
 /// and then passes the call on to the specific BIO reference.

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
+#endif
 
 
 private let asciiIDNAIdentifier: ArraySlice<UInt8> = Array("xn--".utf8)[...]

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -19,7 +19,7 @@ import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else
-let badOS = { fatalError("unsupported OS") }()
+#error("unsupported os")
 #endif
 
 

--- a/Sources/NIOSSL/LinuxCABundle.swift
+++ b/Sources/NIOSSL/LinuxCABundle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,8 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-import NIO
 
 #if os(Linux) || os(FreeBSD)
 /// The path to the root CA bundle file.

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -19,7 +19,7 @@ import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else
-let badOS = { fatalError("unsupported OS") }()
+#error("unsupported os")
 #endif
 
 extension String {

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
+#endif
 
 extension String {
     private func isIPAddress() -> Bool {

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 /// A channel handler that wraps a channel in TLS using NIOSSL. This
 /// handler can be used in channels that are acting as the server in

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -20,7 +20,15 @@
 //
 // The code is an exact port from SwiftNIO, so if that version ever becomes public we
 // can lift anything missing from there and move it over without change.
-import NIO
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
+#endif
+
+import NIOCore
 
 #if os(Android)
 internal typealias FILEPointer = OpaquePointer

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -25,7 +25,7 @@ import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else
-let badOS = { fatalError("unsupported OS") }()
+#error("unsupported os")
 #endif
 
 import NIOCore

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,7 +17,7 @@
 #else
 import CNIOBoringSSL
 #endif
-import NIO
+import NIOCore
 
 /// The result of an attempt to verify an X.509 certificate.
 public enum NIOSSLVerificationResult {

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -19,6 +19,14 @@ import CNIOBoringSSL
 #endif
 import NIOCore
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+#error("unsupported os")
+#endif
+
 /// The result of an attempt to verify an X.509 certificate.
 public enum NIOSSLVerificationResult {
     /// The certificate was successfully verified.

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -19,7 +19,7 @@
 import CNIOBoringSSL
 import CNIOBoringSSLShims
 #endif
-import NIO
+import NIOCore
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import struct Darwin.time_t
 #elseif canImport(Glibc)

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -20,10 +20,13 @@ import CNIOBoringSSL
 import CNIOBoringSSLShims
 #endif
 import NIOCore
+
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import struct Darwin.time_t
-#elseif canImport(Glibc)
-import struct Glibc.time_t
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+#error("unsupported os")
 #endif
 
 /// A reference to a BoringSSL Certificate object (`X509 *`).

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -26,7 +26,7 @@ import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else
-let badOS = { fatalError("unsupported OS") }()
+#error("unsupported os")
 #endif
 
 // This is a neat trick. Swift lazily initializes module-globals based on when they're first

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,13 +12,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 #else
 import CNIOBoringSSL
 import CNIOBoringSSLShims
+#endif
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Darwin.C
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+import Glibc
+#else
+let badOS = { fatalError("unsupported OS") }()
 #endif
 
 // This is a neat trick. Swift lazily initializes module-globals based on when they're first

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,7 +17,6 @@
 #else
 import CNIOBoringSSL
 #endif
-import NIO
 
 
 /// A container of a single PKCS#12 bundle.

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import NIO
+import NIOCore
 
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,7 +17,7 @@
 #else
 import CNIOBoringSSL
 #endif
-import NIO
+import NIOCore
 
 /// Known and supported TLS versions.
 public enum TLSVersion {

--- a/Sources/NIOSSL/UniversalBootstrapSupport.swift
+++ b/Sources/NIOSSL/UniversalBootstrapSupport.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2020-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 /// A TLS provider to bootstrap TLS-enabled connections with `NIOClientTCPBootstrap`.
 ///

--- a/Sources/NIOSSLHTTP1Client/main.swift
+++ b/Sources/NIOSSLHTTP1Client/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
+import NIOPosix
 import NIOFoundationCompat
 import NIOHTTP1
 import NIOSSL

--- a/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchManyWrites.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOSSL
 
 final class BenchManyWrites: Benchmark {

--- a/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
+++ b/Sources/NIOSSLPerformanceTester/BenchRepeatedHandshakes.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOSSL
 
 final class BenchRepeatedHandshakes: Benchmark {

--- a/Sources/NIOSSLPerformanceTester/main.swift
+++ b/Sources/NIOSSLPerformanceTester/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
-import NIOSSL
 import Foundation
 import Dispatch
 

--- a/Sources/NIOSSLPerformanceTester/shared.swift
+++ b/Sources/NIOSSLPerformanceTester/shared.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
-import NIO
+import NIOCore
+import NIOEmbedded
 import NIOSSL
 
 class BackToBackEmbeddedChannel {

--- a/Sources/NIOTLSServer/main.swift
+++ b/Sources/NIOTLSServer/main.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import struct Foundation.URL
-import NIO
+import NIOCore
+import NIOPosix
 import NIOSSL
 
 private final class EchoHandler: ChannelInboundHandler {

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
+import NIOCore
 #if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 #else

--- a/Tests/NIOSSLTests/CertificateVerificationTests.swift
+++ b/Tests/NIOSSLTests/CertificateVerificationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2019-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
 @testable import NIOSSL
 
 final class CertificateVerificationTests: XCTestCase {

--- a/Tests/NIOSSLTests/ClientSNITests.swift
+++ b/Tests/NIOSSLTests/ClientSNITests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
+import NIOCore
+import NIOPosix
 import NIOTLS
 import NIOSSL
 

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
+import NIOCore
 @testable import NIOSSL
 
 /// This cert contains the following SAN fields:

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -18,7 +18,8 @@ import XCTest
 #else
 import CNIOBoringSSL
 #endif
-import NIO
+import NIOCore
+import NIOPosix
 import NIOTLS
 import NIOSSL
 

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -19,7 +19,9 @@ import XCTest
 import CNIOBoringSSL
 #endif
 import NIOConcurrencyHelpers
-import NIO
+import NIOCore
+import NIOEmbedded
+import NIOPosix
 @testable import NIOSSL
 import NIOTLS
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-import NIO
+import NIOCore
 @testable import NIOSSL
 
 let multiSanCert = """

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-import NIO
+import NIOCore
 @testable import NIOSSL
 
 

--- a/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
+++ b/Tests/NIOSSLTests/SSLPrivateKeyTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import Foundation
 import XCTest
-import NIO
+import NIOCore
 @testable import NIOSSL
 
 class SSLPrivateKeyTest: XCTestCase {

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -18,7 +18,9 @@ import XCTest
 #else
 import CNIOBoringSSL
 #endif
-import NIO
+import NIOCore
+import NIOPosix
+import NIOEmbedded
 @testable import NIOSSL
 import NIOTLS
 

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -13,7 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import NIO
+import NIOCore
+import NIOEmbedded
 @testable import NIOSSL
 
 func connectInMemory(client: EmbeddedChannel, server: EmbeddedChannel) throws {

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -50,6 +50,15 @@ if git grep --color=never -i "${unacceptable_terms[@]}" ':(exclude)Sources/CNIOB
 fi
 printf "\033[0;32mokay.\033[0m\n"
 
+# This checks for the umbrella NIO module.
+printf "=> Checking for imports of umbrella NIO module... "
+if git grep --color=never -i "^[ \t]*import \+NIO[ \t]*$" > /dev/null; then
+    printf "\033[0;31mUmbrella imports found.\033[0m\n"
+    git grep -i "^[ \t]*import \+NIO[ \t]*$"
+    exit 1
+fi
+printf "\033[0;32mokay.\033[0m\n"
+
 printf "=> Checking license headers... "
 tmp=$(mktemp /tmp/.swift-nio-soundness_XXXXXX)
 


### PR DESCRIPTION
Motivation:

With NIO 2.32.0 we broke the core NIO module up into modules that split
apart the POSIX layer and the core abstractions. As a result, this
package no longer needs to express a hard dependency on the POSIX layer.

Modifications:

- Rewrote imports of NIO to NIOCore.
- Added NIOEmbedded and NIOPosix imports where necessary in tests.
- Extended soundness script to detect NIO imports.
- Note that the main modules still depend on NIO, which is necessary
for backwards-compatibility reasons. This dependency is unused.

Result:

No need to use NIOPosix.