### PR TITLE
Add sendCANameList to best effort functions.

### DIFF
--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -371,7 +371,8 @@ extension TLSConfiguration {
             self.encodedApplicationProtocols == comparing.encodedApplicationProtocols &&
             self.shutdownTimeout == comparing.shutdownTimeout &&
             isKeyLoggerCallbacksEqual &&
-            self.renegotiationSupport == comparing.renegotiationSupport
+            self.renegotiationSupport == comparing.renegotiationSupport &&
+            self.sendCANameList == comparing.sendCANameList
     }
     
     /// Returns a best effort hash of this TLS configuration.
@@ -396,6 +397,7 @@ extension TLSConfiguration {
             hasher.combine(bytes: closureBits)
         }
         hasher.combine(renegotiationSupport)
+        hasher.combine(sendCANameList)
     }
 
     /// Creates a TLS configuration for use with client-side contexts.

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1075,6 +1075,7 @@ class TLSConfigurationTest: XCTestCase {
             { $0.shutdownTimeout = .seconds((60 * 24 * 24) + 1) },
             { $0.keyLogCallback = { _ in } },
             { $0.renegotiationSupport = .always },
+            { $0.sendCANameList = true },
         ]
 
         for (index, transform) in transforms.enumerated() {

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1057,6 +1057,10 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testBestEffortEquatableHashableDifferences() {
+        // If this assertion fails, DON'T JUST CHANGE THE NUMBER HERE! Make sure you've added any appropriate transforms below
+        // so that we're testing these best effort functions.
+        XCTAssertEqual(MemoryLayout<TLSConfiguration>.size, 146, "TLSConfiguration has changed size: you probably need to update this test!")
+
         let first = TLSConfiguration.makeClientConfiguration()
 
         let transforms: [(inout TLSConfiguration) -> Void] = [


### PR DESCRIPTION
Motivation:

TLSConfiguration cannot be made equatable due to its use of closures, so
we have our own best-effort functions. Unfortunately, I forgot to make
sure everything was added to them, so I'm doing so now.

Modifications:

- Add missing fields to bestEffort functions.

Result:

Better bestEffort functions.