### PR TITLE
ci update

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -6,8 +6,8 @@ services:
     image: swift-nio-ssl:20.04-5.6
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.6-focal"
         ubuntu_version: "focal"
+        swift_version: "5.6"
 
   unit-tests:
     image: swift-nio-ssl:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -3,25 +3,25 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-focal"
 
   unit-tests:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7
 
   integration-tests:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7
 
   test:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7
     environment:
       - MAX_ALLOCS_ALLOWED_simple_handshake=743000
       - MAX_ALLOCS_ALLOWED_many_writes=201000
 
   performance-test:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7
 
   shell:
-    image: swift-nio-ssl:20.04-main
+    image: swift-nio-ssl:20.04-5.7


### PR DESCRIPTION
motivation: 5.6 is out

changes:
* use release version of 5.6
* add docker setup for 5.7 (using nightly for now)