### PR TITLE
Remove the implementationOnly dance

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin.C

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOTLS
 
 /// The base class for all NIOSSL handlers. This class cannot actually be instantiated by

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOCore
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -12,13 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
-#else
-import CNIOBoringSSL
-import CNIOBoringSSLShims
-#endif
 import NIOCore
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 internal let SSL_MAX_RECORD_SIZE = 16 * 1024
 

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -13,13 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
-#else
-import CNIOBoringSSL
-import CNIOBoringSSLShims
-#endif
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin.C

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 /// Wraps a single error from BoringSSL.
 public struct BoringSSLInternalError: Equatable, CustomStringConvertible {

--- a/Sources/NIOSSL/SSLInit.swift
+++ b/Sources/NIOSSL/SSLInit.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 /// Initialize BoringSSL. Note that this function IS NOT THREAD SAFE, and so must be called inside
 /// either an explicit or implicit dispatch_once.

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 
 /// A container of a single PKCS#12 bundle.

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 /// An `NIOSSLPassphraseCallback` is a callback that will be invoked by NIOSSL when it needs to
 /// get access to a private key that is stored in encrypted form.

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 /// An `NIOSSLPublicKey` is an abstract handle to a public key owned by BoringSSL.
 ///

--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -12,12 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import NIOCore
-
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 
 // We can only use Security.framework to validate TLS certificates on Apple platforms.
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOCore
 
 /// Known and supported TLS versions.

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -14,11 +14,7 @@
 
 import XCTest
 import NIOCore
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 @testable import NIOSSL
 
 

--- a/Tests/NIOSSLTests/NIOSSLALPNTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLALPNTest.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOCore
 import NIOPosix
 import NIOTLS

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 @testable import NIOSSL
 
 let samplePemCert = """

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -13,11 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-#if compiler(>=5.1)
 @_implementationOnly import CNIOBoringSSL
-#else
-import CNIOBoringSSL
-#endif
 import NIOCore
 import NIOPosix
 import NIOEmbedded


### PR DESCRIPTION
Motivation:

When we added implementationOnly imports a while back, we supported
Swift 5.0, and so we needed to guard their availability behind a
compiler check. We only support 5.2 and later now, so that check is
redundant and can go away.

Modifications:

- Removed compiler checks around imports of our C libraries.

Result:

Cleaner code