### PR TITLE
Parallel test fix for TLSConfigurationTest

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -436,7 +436,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         let (cert, key) = generateSelfSignedCert()
         NIOSSLIntegrationTest.cert = cert
         NIOSSLIntegrationTest.key = key
-        NIOSSLIntegrationTest.encryptedKeyPath = keyInFile(key: NIOSSLIntegrationTest.key, passphrase: "thisisagreatpassword")
+        NIOSSLIntegrationTest.encryptedKeyPath = try! keyInFile(key: NIOSSLIntegrationTest.key, passphrase: "thisisagreatpassword")
     }
 
     override class func tearDown() {
@@ -478,8 +478,8 @@ class NIOSSLIntegrationTest: XCTestCase {
         ), file: file, line: line)
     }
 
-    static func keyInFile(key: NIOSSLPrivateKey, passphrase: String) -> String {
-        let fileName = makeTemporaryFile(fileExtension: ".pem")
+    static func keyInFile(key: NIOSSLPrivateKey, passphrase: String) throws -> String {
+        let fileName = try makeTemporaryFile(fileExtension: ".pem")
         let tempFile = open(fileName, O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC, 0o644)
         precondition(tempFile > 1, String(cString: strerror(errno)))
         let fileBio = CNIOBoringSSL_BIO_new_fp(fdopen(tempFile, "w+"), BIO_CLOSE)
@@ -498,7 +498,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     func withTrustBundleInFile<T>(tempFile fileName: inout String?, fn: (String) throws -> T) throws -> T {
-        fileName = makeTemporaryFile()
+        fileName = try makeTemporaryFile()
         guard let fileName = fileName else {
             fatalError("couldn't make temp file")
         }

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -142,8 +142,14 @@ kVuVyNH7NBMh6YOuTL1dh55bvDjvgkuzudepsZnpfjgQKE1aZ7dL32Xi000gBM8=
 -----END CERTIFICATE-----
 """
 
-func makeTemporaryFile(fileExtension: String = "") -> String {
-    let template = "\(FileManager.default.temporaryDirectory.path)/niotestXXXXXXX\(fileExtension)"
+func makeTemporaryFile(fileExtension: String = "", customPath: String = "") throws -> String {
+    var template = "\(FileManager.default.temporaryDirectory.path)/niotestXXXXXXX\(fileExtension)"
+    // If a custom file path is passed in then a new directory has to also be created.  Then the file can be written to that directory.
+    if !customPath.isEmpty {
+        let path = "\(FileManager.default.temporaryDirectory.path)/\(customPath)/"
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: path), withIntermediateDirectories: true)
+        template = "\(FileManager.default.temporaryDirectory.path)/\(customPath)/niotestXXXXXXX\(fileExtension)"
+    }
     var templateBytes = template.utf8 + [0]
     let fd = templateBytes.withUnsafeMutableBufferPointer { ptr in
         ptr.baseAddress!.withMemoryRebound(to: Int8.self, capacity: ptr.count) { (ptr: UnsafeMutablePointer<Int8>) in
@@ -155,29 +161,8 @@ func makeTemporaryFile(fileExtension: String = "") -> String {
     return String(decoding: templateBytes, as: UTF8.self)
 }
 
-internal func dumpToFile(data: Data, fileExtension: String = "") throws  -> String {
-    let filename = makeTemporaryFile(fileExtension: fileExtension)
-    try data.write(to: URL(fileURLWithPath: filename))
-    return filename
-}
-
-internal func dumpToFileWithCustomPath(data: Data, fileExtension: String = "", customPath: String = "") throws  -> String {
-    var template = "\(FileManager.default.temporaryDirectory.path)/niotestXXXXXXX\(fileExtension)"
-    // If a custom file path is passed in then a new directory has to also be created.  Then the file can be written to that directory.
-    if !customPath.isEmpty {
-        let path = "\(FileManager.default.temporaryDirectory.path)/\(customPath)/"
-        try FileManager.default.createDirectory(at: URL(string: "file://"  + path)!, withIntermediateDirectories: true)
-        template = "\(FileManager.default.temporaryDirectory.path)/\(customPath)/niotestXXXXXXX\(fileExtension)"
-    }
-    var templateBytes = template.utf8 + [0]
-    let fd = templateBytes.withUnsafeMutableBufferPointer { ptr in
-        ptr.baseAddress!.withMemoryRebound(to: Int8.self, capacity: ptr.count) { (ptr: UnsafeMutablePointer<Int8>) in
-            return mkstemps(ptr, CInt(fileExtension.utf8.count))
-        }
-    }
-    close(fd)
-    templateBytes.removeLast()
-    let filename = String(decoding: templateBytes, as: UTF8.self)
+internal func dumpToFile(data: Data, fileExtension: String = "", customPath: String = "") throws  -> String {
+    let filename = try makeTemporaryFile(fileExtension: fileExtension, customPath: customPath)
     try data.write(to: URL(fileURLWithPath: filename))
     return filename
 }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -264,10 +264,9 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     // Note that this is a stub to create the rehash file format for a certificate.
-    // If needed in the future the numericExtension should be rework to check for duplicates and increment as applicable.
-    func getRehashFilename(path: String, numericExtension: Int) -> String {
+    // If needed in the future the numericExtension should be reworked to check for duplicates and increment as applicable.
+    func getRehashFilename(path: String, testName: String, numericExtension: Int) -> String {
         var cert: NIOSSLCertificate!
-        
         if path.suffix(4) == ".pem" {
             XCTAssertNoThrow(cert = try NIOSSLCertificate(file: path, format: .pem))
         } else {
@@ -275,9 +274,8 @@ class TLSConfigurationTest: XCTestCase {
         }
         // Create a rehash format filename to symlink the hard file above to.
         let originalSubjectName = cert.getSubjectNameHash()
-        let truncatedHash = String(format: "%08lx.0", originalSubjectName)
-        // Constr
-        let tempDirPath = FileManager.default.temporaryDirectory.path + "/"
+        let truncatedHash = String(format: "%08lx.%d", originalSubjectName, numericExtension)
+        let tempDirPath = FileManager.default.temporaryDirectory.path + "/" + testName + "/"
         return tempDirPath + truncatedHash
     }
 
@@ -629,15 +627,16 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     func testRehashFormatToPopulateCANamesFromDirectory() throws {
+        // Use the test name as the directory name in the temporary directory.
+        let testName = String("\(#function)".dropLast(2))
         // Create 2 PEM based certs
-        let rootCAPathOne = try dumpToFile(data: .init(customCARoot.utf8), fileExtension: ".pem")
-        let rootCAPathTwo = try dumpToFile(data: .init(secondaryRootCertificateForClientAuthentication.utf8), fileExtension: ".pem")
+        let rootCAPathOne = try dumpToFileWithCustomPath(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
+        let rootCAPathTwo = try dumpToFileWithCustomPath(data: .init(secondaryRootCertificateForClientAuthentication.utf8), fileExtension: ".pem", customPath: testName)
         
         // Create a rehash formatted name of both certificate's subject name that was created above.
         // Take these rehash certificate names and format a symlink with them below with createSymbolicLink.
-        let rehashSymlinkNameOne = getRehashFilename(path: rootCAPathOne, numericExtension: 0)
-        let rehashSymlinkNameTwo = getRehashFilename(path: rootCAPathTwo, numericExtension: 0)
-        
+        let rehashSymlinkNameOne = getRehashFilename(path: rootCAPathOne, testName: testName, numericExtension: 0)
+        let rehashSymlinkNameTwo = getRehashFilename(path: rootCAPathTwo, testName: testName, numericExtension: 0)
         // Extract just the filename of the newly create certs in the tmp directory.
         let rootCAURLOne = URL(string: "file://" + rootCAPathOne)!
         let rootCAURLTwo = URL(string: "file://" + rootCAPathTwo)!
@@ -656,9 +655,12 @@ class TLSConfigurationTest: XCTestCase {
             XCTAssertNoThrow(try FileManager.default.removeItem(at: rootCAURLTwo))
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + rehashSymlinkNameOne)!))
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + rehashSymlinkNameTwo)!))
+            // Remove the actual directory also.
+            let removePath = "\(FileManager.default.temporaryDirectory.path)/\(testName)/"
+            XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://"  + removePath)!))
         }
         
-        let tempFileDir = FileManager.default.temporaryDirectory.path + "/"
+        let tempFileDir = FileManager.default.temporaryDirectory.path + "/\(testName)/"
         let digitalIdentities = try setupTLSLeafandClientIdentitiesFromCustomCARoot()
         
         // Server Configuration
@@ -678,6 +680,8 @@ class TLSConfigurationTest: XCTestCase {
     }
     
     func testRehashFormat() throws {
+        // Use the test name as the directory name in the temporary directory.
+        let testName = String("\(#function)".dropLast(2))
         // This test case creates path variables and files to run through the `isRehashFormat` function in `NIOSSLContext`.
         // Note that the c_rehash file format is a symlink to an original PEM or CER file in the form of HHHHHHHH.D.
         // Note that CRLs are not supported, only PEM and DER representations of certificates.
@@ -693,17 +697,17 @@ class TLSConfigurationTest: XCTestCase {
         XCTAssertFalse(acceptablePathBadRehashFormat)
         
         // Test with an actual file, but no symlink.
-        let dummyFile = try dumpToFile(data: Data(), fileExtension: ".txt")
-        let newPath = FileManager.default.temporaryDirectory.path + "/7f44456a.1"
+        let dummyFile = try dumpToFileWithCustomPath(data: Data(), fileExtension: ".txt", customPath: testName)
+        let newPath = FileManager.default.temporaryDirectory.path + "/\(testName)/7f44456a.1"
         let _ = try FileManager.default.moveItem(atPath: dummyFile, toPath: newPath)
         // Filename is in rehash format, but not a symlink.
         let acceptablePathAndRehashFormatButNoSymlink = try NIOSSLContext._isRehashFormat(path: newPath)
         XCTAssertFalse(acceptablePathAndRehashFormatButNoSymlink)
         
         // Test actual symlink
-        let rootCAPathOne = try dumpToFile(data: .init(customCARoot.utf8), fileExtension: ".pem")
-        let rehashSymlinkName = getRehashFilename(path: rootCAPathOne, numericExtension: 0)
-        
+        let rootCAPathOne = try dumpToFileWithCustomPath(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
+        let rehashSymlinkName = getRehashFilename(path: rootCAPathOne, testName: testName, numericExtension: 0)
+
         // Extract just the filename of the newly create certs in the tmp directory.
         let rootCAURLOne = URL(string: "file://" + rootCAPathOne)!
         let rootCAFilenameOne = rootCAURLOne.lastPathComponent
@@ -715,6 +719,9 @@ class TLSConfigurationTest: XCTestCase {
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + rootCAPathOne)!))
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + rehashSymlinkName)!))
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + newPath)!))
+            // Remove the actual directory also.
+            let removePath = "\(FileManager.default.temporaryDirectory.path)/\(testName)/"
+            XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://"  + removePath)!))
         }
         
         // Test the success case for the symlink

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -630,8 +630,8 @@ class TLSConfigurationTest: XCTestCase {
         // Use the test name as the directory name in the temporary directory.
         let testName = String("\(#function)".dropLast(2))
         // Create 2 PEM based certs
-        let rootCAPathOne = try dumpToFileWithCustomPath(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
-        let rootCAPathTwo = try dumpToFileWithCustomPath(data: .init(secondaryRootCertificateForClientAuthentication.utf8), fileExtension: ".pem", customPath: testName)
+        let rootCAPathOne = try dumpToFile(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
+        let rootCAPathTwo = try dumpToFile(data: .init(secondaryRootCertificateForClientAuthentication.utf8), fileExtension: ".pem", customPath: testName)
         
         // Create a rehash formatted name of both certificate's subject name that was created above.
         // Take these rehash certificate names and format a symlink with them below with createSymbolicLink.
@@ -697,7 +697,7 @@ class TLSConfigurationTest: XCTestCase {
         XCTAssertFalse(acceptablePathBadRehashFormat)
         
         // Test with an actual file, but no symlink.
-        let dummyFile = try dumpToFileWithCustomPath(data: Data(), fileExtension: ".txt", customPath: testName)
+        let dummyFile = try dumpToFile(data: Data(), fileExtension: ".txt", customPath: testName)
         let newPath = FileManager.default.temporaryDirectory.path + "/\(testName)/7f44456a.1"
         let _ = try FileManager.default.moveItem(atPath: dummyFile, toPath: newPath)
         // Filename is in rehash format, but not a symlink.
@@ -705,7 +705,7 @@ class TLSConfigurationTest: XCTestCase {
         XCTAssertFalse(acceptablePathAndRehashFormatButNoSymlink)
         
         // Test actual symlink
-        let rootCAPathOne = try dumpToFileWithCustomPath(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
+        let rootCAPathOne = try dumpToFile(data: .init(customCARoot.utf8), fileExtension: ".pem", customPath: testName)
         let rehashSymlinkName = getRehashFilename(path: rootCAPathOne, testName: testName, numericExtension: 0)
 
         // Extract just the filename of the newly create certs in the tmp directory.


### PR DESCRIPTION
Motivation:

Address the issue the race condition brought up in #367

Modifications:

Created directories based on the test name so that each file would be isolated.

Result:

Avoid race condition in parallel test.