### PR TITLE
Add `NIOSSLObjectIdentifier` (OID) type

### DIFF
--- a/Sources/NIOSSL/ObjectIdentifier.swift
+++ b/Sources/NIOSSL/ObjectIdentifier.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CNIOBoringSSL
+@_implementationOnly import CNIOBoringSSLShims
+
+/// Object Identifier (OID)
+public struct NIOSSLObjectIdentifier: Hashable {
+    fileprivate final class Storage {
+        
+        /// All operations accessing `reference` need to be implemented while guaranteeing that the enclosing `self` has a reference count of at least one.
+        /// Otherwise `reference` could already be freed. This would result in undefined behaviour as we access a dangling pointer.
+        /// One way we can guarantee this is by implementation all operations as methods/computed properties on `Storage`.
+        /// Swift guarantees that `self` is not deallocated during the execution of a method/computed property on `self`.
+        private let reference: OpaquePointer
+        
+        fileprivate init?(_ string: String) {
+            let result = string.withCString { string in
+                CNIOBoringSSL_OBJ_txt2obj(string, 0)
+            }
+            guard let reference = result else {
+                return nil
+            }
+            self.reference = reference
+        }
+        
+        fileprivate init(reference: OpaquePointer) {
+            self.reference = reference
+        }
+        
+        deinit {
+            CNIOBoringSSL_ASN1_OBJECT_free(reference)
+        }
+    }
+    
+    private let storage: Storage
+    
+    /// Creates a Object Identifier (OID) from its textual dotted representation (e.g. `1.2.3`)
+    /// - Parameter string: textual dotted representation of an OID
+    public init?(_ string: String) {
+        guard let storage = Storage(string) else {
+            return nil
+        }
+        self.storage = storage
+    }
+    
+    /// Creates an Object Identifier (OID) from an OpenSSL reference.
+    /// - Note: initialising an ``NIOSSLObjectIdentifier`` takes ownership of the reference and will free it after the reference count drops to zero
+    /// - Parameter reference: reference to a valid OpenSSL OID aka OBJ
+    internal init(reference: OpaquePointer) {
+        self.storage = Storage(reference: reference)
+    }
+}
+
+extension NIOSSLObjectIdentifier.Storage: Equatable {
+    fileprivate static func == (lhs: NIOSSLObjectIdentifier.Storage, rhs: NIOSSLObjectIdentifier.Storage) -> Bool {
+        CNIOBoringSSL_OBJ_cmp(lhs.reference, rhs.reference) == 0
+    }
+}
+
+extension NIOSSLObjectIdentifier.Storage: Hashable {
+    fileprivate func hash(into hasher: inout Hasher) {
+        let length = CNIOBoringSSL_OBJ_length(self.reference)
+        let data = CNIOBoringSSL_OBJ_get0_data(self.reference)
+        let buffer = UnsafeRawBufferPointer(start: data, count: length)
+        hasher.combine(bytes: buffer)
+    }
+}
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+extension NIOSSLObjectIdentifier.Storage: LosslessStringConvertible {
+    fileprivate var description: String {
+        var failed = false
+        let oid = String(unsafeUninitializedCapacity: 80) { buffer in
+            // OBJ_obj2txt() is awkward and messy to use: it doesn't follow the convention of other OpenSSL functions where the buffer can be set to NULL to determine the amount of data that should be written. Instead buf must point to a valid buffer and buf_len should be set to a positive value. A buffer length of 80 should be more than enough to handle any OID encountered in practice.
+            // source: https://linux.die.net/man/3/obj_obj2txt
+            let result = buffer.withMemoryRebound(to: CChar.self) { buffer in
+                CNIOBoringSSL_OBJ_obj2txt(buffer.baseAddress, Int32(buffer.count), self.reference, 1)
+            }
+            guard result >= 0 else {
+                // result of -1 indicates that it could not successfully
+                failed = true
+                return 0
+            }
+            return Int(result)
+        }
+        guard !failed else {
+            return "failed to convert OID to string"
+        }
+        return oid
+    }
+}
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+extension NIOSSLObjectIdentifier: LosslessStringConvertible {
+    public var description: String {
+        self.storage.description
+    }
+}

