### PR TITLE
Adding back the Explicit time_t import

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -24,6 +24,12 @@ import Glibc
 #error("unsupported os")
 #endif
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import struct Darwin.time_t
+#elseif canImport(Glibc)
+import struct Glibc.time_t
+#endif
+
 /// A reference to a BoringSSL Certificate object (`X509 *`).
 ///
 /// This thin wrapper class allows us to use ARC to automatically manage


### PR DESCRIPTION
 Looks like the "cannot use type alias 'time_t'" issue is back. 8 days ago a commit was merged "Clean up imports and dependencies" that removed the previous patch.