### PR TITLE
Don't call validateSNIServerName when TLS hostname verification is disabled

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -96,7 +96,9 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
 
         connection.setConnectState()
         if let serverHostname = serverHostname {
-            try serverHostname.validateSNIServerName()
+            if context.configuration.certificateVerification != .noHostnameVerification {
+                try serverHostname.validateSNIServerName()
+            }
 
             // IP addresses must not be provided in the SNI extension, so filter them.
             do {

--- a/Sources/NIOSSL/UniversalBootstrapSupport.swift
+++ b/Sources/NIOSSL/UniversalBootstrapSupport.swift
@@ -41,8 +41,10 @@ public struct NIOSSLClientTLSProvider<Bootstrap: NIOClientTCPBootstrapProtocol>:
     public init(context: NIOSSLContext,
                 serverHostname: String?,
                 customVerificationCallback: NIOSSLCustomVerificationCallback? = nil) throws {
-        try serverHostname.map {
-            try $0.validateSNIServerName()
+        if context.configuration.certificateVerification != .noHostnameVerification {
+            try serverHostname.map {
+                try $0.validateSNIServerName()
+            }
         }
         self.context = context
         self.serverHostname = serverHostname


### PR DESCRIPTION
I noticed that `validateSNIServerName` is called even when the TLS configuration explicitly disables hostname validation with `certificateVerification` set to `.noHostnameVerification`. I'm not too familiar with this library but this seems like a bug to me?

This pr adds a check to `NIOSSLClientHandler.swift` and `UniversalBootstrapSupport.swift` to skip `validateSNIServerName()` if the TLS context has `certificateVerification` set to `.noHostnameVerification`. It also adds a test case which fails without this check and now passes.

Hope this change makes sense! Please let me know if there is anything I've missed or can improve.