### PR TITLE
Invoke `additionalPeerCertificateVerificationCallback` with peer certificate

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -258,7 +258,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             
             if let additionalCertificateChainVerification = connection.parentContext.additionalCertificateChainVerification {
                 state = .additionalVerification
-                additionalCertificateChainVerification(context.channel)
+                additionalCertificateChainVerification(connection.getPeerCertificate(), context.channel)
                     .hop(to: context.eventLoop)
                     .whenComplete { result in
                         self.completedAdditionalCertificateChainVerification(result: result)

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -270,7 +270,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
                     preconditionFailure("""
                         Couldn't get peer certificate after chain verification was successful.
                         This should be impossible as we have a precondition during creation of this handler that requires certificate verification.
-                        Please fill an issue.
+                        Please file an issue.
                     """)
                 }
                 additionalPeerCertificateVerificationCallback(peerCertificate, context.channel)

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -89,6 +89,17 @@ public typealias NIOSSLVerificationCallback = (NIOSSLVerificationResult, NIOSSLC
 /// Note that setting this callback will override _all_ verification logic that BoringSSL provides.
 public typealias NIOSSLCustomVerificationCallback = ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void
 
+/// A custom verification callback that allows additional peer certificate verification logic after the logic of BoringSSL has completed successfully.
+///
+/// It is invoked with two arguments:
+/// 1. The leaf certificate from the peer certificate chain if available
+/// 2. The channel to which the certificate belongs
+///
+/// The handshake will only succeed if the returned promise completes successfully.
+///
+/// - warning: This API is not guaranteed to be stable and is likely to be changed without further notice, hence the underscore prefix.
+public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCertificate?, Channel) -> EventLoopFuture<Void>
+
 
 /// A callback that can be used to implement `SSLKEYLOGFILE` support.
 ///

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -92,13 +92,13 @@ public typealias NIOSSLCustomVerificationCallback = ([NIOSSLCertificate], EventL
 /// A custom verification callback that allows additional peer certificate verification logic after the logic of BoringSSL has completed successfully.
 ///
 /// It is invoked with two arguments:
-/// 1. The leaf certificate from the peer certificate chain if available
+/// 1. The verified leaf certificate from the peer certificate chain
 /// 2. The channel to which the certificate belongs
 ///
 /// The handshake will only succeed if the returned promise completes successfully.
 ///
 /// - warning: This API is not guaranteed to be stable and is likely to be changed without further notice, hence the underscore prefix.
-public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCertificate?, Channel) -> EventLoopFuture<Void>
+public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCertificate, Channel) -> EventLoopFuture<Void>
 
 
 /// A callback that can be used to implement `SSLKEYLOGFILE` support.

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -127,14 +127,12 @@ public final class NIOSSLContext {
     private let callbackManager: CallbackManagerProtocol?
     private var keyLogManager: KeyLogCallbackManager?
     internal let configuration: TLSConfiguration
-    internal let additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback?
 
     /// Initialize a context that will create multiple connections, all with the same
     /// configuration.
     internal init(
         configuration: TLSConfiguration,
-        callbackManager: CallbackManagerProtocol?,
-        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback?
+        callbackManager: CallbackManagerProtocol?
     ) throws {
         guard boringSSLIsInitialized else { fatalError("Failed to initialize BoringSSL") }
         guard let context = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_method()) else { fatalError("Failed to create new BoringSSL context") }
@@ -273,7 +271,6 @@ public final class NIOSSLContext {
         self.sslContext = context
         self.configuration = configuration
         self.callbackManager = callbackManager
-        self.additionalCertificateChainVerification = additionalCertificateChainVerification
 
         // Always make it possible to get from an SSL_CTX structure back to this.
         let ptrToSelf = Unmanaged.passUnretained(self).toOpaque()
@@ -289,7 +286,7 @@ public final class NIOSSLContext {
     ///
     /// - Warning: Avoid creating `NIOSSLContext`s on any `EventLoop` because it does _blocking disk I/O_.
     public convenience init(configuration: TLSConfiguration) throws {
-        try self.init(configuration: configuration, callbackManager: nil, additionalCertificateChainVerification: nil)
+        try self.init(configuration: configuration, callbackManager: nil)
     }
 
     /// Initialize a context that will create multiple connections, all with the same
@@ -311,14 +308,7 @@ public final class NIOSSLContext {
     public convenience init<T: Collection>(configuration: TLSConfiguration,
                                            passphraseCallback: @escaping NIOSSLPassphraseCallback<T>) throws where T.Element == UInt8 {
         let manager = BoringSSLPassphraseCallbackManager(userCallback: passphraseCallback)
-        try self.init(configuration: configuration, callbackManager: manager, additionalCertificateChainVerification: nil)
-    }
-    
-    public static func _init(
-        configuration: TLSConfiguration,
-        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback
-    ) throws -> Self {
-        try self.init(configuration: configuration, callbackManager: nil, additionalCertificateChainVerification: nil)
+        try self.init(configuration: configuration, callbackManager: manager)
     }
 
     /// Create a new connection object with the configuration from this

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -123,24 +123,18 @@ private func alpnCallback(ssl: OpaquePointer?,
 ///
 /// - Warning: Avoid creating `NIOSSLContext`s on any `EventLoop` because it does _blocking disk I/O_.
 public final class NIOSSLContext {
-    /// A custom verification callback that allows additional certificate verification logic after the logic of BoringSSL has completed successfully.
-    /// It is invoked with two arguments:
-    /// 1. The leaf certificate from the peer certificate chain if available
-    /// 2. The channel to which the certificate belongs
-    /// The handshake will only succeed if the return promise complets succesfully
-    public typealias _AdditionalCertificateChainVerificationCallback = (NIOSSLCertificate?, Channel) -> EventLoopFuture<Void>
     private let sslContext: OpaquePointer
     private let callbackManager: CallbackManagerProtocol?
     private var keyLogManager: KeyLogCallbackManager?
     internal let configuration: TLSConfiguration
-    internal let additionalCertificateChainVerification: _AdditionalCertificateChainVerificationCallback?
+    internal let additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback?
 
     /// Initialize a context that will create multiple connections, all with the same
     /// configuration.
     internal init(
         configuration: TLSConfiguration,
         callbackManager: CallbackManagerProtocol?,
-        additionalCertificateChainVerification: _AdditionalCertificateChainVerificationCallback?
+        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback?
     ) throws {
         guard boringSSLIsInitialized else { fatalError("Failed to initialize BoringSSL") }
         guard let context = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_method()) else { fatalError("Failed to create new BoringSSL context") }
@@ -322,7 +316,7 @@ public final class NIOSSLContext {
     
     public static func _init(
         configuration: TLSConfiguration,
-        additionalCertificateChainVerification: _AdditionalCertificateChainVerificationCallback
+        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback
     ) throws -> Self {
         try self.init(configuration: configuration, callbackManager: nil, additionalCertificateChainVerification: nil)
     }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -465,7 +465,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     private func configuredClientContext(
-        additionalCertificateChainVerification: NIOSSLContext._AdditionalCertificateChainVerificationCallback? = nil,
+        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> NIOSSLContext {

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -291,6 +291,7 @@ internal func serverTLSChannel(context: NIOSSLContext,
 }
 
 internal func clientTLSChannel(context: NIOSSLContext,
+                               additionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback? = nil,
                                preHandlers: [ChannelHandler],
                                postHandlers: [ChannelHandler],
                                group: EventLoopGroup,
@@ -299,7 +300,7 @@ internal func clientTLSChannel(context: NIOSSLContext,
                                file: StaticString = #file,
                                line: UInt = #line) throws -> Channel {
     func tlsFactory() -> NIOSSLClientTLSProvider<ClientBootstrap> {
-        return try! .init(context: context, serverHostname: serverHostname)
+        return try! .init(context: context, serverHostname: serverHostname, additionalPeerCertificateVerificationCallback: additionalPeerCertificateVerificationCallback)
     }
 
     return try _clientTLSChannel(context: context, preHandlers: preHandlers, postHandlers: postHandlers, group: group, connectingTo: connectingTo, tlsFactory: tlsFactory)
@@ -465,7 +466,6 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     private func configuredClientContext(
-        additionalCertificateChainVerification: _NIOAdditionalPeerCertificateVerificationCallback? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> NIOSSLContext {
@@ -473,8 +473,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
         return try assertNoThrowWithValue(NIOSSLContext(
             configuration: config,
-            callbackManager: nil,
-            additionalCertificateChainVerification: additionalCertificateChainVerification
+            callbackManager: nil
         ), file: file, line: line)
     }
 
@@ -940,10 +939,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
         
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
-            XCTAssertEqual(cert, Self.cert)
-            return channel.eventLoop.makeSucceededFuture(())
-        })
+        let clientCtx = try configuredClientContext()
 
         let serverChannel = try serverTLSChannel(context: serverCtx,
                                                  handlers: [],
@@ -954,6 +950,10 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let eventHandler = EventRecorderHandler<TLSUserEvent>()
         let clientChannel = try clientTLSChannel(context: clientCtx,
+                                                 additionalPeerCertificateVerificationCallback: { cert, channel in
+                                                     XCTAssertEqual(cert, Self.cert)
+                                                     return channel.eventLoop.makeSucceededFuture(())
+                                                 },
                                                  preHandlers: [],
                                                  postHandlers: [eventHandler],
                                                  group: group,
@@ -977,10 +977,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
         
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
-            XCTAssertEqual(cert, Self.cert)
-            return channel.eventLoop.makeFailedFuture(CustomUserError())
-        })
+        let clientCtx = try configuredClientContext()
 
         let serverChannel = try serverTLSChannel(context: serverCtx,
                                                  handlers: [],
@@ -992,6 +989,10 @@ class NIOSSLIntegrationTest: XCTestCase {
         let errorHandler = ErrorCatcher<Error>()
         let clientChannel = try clientTLSChannel(
             context: clientCtx,
+            additionalPeerCertificateVerificationCallback: { cert, channel in
+                XCTAssertEqual(cert, Self.cert)
+                return channel.eventLoop.makeFailedFuture(CustomUserError())
+            },
             preHandlers: [],
             postHandlers: [errorHandler],
             group: group,
@@ -1025,11 +1026,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         
         let additionalHandshakePromise = group.next().makePromise(of: Void.self)
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
-            XCTAssertEqual(cert, Self.cert)
-            channel.flush()
-            return additionalHandshakePromise.futureResult
-        })
+        let clientCtx = try configuredClientContext()
 
         let serverChannel = try serverTLSChannel(context: serverCtx,
                                                  handlers: [],
@@ -1040,6 +1037,11 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let eventHandler = EventRecorderHandler<TLSUserEvent>()
         let clientChannel = try clientTLSChannel(context: clientCtx,
+                                                 additionalPeerCertificateVerificationCallback: { cert, channel in
+                                                     XCTAssertEqual(cert, Self.cert)
+                                                     channel.flush()
+                                                     return additionalHandshakePromise.futureResult
+                                                 },
                                                  preHandlers: [],
                                                  postHandlers: [eventHandler],
                                                  group: group,

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -465,7 +465,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     private func configuredClientContext(
-        additionalCertificateChainVerification: NIOSSLContext.AdditionalCertificateChainVerificationCallback? = nil,
+        additionalCertificateChainVerification: NIOSSLContext._AdditionalCertificateChainVerificationCallback? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> NIOSSLContext {
@@ -940,8 +940,9 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
         
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { channel in
-            channel.eventLoop.makeSucceededFuture(())
+        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
+            XCTAssertEqual(cert, Self.cert)
+            return channel.eventLoop.makeSucceededFuture(())
         })
 
         let serverChannel = try serverTLSChannel(context: serverCtx,
@@ -976,8 +977,9 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
         
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { channel in
-            channel.eventLoop.makeFailedFuture(CustomUserError())
+        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
+            XCTAssertEqual(cert, Self.cert)
+            return channel.eventLoop.makeFailedFuture(CustomUserError())
         })
 
         let serverChannel = try serverTLSChannel(context: serverCtx,
@@ -1023,7 +1025,8 @@ class NIOSSLIntegrationTest: XCTestCase {
         
         let additionalHandshakePromise = group.next().makePromise(of: Void.self)
         let serverCtx = try configuredSSLContext()
-        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { channel in
+        let clientCtx = try configuredClientContext(additionalCertificateChainVerification: { cert, channel in
+            XCTAssertEqual(cert, Self.cert)
             channel.flush()
             return additionalHandshakePromise.futureResult
         })


### PR DESCRIPTION
### Motivation
We want that users can do additional verification of the peer certificate without completely disabling the default certificate chain verification. `additionalPeerCertificateVerificationCallback` is called after the normal certificate chain verification was successful but still gives the user the possibility to accept or reject a connection asynchronously based on the peer certificate.

### Modifications
- rename `AdditionalCertificateChainVerificationCallback` to `_NIOAdditionalPeerCertificateVerificationCallback` as we do not pass in the full certificate chain but just the peers leaf certificate. 
- move the callback from `NIOSSLContext` to `NIOSSLHandler` so users can capture variables in a closure per channel
- make the API public but prefixed with an underscore to indicate that this is not a stable feature. We would like to eventually provide the full certificate chain instead of just the the leaf certificate once we can request it from BoringSSL.


### Result
Users can now easily do custom peer certificate validation while still getting the system/BoringSSL provided full certificate chain validation.