### PR TITLE
Provide better error on EOF during handshake

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -111,7 +111,9 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             // In this case the channel is going through the doHandshake steps and
             // a channelInactive is fired taking down the connection.
             // This case propogates a .handshakeFailed instead of an .uncleanShutdown.
-            channelError = NIOSSLError.handshakeFailed(.sslError(BoringSSLError.buildErrorStack()))
+            // We use a synthetic error here as the error stack will be empty, and we should try to
+            // provide some diagnostic help.
+            channelError = NIOSSLError.handshakeFailed(.sslError([.eofDuringHandshake]))
         default:
             // This is a ragged EOF: we weren't sent a CLOSE_NOTIFY. We want to send a user
             // event to notify about this before we propagate channelInactive. We also want to fail all

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -16,14 +16,33 @@
 
 /// Wraps a single error from BoringSSL.
 public struct BoringSSLInternalError: Equatable, CustomStringConvertible {
-    let errorCode: UInt32
+    private enum Backing: Hashable {
+        case boringSSLErrorCode(UInt32)
+        case synthetic(String)
+    }
 
-    var errorMessage: String? {
-        // TODO(cory): This should become non-optional in the future, as it always succeeds.
-        var scratchBuffer = [CChar](repeating: 0, count: 512)
-        return scratchBuffer.withUnsafeMutableBufferPointer { pointer in
-            CNIOBoringSSL_ERR_error_string_n(self.errorCode, pointer.baseAddress!, pointer.count)
-            return String(cString: pointer.baseAddress!)
+    private var backing: Backing
+
+    private var errorMessage: String? {
+        switch self.backing {
+        case .boringSSLErrorCode(let errorCode):
+            // TODO(cory): This should become non-optional in the future, as it always succeeds.
+            var scratchBuffer = [CChar](repeating: 0, count: 512)
+            return scratchBuffer.withUnsafeMutableBufferPointer { pointer in
+                CNIOBoringSSL_ERR_error_string_n(errorCode, pointer.baseAddress!, pointer.count)
+                return String(cString: pointer.baseAddress!)
+            }
+        case .synthetic(let description):
+            return description
+        }
+    }
+
+    private var errorCode: String {
+        switch self.backing {
+        case .boringSSLErrorCode(let code):
+            return String(code, radix: 10)
+        case .synthetic:
+            return ""
         }
     }
 
@@ -32,8 +51,15 @@ public struct BoringSSLInternalError: Equatable, CustomStringConvertible {
     }
 
     init(errorCode: UInt32) {
-        self.errorCode = errorCode
+        self.backing = .boringSSLErrorCode(errorCode)
     }
+
+    private init(syntheticErrorDescription description: String) {
+        self.backing = .synthetic(description)
+    }
+
+    /// Received EOF during the TLS handshake.
+    public static let eofDuringHandshake = Self(syntheticErrorDescription: "EOF during handshake")
 }
 
 /// A representation of BoringSSL's internal error stack: a list of BoringSSL errors.

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -1009,9 +1009,9 @@ final class UnwrappingTests: XCTestCase {
             try interactInMemory(clientChannel: clientChannel, serverChannel: serverChannel)
         } catch {
             switch error as? NIOSSLError {
-            case .some(.handshakeFailed):
-                // Expected to fall into .handshakeFailed
-                break
+            case .some(.handshakeFailed(let innerError)):
+                // Expected to fall into .handshakeFailed with .eofDuringHandshake
+                XCTAssertEqual(innerError, .sslError([.eofDuringHandshake]))
             default:
                 XCTFail("Unexpected error: \(error)")
             }


### PR DESCRIPTION
Motivation:

When we get channelInactive during a handshake, we currently produce a
fairly useless error:
.handshakeFailed(NIOSSL.BoringSSLError.sslError([])). This error isn't
helpful to anyone, and it doesn't really communicate what's happened.

Sadly, due to the tightly constrained types it's really hard for us to
add new errors to handshakeFailed. Regardless, it would be good for us
to give as much diagnostic information as we can here.

Modifications:

- Changed the representation of BoringSSLInternalError to allow
  "synthetic" errors that don't come from BoringSSL at all.
- Added a new synthetic error for eof during handshake.
- Sent that error instead of a BoringSSL error stack that will always be
  empty.

Result:

- Easier to diagnose the error.