### PR TITLE
Clean up write logic

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -429,9 +429,6 @@ class NIOSSLIntegrationTest: XCTestCase {
     static var cert: NIOSSLCertificate!
     static var key: NIOSSLPrivateKey!
     static var encryptedKeyPath: String!
-
-    static let giantWriteSize = Int(CInt.max) + 1
-    static let giantWrite = ByteBuffer(repeating: 0, count: giantWriteSize)
     
     override class func setUp() {
         super.setUp()
@@ -2408,8 +2405,8 @@ class NIOSSLIntegrationTest: XCTestCase {
         // for an existing bug.
         // We only run this test on 64-bit systems where we can safely allocate enough memory.
         try XCTSkipIf(MemoryLayout<Int>.size <= 4)
-        let targetSize = Self.giantWriteSize
-        let write = Self.giantWrite
+        let targetSize = Int(CInt.max) + 1
+        let write = ByteBuffer(repeating: 0, count: targetSize)
 
         let b2b = BackToBackEmbeddedChannel()
 

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -669,7 +669,7 @@ func generateSelfSignedCert(keygenFunction: () -> UnsafeMutablePointer<EVP_PKEY>
 final class BackToBackEmbeddedChannel {
     private(set) var client: EmbeddedChannel
     private(set) var server: EmbeddedChannel
-    private var loop: EmbeddedEventLoop
+    private(set) var loop: EmbeddedEventLoop
 
 
     init() {


### PR DESCRIPTION
Motivation:

Unnecessary empty writes should be avoided, and we should avoid
completing promises too often.

Modifications:

- Avoid sending a split promise on every write when writes are too big.
- Avoid sending a zero-length write when writes are too big.

Result:

Slightly better write behaviour.

Note that this is fundamentally un-testable: there's no place to put a
test hook here, and we coalesce writes on the far side, so we can't do
much here.