### PR TITLE
Tolerate massive writes

### DIFF
--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -297,7 +297,10 @@ internal final class SSLConnection {
         // We require that there is space to write at least one TLS record.
         var bytesRead: CInt = 0
         let rc = outputBuffer.writeWithUnsafeMutableBytes(minimumWritableBytes: SSL_MAX_RECORD_SIZE) { (pointer) -> Int in
-            bytesRead = CNIOBoringSSL_SSL_read(self.ssl, pointer.baseAddress, CInt(pointer.count))
+            // We ask for the amount of spare space in the buffer, clamping to CInt.max.
+            let maxReadSize = Int(CInt.max)
+            let readSize = CInt(min(maxReadSize, pointer.count))
+            bytesRead = CNIOBoringSSL_SSL_read(self.ssl, pointer.baseAddress, readSize)
             return bytesRead >= 0 ? Int(bytesRead) : 0
         }
         

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -69,6 +69,7 @@ extension NIOSSLIntegrationTest {
                 ("testWriteFromFailureOfWrite", testWriteFromFailureOfWrite),
                 ("testChannelInactiveDuringHandshakeSucceeded", testChannelInactiveDuringHandshakeSucceeded),
                 ("testTrustedFirst", testTrustedFirst),
+                ("testGiantWrite", testGiantWrite),
            ]
    }
 }


### PR DESCRIPTION
Motivation:

In rare cases, users may attempt to write more data than can be
expressed in 2**31 bytes. This should not crash our program.

Modifications:

- Break up extremely long writes into smaller chunks
- Make sure to clamp on the read path too

Result:

Users who send hilariously long writes can do so.