### PR TITLE
Make `NIOSSLCertificate._subjectAlternativeNames()` return type non-optional

### DIFF
--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -135,25 +135,23 @@ private func validIdentityForService(serverHostname: Array<UInt8>?,
     // them, and then refuse to check the commonName field. If there are no SAN fields to
     // validate against, we'll check commonName.
     var checkedMatch = false
-    if let alternativeNames = leafCertificate._subjectAlternativeNames() {
-        for name in alternativeNames {
-            checkedMatch = true
+    for name in leafCertificate._subjectAlternativeNames() {
+        checkedMatch = true
 
-            switch name.nameType {
-            case .dnsName:
-                let dnsName = Array(name.contents)
-                if matchHostname(ourHostname: serverHostnameSlice, firstPeriodIndex: firstPeriodIndex, dnsName: dnsName) {
-                    return true
-                }
-            case .ipAddress:
-                if let ip = _SubjectAlternativeName.IPAddress(name),
-                   matchIpAddress(socketAddress: socketAddress, certificateIP: ip)
-                {
-                    return true
-                }
-            default:
-                continue
+        switch name.nameType {
+        case .dnsName:
+            let dnsName = Array(name.contents)
+            if matchHostname(ourHostname: serverHostnameSlice, firstPeriodIndex: firstPeriodIndex, dnsName: dnsName) {
+                return true
             }
+        case .ipAddress:
+            if let ip = _SubjectAlternativeName.IPAddress(name),
+               matchIpAddress(socketAddress: socketAddress, certificateIP: ip)
+            {
+                return true
+            }
+        default:
+            continue
         }
     }
 

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -165,11 +165,9 @@ public class NIOSSLCertificate {
     }
 
     /// Get a collection of the alternative names in the certificate.
-    public func _subjectAlternativeNames() -> _SubjectAlternativeNames? {
-        guard let sanExtension = CNIOBoringSSL_X509_get_ext_d2i(self.ref, NID_subject_alt_name, nil, nil) else {
-            return nil
-        }
-        return _SubjectAlternativeNames(nameStack: OpaquePointer(sanExtension))
+    public func _subjectAlternativeNames() -> _SubjectAlternativeNames {
+        let sanExtension = CNIOBoringSSL_X509_get_ext_d2i(self.ref, NID_subject_alt_name, nil, nil)
+        return _SubjectAlternativeNames(nameStack: sanExtension.map(OpaquePointer.init))
     }
     
     /// Extracts the SHA1 hash of the subject name before it has been truncated.
@@ -406,7 +404,8 @@ extension NIOSSLCertificate: CustomStringConvertible {
             let commonName = String(decoding: commonNameBytes, as: UTF8.self)
             desc += ";common_name=" + commonName
         }
-        if let alternativeName = self._subjectAlternativeNames() {
+        let alternativeName = self._subjectAlternativeNames()
+        if !alternativeName.isEmpty {
             let altNames = alternativeName.compactMap { name in
                 switch name.nameType {
                 case .dnsName:

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -379,9 +379,7 @@ class SSLCertificateTest: XCTestCase {
         precondition(inet_pton(AF_INET6, "2001:db8::1", &v6addr) == 1)
 
         let cert = try NIOSSLCertificate(bytes: .init(certWithAllSupportedSANTypes.utf8), format: .pem)
-        guard let sans = cert._subjectAlternativeNames() else {
-            return XCTFail("could not get subject alternative names")
-        }
+        let sans = cert._subjectAlternativeNames()
         XCTAssertEqual(sans.count, 7)
         XCTAssertEqual(sans[0].nameType, .dnsName)
         XCTAssertEqual(String(decoding: sans[0].contents, as: UTF8.self), "localhost")
@@ -405,7 +403,7 @@ class SSLCertificateTest: XCTestCase {
 
     func testNonexistentSan() throws {
         let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
-        XCTAssertNil(cert._subjectAlternativeNames())
+        XCTAssertTrue(cert._subjectAlternativeNames().isEmpty)
     }
 
     func testCommonName() throws {


### PR DESCRIPTION
### Motivation

`NIOSSLCertificate._subjectAlternativeNames()` can currently return `nil` or an empty `_SubjectAlternativeNames` collection. There is no semantic difference in these two cases.

### Modification
- support a `nil` `nameStack` in `_SubjectAlternativeNames`
- make `NIOSSLCertificate._subjectAlternativeNames()` return type non-optional 

### Result

We now return an empty `_SubjectAlternativeNames` instead of `nil`

### Source Compatibility

This is a non-breaking change even though this is public API because it has an underscore prefix. It is therefore unstable and allowed to change in a minor release.