--- a/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
+++ b/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
@@ -13,12 +13,25 @@
 //===----------------------------------------------------------------------===//
 
 extension String {
-    /// This is a backport of a proposed String initializer that will allow writing directly into an uninitialized String's backing memory.
-    /// This feature will be useful when decoding Huffman-encoded HPACK strings.
+    /// This is a backport of `String.init(unsafeUninitializedCapacity:initializingUTF8With:)`
+    /// that allows writing directly into an uninitialized String's backing memory.
     ///
-    /// As this API does not exist prior to 5.3 on Linux, or on older Apple platforms, we fake it out with a pointer and accept the extra copy.
-    init(backportUnsafeUninitializedCapacity capacity: Int,
-         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
+    /// As this API does not exist on older Apple platforms, we fake it out with a pointer and accept the extra copy.
+    init(
+        customUnsafeUninitializedCapacity capacity: Int,
+        initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int
+    ) rethrows {
+        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+            try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+        } else {
+            try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+        }
+    }
+    
+    private init(
+        backportUnsafeUninitializedCapacity capacity: Int,
+        initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int
+    ) rethrows {
         let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: capacity)
         defer {
             buffer.deallocate()
@@ -31,27 +44,3 @@ extension String {
         self = String(decoding: UnsafeMutableBufferPointer(start: buffer.baseAddress!, count: initializedCount), as: UTF8.self)
     }
 }
-
-// Frustratingly, Swift 5.3 shipped before the macOS 11 SDK did, so we cannot gate the availability of
-// this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
-// to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
-// enhancement on Apple platforms.
-#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))) || compiler(>=5.4)
-extension String {
-    init(customUnsafeUninitializedCapacity capacity: Int,
-         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
-        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
-        } else {
-            try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
-        }
-    }
-}
-#else
-extension String {
-    init(customUnsafeUninitializedCapacity capacity: Int,
-         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
-        try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
-    }
-}
-#endif

--- a/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
+++ b/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension String {
+    /// This is a backport of a proposed String initializer that will allow writing directly into an uninitialized String's backing memory.
+    /// This feature will be useful when decoding Huffman-encoded HPACK strings.
+    ///
+    /// As this API does not exist prior to 5.3 on Linux, or on older Apple platforms, we fake it out with a pointer and accept the extra copy.
+    init(backportUnsafeUninitializedCapacity capacity: Int,
+         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: capacity)
+        defer {
+            buffer.deallocate()
+        }
+
+
+        let initializedCount = try initializer(buffer)
+        precondition(initializedCount <= capacity, "Overran buffer in initializer!")
+
+        self = String(decoding: UnsafeMutableBufferPointer(start: buffer.baseAddress!, count: initializedCount), as: UTF8.self)
+    }
+}
+
+// Frustratingly, Swift 5.3 shipped before the macOS 11 SDK did, so we cannot gate the availability of
+// this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
+// to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
+// enhancement on Apple platforms.
+#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))) || compiler(>=5.4)
+extension String {
+    init(customUnsafeUninitializedCapacity capacity: Int,
+         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
+        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+            try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+        } else {
+            try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+        }
+    }
+}
+#else
+extension String {
+    init(customUnsafeUninitializedCapacity capacity: Int,
+         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
+        try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
+    }
+}
+#endif

--- a/Tests/NIOSSLTests/ObjectIdentifier.swift
+++ b/Tests/NIOSSLTests/ObjectIdentifier.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import NIOSSL
+
+final class ObjectIdentifierTests: XCTestCase {
+    func testEquatable() {
+        XCTAssertEqual(
+            NIOSSLObjectIdentifier("1.1"),
+            NIOSSLObjectIdentifier("1.1")
+        )
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.2"), NIOSSLObjectIdentifier("1.2"))
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.2.3"), NIOSSLObjectIdentifier("1.2.3"))
+        
+        XCTAssertNotEqual(NIOSSLObjectIdentifier("1"), NIOSSLObjectIdentifier("1.2"))
+        XCTAssertNotEqual(NIOSSLObjectIdentifier("1.2"), NIOSSLObjectIdentifier("1.2.3"))
+    }
+    
+    func testHashable() {
+        XCTAssertEqual(Set([
+            NIOSSLObjectIdentifier("1.1"),
+        ]), Set([
+            NIOSSLObjectIdentifier("1.1"),
+        ]))
+        XCTAssertEqual(Set([
+            NIOSSLObjectIdentifier("1.1"),
+            NIOSSLObjectIdentifier("1.2"),
+        ]), Set([
+            NIOSSLObjectIdentifier("1.2"),
+            NIOSSLObjectIdentifier("1.1"),
+        ]))
+    }
+    
+    func testCustomStringConvertible() {
+        guard #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) else { return }
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.1")?.description, "1.1")
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.2")?.description, "1.2")
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.2.3")?.description, "1.2.3")
+        XCTAssertEqual(NIOSSLObjectIdentifier("1.2.3.4")?.description, "1.2.3.4")
+    }
+}

--- a/Tests/NIOSSLTests/ObjectIdentifier.swift
+++ b/Tests/NIOSSLTests/ObjectIdentifier.swift
@@ -44,7 +44,6 @@ final class ObjectIdentifierTests: XCTestCase {
     }
     
     func testCustomStringConvertible() {
-        guard #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) else { return }
         XCTAssertEqual(NIOSSLObjectIdentifier("1.1")?.description, "1.1")
         XCTAssertEqual(NIOSSLObjectIdentifier("1.2")?.description, "1.2")
         XCTAssertEqual(NIOSSLObjectIdentifier("1.2.3")?.description, "1.2.3")


### PR DESCRIPTION
This PR adds a wrapper around `ASN1_OBJECT` that represents an Object Identifier (OID). It manages memory through ARC and implements `Equatable`, `Hashable`, `CustomStringConvertible` and `LosslessStringConvertible`.