### PR TITLE
Use Docc for documentation

### DIFF
--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -37,7 +37,6 @@ func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
             .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-            .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {
         return [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project
@@ -37,7 +37,6 @@ func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
             .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-            .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {
         return [

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -15,7 +15,7 @@
 import NIOCore
 @_implementationOnly import CNIOBoringSSL
 
-/// `NIOSSLCustomPrivateKey` defines the interface of a custom, non-BoringSSL private key.
+/// ``NIOSSLCustomPrivateKey`` defines the interface of a custom, non-BoringSSL private key.
 ///
 /// In a number of circumstances it is advantageous to store a TLS private key in some form of high-security storage,
 /// such as a smart card. In these cases it is not possible to represent the TLS private key directly as a sequence
@@ -23,11 +23,12 @@ import NIOCore
 ///
 /// This protocol allows a type to implement callbacks that perform the specific operation required by the TLS handshake.
 /// Implementers are required to specify what signature algorithms they support, and then must implement **only one** of
-/// the `sign`/`decrypt` functions. For elliptic curve keys, implementers should implement `sign`. For RSA keys,
-/// implementers should implement `sign` and, if supporting RSA key exchange in TLS versions before 1.3, you should
-/// also implement `decrypt`.
+/// the ``NIOSSLCustomPrivateKey/sign(channel:algorithm:data:)`` and ``NIOSSLCustomPrivateKey/decrypt(channel:data:)``
+/// functions. For elliptic curve keys, implementers should implement ``NIOSSLCustomPrivateKey/sign(channel:algorithm:data:)``.
+/// For RSA keys, implementers should implement ``NIOSSLCustomPrivateKey/sign(channel:algorithm:data:)`` and, if supporting
+/// RSA key exchange in TLS versions before 1.3, you should also implement ``NIOSSLCustomPrivateKey/decrypt(channel:data:)``.
 ///
-/// If the same `NIOSSLCustomPrivateKey` implementation is used by multiple channels at once, then no synchronization
+/// If the same ``NIOSSLCustomPrivateKey`` implementation is used by multiple channels at once, then no synchronization
 /// is imposed by SwiftNIO. The calls to the protocol requirements will be made on event loop threads, so if further
 /// synchronization is required it is up to the implementer to provide it. Note that it is unacceptable to block in
 /// these functions, and so potentially blocking operations must delegate to another thread.
@@ -45,7 +46,7 @@ public protocol NIOSSLCustomPrivateKey {
     ///
     /// - parameters:
     ///     - channel: The `Channel` representing the connection for which we are performing the signing operation.
-    ///     - algorithm: The `SignatureAlgorithm` that should be used to generate the signature.
+    ///     - algorithm: The ``SignatureAlgorithm`` that should be used to generate the signature.
     ///     - data: The data to be signed.
     /// - returns: An `EventLoopFuture` that will be fulfilled with a `ByteBuffer` containing the signature bytes, if
     ///     the signing operation completes, or that will be failed with a relevant `Error` if the signature could not

--- a/Sources/NIOSSL/Docs.docc/index.md
+++ b/Sources/NIOSSL/Docs.docc/index.md
@@ -1,0 +1,118 @@
+# ``NIOSSL``
+
+TLS for SwiftNIO.
+
+SwiftNIO SSL is a Swift package that contains an implementation of TLS based on BoringSSL. This package allows users of SwiftNIO to write protocol clients and servers that use TLS to secure data in flight.
+
+The name is inspired primarily by the names of the library this package uses (BoringSSL), and not because we don't know the name of the protocol. We know the protocol is TLS!
+
+## Using SwiftNIO SSL
+
+SwiftNIO SSL provides two `ChannelHandler`s to use to secure a data stream: the ``NIOSSLClientHandler`` and the ``NIOSSLServerHandler``. Each of these can be added to a `Channel` to secure the communications on that channel.
+
+Additionally, we provide a number of low-level primitives for configuring your TLS connections. These will be shown below.
+
+To secure a server connection, you will need a X.509 certificate chain in a file (either PEM or DER, but PEM is far easier), and the associated private key for the leaf certificate. These objects can then be wrapped up in a ``TLSConfiguration`` object that is used to initialize the `ChannelHandler`.
+
+For example:
+
+```swift
+let configuration = TLSConfiguration.makeServerConfiguration(
+    certificateChain: try NIOSSLCertificate.fromPEMFile("cert.pem").map { .certificate($0) },
+    privateKey: .file("key.pem")
+)
+let sslContext = try NIOSSLContext(configuration: configuration)
+
+let server = ServerBootstrap(group: group)
+    .childChannelInitializer { channel in
+        // important: The handler must be initialized _inside_ the `childChannelInitializer`
+        let handler = NIOSSLServerHandler(context: sslContext)
+
+        [...]
+        channel.pipeline.addHandler(handler)
+        [...]
+    }
+```
+
+For clients, it is a bit simpler as there is no need to have a certificate chain or private key (though clients *may* have these things). Setup for clients may be done like this:
+
+```swift
+let configuration = TLSConfiguration.makeClientConfiguration()
+let sslContext = try NIOSSLContext(configuration: configuration)
+
+let client = ClientBootstrap(group: group)
+    .channelInitializer { channel in
+        // important: The handler must be initialized _inside_ the `channelInitializer`
+        let handler = try NIOSSLClientHandler(context: sslContext)
+
+        [...]
+        channel.pipeline.addHandler(handler)
+        [...]
+    }
+```
+Note that SwiftNIO SSL currently requires Swift 5.4 and above. Release 2.13.x and prior support Swift 5.0 and 5.1, Release 2.18.x and prior supports Swift 5.2 and 5.3.
+
+
+## Topics
+
+### Channel Handlers
+
+- ``NIOSSLClientHandler``
+- ``NIOSSLServerHandler``
+- ``NIOSSLHandler``
+
+### Certificates and Keys
+
+- ``NIOSSLCertificate``
+- ``NIOSSLPrivateKey``
+- ``NIOSSLPassphraseCallback``
+- ``NIOSSLPassphraseSetter``
+- ``NIOSSLPublicKey``
+- ``NIOSSLCustomPrivateKey``
+- ``NIOSSLPKCS12Bundle``
+
+### Custom Verification Callbacks
+
+- ``NIOSSLCustomVerificationCallback``
+- ``NIOSSLVerificationCallback``
+- ``NIOSSLVerificationResult``
+
+### Configuration and State
+
+- ``TLSConfiguration``
+- ``TLSVersion``
+- ``NIOTLSCipher``
+- ``NIOSSLSerializationFormats``
+- ``CertificateVerification``
+- ``NIORenegotiationSupport``
+- ``SignatureAlgorithm``
+- ``defaultCipherSuites``
+- ``NIOSSLTrustRoots``
+- ``NIOSSLAdditionalTrustRoots``
+- ``NIOSSLCertificateSource``
+- ``NIOSSLPrivateKeySource``
+- ``NIOSSLKeyLogCallback``
+- ``NIOPSKClientIdentityCallback``
+- ``NIOPSKServerIdentityCallback``
+- ``PSKServerIdentityResponse``
+- ``PSKClientIdentityResponse``
+- ``NIOSSLContext``
+
+### Generic TLS Abstractions
+
+- ``NIOSSLClientTLSProvider``
+
+### Utility Objects
+
+- ``NIOSSLSecureBytes``
+- ``NIOSSLObjectIdentifier``
+
+### Errors
+
+- ``NIOSSLError``
+- ``BoringSSLError``
+- ``NIOBoringSSLErrorStack``
+- ``BoringSSLInternalError``
+- ``NIOSSLCloseTimedOutError``
+- ``NIOTLSUnwrappingError``
+- ``NIOSSLExtraError``

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -52,8 +52,14 @@ extension String {
 
 /// A channel handler that wraps a channel in TLS using NIOSSL.
 /// This handler can be used in channels that are acting as the client
-/// in the TLS dialog. For server connections, use the `NIOSSLServerHandler`.
+/// in the TLS dialog. For server connections, use the ``NIOSSLServerHandler``.
 public final class NIOSSLClientHandler: NIOSSLHandler {
+    /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
+    ///     - serverHostname: The hostname of the server we're trying to connect to, if known. This will be used in the SNI extension,
+    ///         and used to validate the server certificate.
     public convenience init(context: NIOSSLContext, serverHostname: String?) throws {
         try self.init(context: context, serverHostname: serverHostname, optionalCustomVerificationCallback: nil, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }
@@ -83,7 +89,16 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
         super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil)
     }
 
-
+    /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
+    ///     - serverHostname: The hostname of the server we're trying to connect to, if known. This will be used in the SNI extension,
+    ///         and used to validate the server certificate.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
     public convenience init(context: NIOSSLContext, serverHostname: String?, customVerificationCallback: @escaping NIOSSLCustomVerificationCallback) throws {
         try self.init(context: context, serverHostname: serverHostname, optionalCustomVerificationCallback: customVerificationCallback, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -16,9 +16,10 @@ import NIOCore
 @_implementationOnly import CNIOBoringSSL
 import NIOTLS
 
-/// The base class for all NIOSSL handlers. This class cannot actually be instantiated by
-/// users directly: instead, users must select which mode they would like their handler to
-/// operate in, client or server.
+/// The base class for all NIOSSL handlers.
+///
+/// This class cannot actually be instantiated by users directly: instead, users must select
+/// which mode they would like their handler to operate in, client or server.
 ///
 /// This class exists to deal with the reality that for almost the entirety of the lifetime
 /// of a TLS connection there is no meaningful distinction between a server and a client.
@@ -619,14 +620,17 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
 }
 
 extension NIOSSLHandler {
-    /// Variable that can be queried during the connection lifecycle to grab the `TLSVersion` used on the `SSLConnection`.
+    /// Variable that can be queried during the connection lifecycle to grab the ``TLSVersion`` used on this connection.
+    ///
+    /// This variable **is not thread-safe**: you **must** call it from the correct event
+    /// loop thread.
     public var tlsVersion: TLSVersion? {
         return self.connection.getTLSVersionForConnection()
     }
 }
 
 extension Channel {
-    ///  API to extract the `TLSVersion` from an EventLoopFuture.
+    ///  API to extract the ``TLSVersion`` from off the `Channel`.
     public func nioSSL_tlsVersion() -> EventLoopFuture<TLSVersion?> {
         return self.pipeline.handler(type: NIOSSLHandler.self).map {
             $0.tlsVersion
@@ -635,7 +639,7 @@ extension Channel {
 }
 
 extension ChannelPipeline.SynchronousOperations {
-    /// API to query the `TLSVersion` directly from the `ChannelPipeline`.
+    /// API to query the ``TLSVersion`` directly from the `ChannelPipeline`.
     public func nioSSL_tlsVersion() throws -> TLSVersion? {
         let handler = try self.handler(type: NIOSSLHandler.self)
         return handler.tlsVersion
@@ -648,8 +652,8 @@ extension NIOSSLHandler {
     /// from the pipeline. This will leave the connection established, but remove the TLS wrapper
     /// from it.
     ///
-    /// This will send a CLOSE_NOTIFY and wait for the corresponding CLOSE_NOTIFY. When that next
-    /// CLOSE_NOTIFY is received, this handler will pass on all pending writes and remove itself
+    /// This will send a `CLOSE_NOTIFY` and wait for the corresponding `CLOSE_NOTIFY`. When that next
+    /// `CLOSE_NOTIFY` is received, this handler will pass on all pending writes and remove itself
     /// from the channel pipeline. If the shutdown times out then an error will fire down the
     /// pipeline, this handler will remove itself from the pipeline, but the channel will not be
     /// automatically closed.

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -16,8 +16,12 @@ import NIOCore
 
 /// A channel handler that wraps a channel in TLS using NIOSSL. This
 /// handler can be used in channels that are acting as the server in
-/// the TLS dialog. For client connections, use the `NIOSSLClientHandler`.
+/// the TLS dialog. For client connections, use the ``NIOSSLClientHandler``.
 public final class NIOSSLServerHandler: NIOSSLHandler {
+    /// Construct a new ``NIOSSLServerHandler`` with the given `context`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
     public convenience init(context: NIOSSLContext) {
         self.init(context: context, optionalCustomVerificationCallback: nil, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }
@@ -37,6 +41,14 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
         super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil)
     }
 
+    /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
     public convenience init(context: NIOSSLContext, customVerificationCallback: @escaping NIOSSLCustomVerificationCallback) {
         self.init(context: context, optionalCustomVerificationCallback: customVerificationCallback, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }

--- a/Sources/NIOSSL/ObjectIdentifier.swift
+++ b/Sources/NIOSSL/ObjectIdentifier.swift
@@ -15,7 +15,7 @@
 @_implementationOnly import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSLShims
 
-/// Object Identifier (OID)
+/// A representation of an ASN.1 Object Identifier (OID)
 public struct NIOSSLObjectIdentifier {
     private enum Storage {
         final class Deallocator {
@@ -61,6 +61,7 @@ public struct NIOSSLObjectIdentifier {
     private let storage: Storage
     
     /// Creates a Object Identifier (OID) from its textual dotted representation (e.g. `1.2.3`)
+    ///
     /// - Parameter string: textual dotted representation of an OID
     public init?(_ string: String) {
         let result = string.withCString { string in
@@ -77,6 +78,7 @@ public struct NIOSSLObjectIdentifier {
     }
     
     /// Creates an Object Identifier (OID) from an OpenSSL reference.
+    /// 
     /// - Note: initialising an ``NIOSSLObjectIdentifier`` takes ownership of the reference and will free it after the reference count drops to zero
     /// - Parameter reference: reference to a valid OpenSSL OID aka OBJ
     internal init(takingOwnershipOf reference: OpaquePointer!) {

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -52,7 +52,8 @@ public class NIOSSLCertificate {
     private var ref: OpaquePointer {
         return self._ref
     }
-    
+
+    /// The serial number of this certificate, as raw bytes.
     public var serialNumber: [UInt8] {
         let serialNumber = CNIOBoringSSL_X509_get_serialNumber(self.ref)!
         return Array(UnsafeBufferPointer(start: serialNumber.pointee.data, count: Int(serialNumber.pointee.length)))
@@ -62,10 +63,14 @@ public class NIOSSLCertificate {
         self._ref = ref
     }
 
-    /// Create a NIOSSLCertificate from a file at a given path in either PEM or
+    /// Create a ``NIOSSLCertificate`` from a file at a given path in either PEM or
     /// DER format.
     ///
     /// Note that this method will only ever load the first certificate from a given file.
+    ///
+    /// - parameters:
+    ///     - file: The path to the file to load the certificate from.
+    ///     - format: The format to use to parse the file.
     public convenience init(file: String, format: NIOSSLSerializationFormats) throws {
         let fileObject = try Posix.fopen(file: file, mode: "rb")
         defer {
@@ -87,7 +92,7 @@ public class NIOSSLCertificate {
         self.init(withOwnedReference: x509!)
     }
 
-    /// Create a NIOSSLCertificate from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLCertificate`` from a buffer of bytes in either PEM or
     /// DER format.
     ///
     /// - SeeAlso: `NIOSSLCertificate.init(bytes:format:)`
@@ -96,8 +101,12 @@ public class NIOSSLCertificate {
         try self.init(bytes: buffer.map(UInt8.init), format: format)
     }
 
-    /// Create a NIOSSLCertificate from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLCertificate`` from a buffer of bytes in either PEM or
     /// DER format.
+    ///
+    /// - parameters:
+    ///     - bytes: The raw bytes containing the certificate.
+    ///     - format: The format to use to parse the file.
     public convenience init(bytes: [UInt8], format: NIOSSLSerializationFormats) throws {
         let ref = bytes.withUnsafeBytes { (ptr) -> OpaquePointer? in
             let bio = CNIOBoringSSL_BIO_new_mem_buf(ptr.baseAddress, CInt(ptr.count))!
@@ -232,9 +241,9 @@ public class NIOSSLCertificate {
 // enable users of swift-nio-ssl to use other cryptography libraries it will be helpful to provide
 // the ability to obtain the bytes that correspond to certificates and keys.
 extension NIOSSLCertificate {
-    /// Obtain the public key for this `NIOSSLCertificate`.
+    /// Obtain the public key for this ``NIOSSLCertificate``.
     ///
-    /// - returns: This certificate's `NIOSSLPublicKey`.
+    /// - returns: This certificate's ``NIOSSLPublicKey``.
     /// - throws: If an error is encountered extracting the key.
     public func extractPublicKey() throws -> NIOSSLPublicKey {
         guard let key = CNIOBoringSSL_X509_get_pubkey(self.ref) else {
@@ -252,7 +261,7 @@ extension NIOSSLCertificate {
         return try self.withUnsafeDERCertificateBuffer { Array($0) }
     }
 
-    /// Create an array of `NIOSSLCertificate`s from a buffer of bytes in PEM format.
+    /// Create an array of ``NIOSSLCertificate``s from a buffer of bytes in PEM format.
     ///
     /// - Parameter buffer: The PEM buffer to read certificates from.
     /// - Throws: If an error is encountered while reading certificates.
@@ -262,7 +271,7 @@ extension NIOSSLCertificate {
         return try fromPEMBytes(buffer.map(UInt8.init))
     }
 
-    /// Create an array of `NIOSSLCertificate`s from a buffer of bytes in PEM format.
+    /// Create an array of ``NIOSSLCertificate``s from a buffer of bytes in PEM format.
     ///
     /// - Parameter bytes: The PEM buffer to read certificates from.
     /// - Throws: If an error is encountered while reading certificates.
@@ -282,7 +291,7 @@ extension NIOSSLCertificate {
         }
     }
 
-    /// Create an array of `NIOSSLCertificate`s from a file at a given path in PEM format.
+    /// Create an array of ``NIOSSLCertificate``s from a file at a given path in PEM format.
     ///
     /// - Parameter file: The PEM file to read certificates from.
     /// - Throws: If an error is encountered while reading certificates.

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -214,11 +214,11 @@ private func clientPSKCallback(ssl: OpaquePointer?,
 /// This object is thread-safe and can be shared across TLS connections in your application. Even if the connections
 /// are associated with `Channel`s from different `EventLoop`s.
 ///
-/// - Note: Creating a `NIOSSLContext` is a very expensive operation because BoringSSL will usually need to load and
+/// > Note: Creating a ``NIOSSLContext`` is a very expensive operation because BoringSSL will usually need to load and
 ///         parse large number of certificates from the system trust store. Therefore, creating a
-///         `NIOSSLContext` will likely allocate many thousand times and will also _perform blocking disk I/O_.
+///         ``NIOSSLContext`` will likely allocate many thousand times and will also _perform blocking disk I/O_.
 ///
-/// - Warning: Avoid creating `NIOSSLContext`s on any `EventLoop` because it does _blocking disk I/O_.
+/// > Warning: Avoid creating ``NIOSSLContext``s on any `EventLoop` because it does _blocking disk I/O_.
 public final class NIOSSLContext {
     private let sslContext: OpaquePointer
     private let callbackManager: CallbackManagerProtocol?
@@ -395,11 +395,11 @@ public final class NIOSSLContext {
     /// Initialize a context that will create multiple connections, all with the same
     /// configuration.
     ///
-    /// - Note: Creating a `NIOSSLContext` is a very expensive operation because BoringSSL will usually need to load and
+    /// - Note: Creating a ``NIOSSLContext`` is a very expensive operation because BoringSSL will usually need to load and
     ///         parse large number of certificates from the system trust store. Therefore, creating a
-    ///         `NIOSSLContext` will likely allocate many thousand times and will also _perform blocking disk I/O_.
+    ///         ``NIOSSLContext`` will likely allocate many thousand times and will also _perform blocking disk I/O_.
     ///
-    /// - Warning: Avoid creating `NIOSSLContext`s on any `EventLoop` because it does _blocking disk I/O_.
+    /// - Warning: Avoid creating ``NIOSSLContext``s on any `EventLoop` because it does _blocking disk I/O_.
     public convenience init(configuration: TLSConfiguration) throws {
         try self.init(configuration: configuration, callbackManager: nil)
     }
@@ -408,18 +408,18 @@ public final class NIOSSLContext {
     /// configuration, along with a callback that will be called when needed to decrypt any
     /// encrypted private keys.
     ///
-    /// - Note: Creating a `NIOSSLContext` is a very expensive operation because BoringSSL will usually need to load and
+    /// - Note: Creating a ``NIOSSLContext`` is a very expensive operation because BoringSSL will usually need to load and
     ///         parse large number of certificates from the system trust store. Therefore, creating a
-    ///         `NIOSSLContext` will likely allocate many thousand times and will also _perform blocking disk I/O_.
+    ///         ``NIOSSLContext`` will likely allocate many thousand times and will also _perform blocking disk I/O_.
     ///
-    /// - Warning: Avoid creating `NIOSSLContext`s on any `EventLoop` because it does _blocking disk I/O_.
+    /// - Warning: Avoid creating ``NIOSSLContext``s on any `EventLoop` because it does _blocking disk I/O_.
     ///
     /// - parameters:
-    ///     - configuration: The `TLSConfiguration` to use for all the connections with this
-    ///         `NIOSSLContext`.
+    ///     - configuration: The ``TLSConfiguration`` to use for all the connections with this
+    ///         ``NIOSSLContext``.
     ///     - passphraseCallback: The callback to use to decrypt any private keys used by this
-    ///         `NIOSSLContext`. For more details on this parameter see the documentation for
-    ///         `NIOSSLPassphraseCallback`.
+    ///         ``NIOSSLContext``. For more details on this parameter see the documentation for
+    ///         ``NIOSSLPassphraseCallback``.
     public convenience init<T: Collection>(configuration: TLSConfiguration,
                                            passphraseCallback: @escaping NIOSSLPassphraseCallback<T>) throws where T.Element == UInt8 {
         let manager = BoringSSLPassphraseCallbackManager(userCallback: passphraseCallback)

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -174,7 +174,7 @@ public enum NIOTLSUnwrappingError: Error {
 }
 
 
-/// This structure contains errors added to NIOSSL after the original `NIOSSLError` enum was
+/// This structure contains errors added to NIOSSL after the original ``NIOSSLError`` enum was
 /// shipped. This is an extensible error object that allows us to evolve it going forward.
 public struct NIOSSLExtraError: Error {
     private var baseError: NIOSSLExtraError.BaseError
@@ -210,7 +210,7 @@ extension NIOSSLExtraError {
 
     /// The SNI hostname requirements have not been met.
     ///
-    /// - note: Should the provided SNI hostname be an IP address instead, `.cannotUseIPAddressInSNI` is thrown instead
+    /// - note: Should the provided SNI hostname be an IP address instead, ``cannotUseIPAddressInSNI`` is thrown instead
     ///         of this error.
     ///
     /// Reasons a hostname might not meet the requirements:

--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -15,21 +15,21 @@
 @_implementationOnly import CNIOBoringSSL
 
 
-/// A container of a single PKCS#12 bundle.
+/// A container for a single PKCS#12 bundle.
 ///
 /// PKCS#12 is a specification that defines an archive format for storing multiple
 /// cryptographic objects together in one file. Its most common usage, and the one
 /// that SwiftNIO is most interested in, is its use to bundle one or more X.509
-/// certificates (`NIOSSLCertificate`) together with an associated private key
-/// (`NIOSSLPrivateKey`).
+/// certificates (``NIOSSLCertificate``) together with an associated private key
+/// (``NIOSSLPrivateKey``).
 ///
 /// ### Working with TLSConfiguration
 ///
-/// In many cases users will want to configure a `TLSConfiguration` with the data
+/// In many cases users will want to configure a ``TLSConfiguration`` with the data
 /// from a PKCS#12 bundle. This object assists in unpacking that bundle into its
 /// associated pieces.
 ///
-/// If you have a PKCS12 bundle, you configure a `TLSConfiguration` like this:
+/// If you have a PKCS12 bundle, you configure a ``TLSConfiguration`` like this:
 ///
 ///     let p12Bundle = NIOSSLPKCS12Bundle(file: pathToMyP12)
 ///     let config = TLSConfiguration.makeServerConfiguration(
@@ -37,9 +37,12 @@
 ///         privateKey: p12Bundle.privateKey
 ///     )
 ///
-/// The created `TLSConfiguration` can then be safely used for your endpoint.
+/// The created ``TLSConfiguration`` can then be safely used for your endpoint.
 public struct NIOSSLPKCS12Bundle: Hashable {
+    /// The chain of ``NIOSSLCertificate`` objects in the PKCS#12 bundle.
     public let certificateChain: [NIOSSLCertificate]
+
+    /// The ``NIOSSLPrivateKey`` object for the leaf certificate in the PKCS#12 bundle.
     public let privateKey: NIOSSLPrivateKey
 
     private init<Bytes: Collection>(ref: OpaquePointer, passphrase: Bytes?) throws where Bytes.Element == UInt8 {
@@ -77,7 +80,7 @@ public struct NIOSSLPKCS12Bundle: Hashable {
 
     }
 
-    /// Create a `NIOSSLPKCS12Bundle` from the given bytes in memory,
+    /// Create a ``NIOSSLPKCS12Bundle`` from the given bytes in memory,
     /// optionally decrypting the bundle with the given passphrase.
     ///
     /// - parameters:
@@ -104,7 +107,7 @@ public struct NIOSSLPKCS12Bundle: Hashable {
         }
     }
 
-    /// Create a `NIOSSLPKCS12Bundle` from the given bytes on disk,
+    /// Create a ``NIOSSLPKCS12Bundle`` from the given bytes on disk,
     /// optionally decrypting the bundle with the given passphrase.
     ///
     /// - parameters:
@@ -130,10 +133,10 @@ public struct NIOSSLPKCS12Bundle: Hashable {
         }
     }
 
-    /// Create a `NIOSSLPKCS12Bundle` from the given bytes on disk,
+    /// Create a ``NIOSSLPKCS12Bundle`` from the given bytes on disk,
     /// assuming it has no passphrase.
     ///
-    /// If the bundle does have a passphrase, call `init(file:passphrase:)` instead.
+    /// If the bundle does have a passphrase, call ``init(file:passphrase:)`` instead.
     ///
     /// - parameters:
     ///     - file: The path to the PKCS#12 bundle on disk.
@@ -141,10 +144,10 @@ public struct NIOSSLPKCS12Bundle: Hashable {
         try self.init(file: file, passphrase: Optional<[UInt8]>.none)
     }
 
-    /// Create a `NIOSSLPKCS12Bundle` from the given bytes in memory,
+    /// Create a ``NIOSSLPKCS12Bundle`` from the given bytes in memory,
     /// assuming it has no passphrase.
     ///
-    /// If the bundle does have a passphrase, call `init(buffer:passphrase:)` instead.
+    /// If the bundle does have a passphrase, call ``init(buffer:passphrase:)`` instead.
     ///
     /// - parameters:
     ///     - buffer: The bytes of the PKCS#12 bundle.

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -14,39 +14,39 @@
 
 @_implementationOnly import CNIOBoringSSL
 
-/// An `NIOSSLPassphraseCallback` is a callback that will be invoked by NIOSSL when it needs to
+/// An ``NIOSSLPassphraseCallback`` is a callback that will be invoked by NIOSSL when it needs to
 /// get access to a private key that is stored in encrypted form.
 ///
 /// This callback will be invoked with one argument, a non-escaping closure that must be called with the
 /// passphrase. Failing to call the closure will cause decryption to fail.
 ///
 /// The reason this design has been used is to allow you to secure any memory storing the passphrase after
-/// use. We guarantee that after the `NIOSSLPassphraseSetter` closure has been invoked the `Collection`
+/// use. We guarantee that after the ``NIOSSLPassphraseSetter`` closure has been invoked the `Collection`
 /// you have passed in will no longer be needed by BoringSSL, and so you can safely destroy any memory it
 /// may be using if you need to.
 public typealias NIOSSLPassphraseCallback<Bytes: Collection> = (NIOSSLPassphraseSetter<Bytes>) throws -> Void where Bytes.Element == UInt8
 
 
-/// An `NIOSSLPassphraseSetter` is a closure that you must invoke to provide a passphrase to BoringSSL.
-/// It will be provided to you when your `NIOSSLPassphraseCallback` is invoked.
+/// An ``NIOSSLPassphraseSetter`` is a closure that you must invoke to provide a passphrase to BoringSSL.
+/// It will be provided to you when your ``NIOSSLPassphraseCallback`` is invoked.
 public typealias NIOSSLPassphraseSetter<Bytes: Collection> = (Bytes) -> Void where Bytes.Element == UInt8
 
 
 /// An internal protocol that exists to let us avoid problems with generic types.
 ///
 /// The issue we have here is that we want to allow users to use whatever collection type suits them best to set
-/// the passphrase. For this reason, `NIOSSLPassphraseSetter` is a generic function, generic over the `Collection`
+/// the passphrase. For this reason, ``NIOSSLPassphraseSetter`` is a generic function, generic over the `Collection`
 /// protocol. However, that causes us an issue, because we need to stuff that callback into an
-/// `BoringSSLPassphraseCallbackManager` in order to create an `Unmanaged` and round-trip the pointer through C code.
+/// ``BoringSSLPassphraseCallbackManager`` in order to create an `Unmanaged` and round-trip the pointer through C code.
 ///
-/// That makes `BoringSSLPassphraseCallbackManager` a generic object, and now we're in *real* trouble, becuase
+/// That makes ``BoringSSLPassphraseCallbackManager`` a generic object, and now we're in *real* trouble, becuase
 /// `Unmanaged` requires us to specify the *complete* type of the object we want to unwrap. In this case, we
 /// don't know it, because it's generic!
 ///
 /// Our way out is to note that while the class itself is generic, the only function we want to call in the
-/// `globalBoringSSLPassphraseCallback` is not. Thus, rather than try to hold the actual specific `BoringSSLPassphraseManager`,
+/// ``globalBoringSSLPassphraseCallback`` is not. Thus, rather than try to hold the actual specific ``BoringSSLPassphraseManager``,
 /// we can hold it inside a protocol existential instead, so long as that protocol existential gives us the correct
-/// function to call. Hence: `CallbackManagerProtocol`, a private protocol with a single conforming type.
+/// function to call. Hence: ``CallbackManagerProtocol``, a private protocol with a single conforming type.
 internal protocol CallbackManagerProtocol: AnyObject {
     func invoke(buffer: UnsafeMutableBufferPointer<CChar>) -> CInt
 }
@@ -201,7 +201,7 @@ public class NIOSSLPrivateKey {
         self.init(withReference: ref!)
     }
 
-    /// Create an NIOSSLPrivateKey from a file at a given path in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a file at a given path in either PEM or
     /// DER format, providing a passphrase callback.
     ///
     /// - parameters:
@@ -211,7 +211,7 @@ public class NIOSSLPrivateKey {
         try self.init(file: file, format: format, callbackManager: nil)
     }
 
-    /// Create an NIOSSLPrivateKey from a file at a given path in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a file at a given path in either PEM or
     /// DER format, providing a passphrase callback.
     ///
     /// - parameters:
@@ -224,19 +224,19 @@ public class NIOSSLPrivateKey {
         try self.init(file: file, format: format, callbackManager: manager)
     }
 
-    /// Create an NIOSSLPrivateKey from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a buffer of bytes in either PEM or
     /// DER format.
     ///
     /// - parameters:
     ///     - buffer: The key bytes.
     ///     - format: The format of the key to load, either DER or PEM.
-    /// - SeeAlso: `NIOSSLPrivateKey.init(bytes:format:)`
+    /// - SeeAlso: ``NIOSSLPrivateKey/init(bytes:format:)``
     @available(*, deprecated, renamed: "NIOSSLPrivateKey.init(bytes:format:)")
     public convenience init(buffer: [Int8], format: NIOSSLSerializationFormats) throws {
         try self.init(bytes: buffer.map(UInt8.init), format: format)
     }
 
-    /// Create an NIOSSLPrivateKey from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a buffer of bytes in either PEM or
     /// DER format.
     ///
     /// - parameters:
@@ -246,7 +246,7 @@ public class NIOSSLPrivateKey {
         try self.init(bytes: bytes, format: format, callbackManager: nil)
     }
 
-    /// Create an NIOSSLPrivateKey from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a buffer of bytes in either PEM or
     /// DER format.
     ///
     /// - parameters:
@@ -262,7 +262,7 @@ public class NIOSSLPrivateKey {
         try self.init(bytes: buffer.map(UInt8.init), format: format, passphraseCallback: passphraseCallback)
     }
 
-    /// Create an NIOSSLPrivateKey from a buffer of bytes in either PEM or
+    /// Create a ``NIOSSLPrivateKey`` from a buffer of bytes in either PEM or
     /// DER format.
     ///
     /// - parameters:
@@ -277,10 +277,10 @@ public class NIOSSLPrivateKey {
         try self.init(bytes: bytes, format: format, callbackManager: manager)
     }
 
-    /// Create a `NIOSSLPrivateKey` from a custom private key callback.
+    /// Create a ``NIOSSLPrivateKey`` from a custom private key callback.
     ///
-    /// The private key, in addition to needing to conform to `NIOSSLCustomPrivateKey`,
-    /// is also required to be `Hashable`. This is because `NIOSSLPrivateKey`s are `Hashable`.
+    /// The private key, in addition to needing to conform to ``NIOSSLCustomPrivateKey``,
+    /// is also required to be `Hashable`. This is because ``NIOSSLPrivateKey``s are `Hashable`.
     ///
     /// - parameters:
     ///     - customPrivateKey: The custom private key to use with the TLS certificate.

--- a/Sources/NIOSSL/SSLPublicKey.swift
+++ b/Sources/NIOSSL/SSLPublicKey.swift
@@ -14,11 +14,11 @@
 
 @_implementationOnly import CNIOBoringSSL
 
-/// An `NIOSSLPublicKey` is an abstract handle to a public key owned by BoringSSL.
+/// A ``NIOSSLPublicKey`` is an abstract handle to a public key owned by BoringSSL.
 ///
 /// This object is of minimal utility, as it cannot be used for very many operations
-/// in `NIOSSL`. Its primary purpose is to allow extracting public keys from
-/// `NIOSSLCertificate` objects to be serialized, so that they can be passed to
+/// in ``NIOSSL``. Its primary purpose is to allow extracting public keys from
+/// ``NIOSSLCertificate`` objects to be serialized, so that they can be passed to
 /// general-purpose cryptography libraries.
 public class NIOSSLPublicKey {
     private let _ref: UnsafeMutableRawPointer /*<EVP_PKEY>*/
@@ -38,7 +38,7 @@ public class NIOSSLPublicKey {
 
 // MARK:- Helpful initializers
 extension NIOSSLPublicKey {
-    /// Create an `NIOSSLPublicKey` object from an internal `EVP_PKEY` pointer.
+    /// Create a ``NIOSSLPublicKey`` object from an internal `EVP_PKEY` pointer.
     ///
     /// This method expects `pointer` to be passed at +1, and consumes that reference.
     ///

--- a/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
+++ b/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
@@ -12,11 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-
+/// Auto-zeroing storage for data in memory.
+///
+/// ``NIOSSLSecureBytes`` uses a best-effort strategy to try to remove data from memory when it is no longer in use, by
+/// automatically zeroing the heap memory it uses. This is best-effort becuase it's easy for users to accidentally copy
+/// data out of this structure. To get its best effect, do not copy this data out into another type, but operate on
+/// ``NIOSSLSecureBytes`` generically or specifically.
 public struct NIOSSLSecureBytes {
     @usableFromInline
     var backing: Backing
 
+    /// Create an empty ``NIOSSLSecureBytes``.
     @inlinable
     public init() {
         self = .init(count: 0)
@@ -46,6 +52,9 @@ public struct NIOSSLSecureBytes {
 }
 
 extension NIOSSLSecureBytes {
+    /// Append the contents of a collection of bytes to this ``NIOSSLSecureBytes``.
+    ///
+    /// - parameter data: The `data` to add to the ``NIOSSLSecureBytes``.
     @inlinable
     mutating public func append<C: Collection>(_ data: C) where C.Element == UInt8 {
         let requiredCapacity = self.count + data.count
@@ -57,7 +66,6 @@ extension NIOSSLSecureBytes {
         self.backing._appendBytes(data)
     }
 
-    
     mutating public func reserveCapacity(_ n: Int) {
         if self.backing.capacity >= n {
             return

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -70,23 +70,26 @@ public enum NIOSSLTrustRoots: Hashable {
 
 /// Places NIOSSL can obtain additional trust roots from.
 public enum NIOSSLAdditionalTrustRoots: Hashable {
-    /// See `NIOSSLTrustRoots.file`
+    /// See ``NIOSSLTrustRoots/file(_:)``
     case file(String)
 
-    /// See `NIOSSLTrustRoots.certificates`
+    /// See ``NIOSSLTrustRoots/certificates(_:)``
     case certificates([NIOSSLCertificate])
 }
 
 /// Available ciphers to use for TLS instead of a string based representation.
 public struct NIOTLSCipher: RawRepresentable, Hashable {
+    /// Construct a ``NIOTLSCipher`` from the RFC code point for that cipher.
     public init(rawValue: UInt16) {
         self.rawValue = rawValue
     }
-    
+
+    /// Construct a ``NIOTLSCipher`` from the RFC code point for that cipher.
     public init(_ rawValue: RawValue) {
         self.rawValue = rawValue
     }
-    
+
+    /// The RFC code point for the given cipher.
     public var rawValue: UInt16
     public typealias RawValue = UInt16
     
@@ -229,17 +232,17 @@ public struct TLSConfiguration {
     /// A default TLS configuration for client use.
     public static let clientDefault = TLSConfiguration.makeClientConfiguration()
 
-    /// The minimum TLS version to allow in negotiation. Defaults to tlsv1.
+    /// The minimum TLS version to allow in negotiation. Defaults to ``TLSVersion/tlsv1``.
     public var minimumTLSVersion: TLSVersion
 
-    /// The maximum TLS version to allow in negotiation. If nil, there is no upper limit. Defaults to nil.
+    /// The maximum TLS version to allow in negotiation. If `nil`, there is no upper limit. Defaults to `nil`.
     public var maximumTLSVersion: TLSVersion?
 
     /// The pre-TLS1.3 cipher suites supported by this handler. This uses the OpenSSL cipher string format.
     /// TLS 1.3 cipher suites cannot be configured.
     public var cipherSuites: String = defaultCipherSuites
     
-    /// Public property used to set the internal cipherSuites from NIOTLSCipher.
+    /// Public property used to set the internal ``cipherSuites`` from ``NIOTLSCipher``.
     public var cipherSuiteValues: [NIOTLSCipher] {
         get {
             guard let sslContext = try? NIOSSLContext(configuration: self) else {
@@ -253,10 +256,10 @@ public struct TLSConfiguration {
         }
     }
 
-    /// Allowed algorithms to verify signatures. Passing nil means, that a built-in set of algorithms will be used.
+    /// Allowed algorithms to verify signatures. Passing `nil` means that a built-in set of algorithms will be used.
     public var verifySignatureAlgorithms : [SignatureAlgorithm]?
 
-    /// Allowed algorithms to sign signatures. Passing nil means, that a built-in set of algorithms will be used.
+    /// Allowed algorithms to sign signatures. Passing `nil` means that a built-in set of algorithms will be used.
     public var signingSignatureAlgorithms : [SignatureAlgorithm]?
 
     /// Whether to verify remote certificates.
@@ -265,14 +268,14 @@ public struct TLSConfiguration {
     /// The trust roots to use to validate certificates. This only needs to be provided if you intend to validate
     /// certificates.
     ///
-    /// - NOTE: If certificate validation is enabled and `trustRoots` is `nil` then the system default root of
-    /// trust is used (as if `trustRoots` had been explicitly set to `.default`).
+    /// - NOTE: If certificate validation is enabled and ``trustRoots`` is `nil` then the system default root of
+    /// trust is used (as if ``trustRoots`` had been explicitly set to ``NIOSSLTrustRoots/default``).
     ///
     /// - NOTE: If a directory path is used here to load a directory of certificates into a configuration, then the
-    ///         certificates in this directory must be formatted by c_rehash to create the rehash file format of HHHHHHHH.D with a symlink.
+    ///         certificates in this directory must be formatted by `c_rehash` to create the rehash file format of `HHHHHHHH.D` with a symlink.
     public var trustRoots: NIOSSLTrustRoots?
 
-    /// Additional trust roots to use to validate certificates, used in addition to `trustRoots`.
+    /// Additional trust roots to use to validate certificates, used in addition to ``trustRoots``.
     public var additionalTrustRoots: [NIOSSLAdditionalTrustRoots]
 
     /// The certificates to offer during negotiation. If not present, no certificates will be offered.
@@ -315,7 +318,7 @@ public struct TLSConfiguration {
     /// Whether renegotiation is supported.
     public var renegotiationSupport: NIORenegotiationSupport
     
-    /// Send the CA names derived from the `trustRoots`  for client authentication.
+    /// Send the CA names derived from the ``trustRoots`` for client authentication.
     /// This instructs the client which identities can be used by evaluating what CA the identity certificate was issued from.
     public var sendCANameList: Bool
 
@@ -365,9 +368,9 @@ public struct TLSConfiguration {
 
 // MARK: BestEffortHashable
 extension TLSConfiguration {
-    /// Returns a best effort result of whether two `TLSConfiguration` objects are equal.
+    /// Returns a best effort result of whether two ``TLSConfiguration`` objects are equal.
     ///
-    /// The "best effort" stems from the fact that we are checking the pointer to the `keyLogCallback` closure.
+    /// The "best effort" stems from the fact that we are checking the pointer to the ``keyLogCallback`` closure.
     ///
     /// - warning: You should probably not use this function. This function can return false-negatives, but not false-positives.
     public func bestEffortEquals(_ comparing: TLSConfiguration) -> Bool {
@@ -409,7 +412,7 @@ extension TLSConfiguration {
     
     /// Returns a best effort hash of this TLS configuration.
     ///
-    /// The "best effort" stems from the fact that we are hashing the pointer bytes of the `keyLogCallback` closure.
+    /// The "best effort" stems from the fact that we are hashing the pointer bytes of the ``keyLogCallback`` closure.
     ///
     /// - warning: You should probably not use this function. This function can return false-negatives, but not false-positives.
     public func bestEffortHash(into hasher: inout Hasher) {
@@ -442,7 +445,7 @@ extension TLSConfiguration {
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     ///
     /// For customising fields, modify the returned TLSConfiguration object.
     public static func makeClientConfiguration() -> TLSConfiguration {
@@ -469,7 +472,7 @@ extension TLSConfiguration {
     /// Create a TLS configuration for use with server-side contexts.
     ///
     /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    /// for server-side function. For client use, try ``TLSConfiguration/makeClientConfiguration()`` instead.
     ///
     /// For customising fields, modify the returned TLSConfiguration object.
     public static func makeServerConfiguration(
@@ -528,10 +531,10 @@ extension TLSConfiguration {
 // MARK: Deprecated constructors.
 
 extension TLSConfiguration {
-    /// Create a TLS configuration for use with server-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    /// Create a TLS configuration for use with server-side contexts. This allows setting the ``NIOTLSCipher`` property specifically.
     ///
     /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    /// for server-side function. For client use, try ``TLSConfiguration/makeClientConfiguration()`` instead.
     @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
     public static func forServer(certificateChain: [NIOSSLCertificateSource],
                                  privateKey: NIOSSLPrivateKeySource,
@@ -565,7 +568,7 @@ extension TLSConfiguration {
     /// Create a TLS configuration for use with server-side contexts.
     ///
     /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    /// for server-side function. For client use, try ``TLSConfiguration/makeClientConfiguration()`` instead.
     @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
     public static func forServer(certificateChain: [NIOSSLCertificateSource],
                                  privateKey: NIOSSLPrivateKeySource,
@@ -596,7 +599,7 @@ extension TLSConfiguration {
     /// Create a TLS configuration for use with server-side contexts.
     ///
     /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    /// for server-side function. For client use, try ``TLSConfiguration/makeClientConfiguration()`` instead.
     @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
     public static func forServer(certificateChain: [NIOSSLCertificateSource],
                                  privateKey: NIOSSLPrivateKeySource,
@@ -629,7 +632,7 @@ extension TLSConfiguration {
     /// Create a TLS configuration for use with server-side contexts.
     ///
     /// This provides sensible defaults while requiring that you provide any data that is necessary
-    /// for server-side function. For client use, try `makeClientConfiguration` instead.
+    /// for server-side function. For client use, try ``TLSConfiguration/makeClientConfiguration()`` instead.
     @available(*, deprecated, renamed: "makeServerConfiguration(certificateChain:privateKey:)")
     public static func forServer(certificateChain: [NIOSSLCertificateSource],
                                  privateKey: NIOSSLPrivateKeySource,
@@ -660,10 +663,10 @@ extension TLSConfiguration {
                                 additionalTrustRoots: additionalTrustRoots)
     }
 
-    /// Creates a TLS configuration for use with client-side contexts. This allows setting the `NIOTLSCipher` property specifically.
+    /// Creates a TLS configuration for use with client-side contexts. This allows setting the ``NIOTLSCipher`` property specifically.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     @available(*, deprecated, renamed: "makeClientConfiguration()")
     public static func forClient(cipherSuites: [NIOTLSCipher],
                                  verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
@@ -698,7 +701,7 @@ extension TLSConfiguration {
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     @available(*, deprecated, renamed: "makeClientConfiguration()")
     public static func forClient(cipherSuites: String = defaultCipherSuites,
                                  minimumTLSVersion: TLSVersion = .tlsv1,
@@ -730,7 +733,7 @@ extension TLSConfiguration {
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     @available(*, deprecated, renamed: "makeClientConfiguration()")
     public static func forClient(cipherSuites: String = defaultCipherSuites,
                                  minimumTLSVersion: TLSVersion = .tlsv1,
@@ -762,7 +765,7 @@ extension TLSConfiguration {
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     @available(*, deprecated, renamed: "makeClientConfiguration()")
     public static func forClient(cipherSuites: String = defaultCipherSuites,
                                  verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,
@@ -796,7 +799,7 @@ extension TLSConfiguration {
     /// Creates a TLS configuration for use with client-side contexts.
     ///
     /// This provides sensible defaults, and can be used without customisation. For server-side
-    /// contexts, you should use `makeServerConfiguration` instead.
+    /// contexts, you should use ``TLSConfiguration/makeServerConfiguration(certificateChain:privateKey:)`` instead.
     @available(*, deprecated, renamed: "makeClientConfiguration()")
     public static func forClient(cipherSuites: String = defaultCipherSuites,
                                  verifySignatureAlgorithms: [SignatureAlgorithm]? = nil,

--- a/Sources/NIOSSL/UniversalBootstrapSupport.swift
+++ b/Sources/NIOSSL/UniversalBootstrapSupport.swift
@@ -54,6 +54,15 @@ public struct NIOSSLClientTLSProvider<Bootstrap: NIOClientTCPBootstrapProtocol>:
     }
     
     /// Construct the TLS provider with the necessary configuration.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use with the connection.
+    ///     - serverHostname: The hostname of the server we're trying to connect to, if known. This will be used in the SNI extension,
+    ///         and used to validate the server certificate.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
     public init(
         context: NIOSSLContext,
         serverHostname: String?,

--- a/docker/docker-compose.1804.54.yaml
+++ b/docker/docker-compose.1804.54.yaml
@@ -12,12 +12,14 @@ services:
 
   unit-tests:
     image: swift-nio-ssl:18.04-5.4
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio-ssl:18.04-5.4
 
   test:
     image: swift-nio-ssl:18.04-5.4
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_simple_handshake=743000
       - MAX_ALLOCS_ALLOWED_many_writes=201000

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -11,12 +11,14 @@ services:
 
   unit-tests:
     image: swift-nio-ssl:20.04-5.5
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
 
   integration-tests:
     image: swift-nio-ssl:20.04-5.5
 
   test:
     image: swift-nio-ssl:20.04-5.5
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh"
     environment:
       - MAX_ALLOCS_ALLOWED_simple_handshake=743000
       - MAX_ALLOCS_ALLOWED_many_writes=201000

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   unit-tests:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery"
 
   integration-tests:
     <<: *common
@@ -36,7 +36,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} && ./scripts/integration_tests.sh"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-} && ./scripts/integration_tests.sh"
 
   performance-test:
     <<: *common

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -69,7 +69,7 @@ for language in swift-or-c bash dtrace python; do
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -path '*Sources/CNIOBoringSSL/*' -o -name 'Package.swift')
+        exceptions=( -path '*Sources/CNIOBoringSSL/*' -o -name 'Package.swift' -o -name 'Package@swift*.swift')
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Motivation

Documentation is nice, and we can help support users by providing useful
clear docs.

Modifications

Add Docc to 5.6 and later builds
Make sure symbol references work
Add overview docs

Result

Nice rendering docs