### PR TITLE
Add `Hashable` conformance to `NIOSSLPKCS12Bundle`

### DIFF
--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -38,7 +38,7 @@
 ///     )
 ///
 /// The created `TLSConfiguration` can then be safely used for your endpoint.
-public struct NIOSSLPKCS12Bundle {
+public struct NIOSSLPKCS12Bundle: Hashable {
     public let certificateChain: [NIOSSLCertificate]
     public let privateKey: NIOSSLPrivateKey
 

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest+XCTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest+XCTest.swift
@@ -34,6 +34,7 @@ extension SSLPKCS12BundleTest {
                 ("testDecodingComplexP12FromFile", testDecodingComplexP12FromFile),
                 ("testDecodingSimpleP12FromFileWithoutPassphrase", testDecodingSimpleP12FromFileWithoutPassphrase),
                 ("testDecodingNonExistentPKCS12File", testDecodingNonExistentPKCS12File),
+                ("testEquatableAndHashable", testEquatableAndHashable),
            ]
    }
 }

--- a/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
+++ b/Tests/NIOSSLTests/SSLPKCS12BundleTest.swift
@@ -499,5 +499,20 @@ class SSLPKCS12BundleTest: XCTestCase {
             XCTAssertEqual(ENOENT, (error as? IOError).map { $0.errnoCode })
         }
     }
+    
+    func testEquatableAndHashable() throws {
+        let bundle1_a = try NIOSSLPKCS12Bundle(buffer: simpleP12, passphrase: "thisisagreatpassword".utf8)
+        let bundle1_b = try NIOSSLPKCS12Bundle(buffer: simpleP12, passphrase: "thisisagreatpassword".utf8)
+        let bundle2 = try NIOSSLPKCS12Bundle(buffer: complexP12, passphrase: "thisisagreatpassword".utf8)
+        XCTAssertEqual(bundle1_a, bundle1_a)
+        XCTAssertEqual(bundle1_a, bundle1_b)
+        XCTAssertNotEqual(bundle1_a, bundle2)
+        
+        let set = Set([bundle1_a, bundle1_b, bundle2])
+        XCTAssertEqual(set.count, 2)
+        XCTAssertTrue(set.contains(bundle1_a))
+        XCTAssertTrue(set.contains(bundle1_b))
+        XCTAssertTrue(set.contains(bundle2))
+    }
 }
 


### PR DESCRIPTION
All stored properties of `NIOSSLPKCS12Bundle` conform to `Hashable` and it should therefore conform to `Hashable` too.