### PR TITLE
Fix non-modular header compile error

### DIFF
--- a/Sources/CNIOBoringSSL/crypto/x509/t_x509.c
+++ b/Sources/CNIOBoringSSL/crypto/x509/t_x509.c
@@ -67,7 +67,7 @@
 #include <CNIOBoringSSL_x509v3.h>
 
 #include "internal.h"
-
+#include <inttypes.h>  // for PRIu64 and friends
 
 int X509_print_ex_fp(FILE *fp, X509 *x, unsigned long nmflag,
                      unsigned long cflag)

--- a/Sources/CNIOBoringSSL/include/CNIOBoringSSL_bn.h
+++ b/Sources/CNIOBoringSSL/include/CNIOBoringSSL_bn.h
@@ -126,7 +126,6 @@
 #include "CNIOBoringSSL_base.h"
 #include "CNIOBoringSSL_thread.h"
 
-#include <inttypes.h>  // for PRIu64 and friends
 #include <sys/types.h>
 #include <stdio.h>  // for FILE*
 


### PR DESCRIPTION
I am using vapor and there is error when compiling swift-nio-ssl

`Include of non-modular header inside framework module 'CNIOBoringSSL.CNIOBoringSSL_bn': '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/clang/include/inttypes.h'`