### PR TITLE
Fix build for Android armv7

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -41,7 +41,7 @@ internal enum FileSystemObject {
             return nil
         }
 
-#if os(Android)
+#if os(Android) && arch(arm)
         return (statObj.st_mode & UInt32(Glibc.S_IFDIR)) != 0 ? .directory : .file
 #else
         return (statObj.st_mode & S_IFDIR) != 0 ? .directory : .file
@@ -595,7 +595,11 @@ extension NIOSSLContext {
         var buffer = stat()
         let _ = try Posix.lstat(path: path, buf: &buffer)
         // Check the mode to make sure this is a symlink
+#if os(Android) && arch(arm)
+        if (buffer.st_mode & UInt32(Glibc.S_IFMT)) != UInt32(Glibc.S_IFLNK) { return false }
+#else
         if (buffer.st_mode & S_IFMT) != S_IFLNK { return false }
+#endif
 
         // Return true at this point because the file format is considered to be in rehash format and a symlink.
         // Rehash format being "%08lx.%d" or HHHHHHHH.D


### PR DESCRIPTION
Motivation:

Fix compilation error because of a type mismatch between `st_mode` and `mode_t` on 32-bit Android.

Modifications:

- Zero-extend `mode_t` constants on Android armv7 to match the types.
- Scope an earlier modification in this vein to armv7 only.

Result:

The code builds on Android armv7 again.

This line just added in #327 yesterday [broke the armv7 build on my daily Android CI](https://github.com/buttaface/swift-android-sdk/runs/3868413805?check_suite_focus=true#step:23:569). Adding these conversions fixes it and I went ahead and scoped the earlier change from #45 more narrowly too.