### PR TITLE
Add 5.6 nightly CI.

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-nio-ssl:20.04-5.6
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.6-focal"
+        ubuntu_version: "focal"
+
+  unit-tests:
+    image: swift-nio-ssl:20.04-5.6
+
+  integration-tests:
+    image: swift-nio-ssl:20.04-5.6
+
+  test:
+    image: swift-nio-ssl:20.04-5.6
+    environment:
+      - MAX_ALLOCS_ALLOWED_simple_handshake=743000
+      - MAX_ALLOCS_ALLOWED_many_writes=201000
+
+  performance-test:
+    image: swift-nio-ssl:20.04-5.6
+
+  shell:
+    image: swift-nio-ssl:20.04-5.6


### PR DESCRIPTION
The 5.6 nightly images are available, let's use them.

@tomerd Do you mind adding a 5.6 builder for this?