### PR TITLE
Remove `try` from Server Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let sslContext = try NIOSSLContext(configuration: configuration)
 let server = ServerBootstrap(group: group)
     .childChannelInitializer { channel in
         // important: The handler must be initialized _inside_ the `childChannelInitializer`
-        let handler = try NIOSSLServerHandler(context: sslContext)
+        let handler = NIOSSLServerHandler(context: sslContext)
 
         [...]
         channel.pipeline.addHandler(handler)


### PR DESCRIPTION
The constructor of `NIOSSLServerHandler` no longer throws:
https://github.com/apple/swift-nio-ssl/blob/2054785706cca5d040dfa0946e05f3a1f3580a27/Sources/NIOSSL/NIOSSLServerHandler.swift#L21-L23
 The throwing version is deprecated and should not be used:
https://github.com/apple/swift-nio-ssl/blob/2054785706cca5d040dfa0946e05f3a1f3580a27/Sources/NIOSSL/NIOSSLServerHandler.swift#L25-L26