### PR TITLE
Adopt `Sendable` in `SSLError.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
             .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -13,9 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 @_implementationOnly import CNIOBoringSSL
+import NIOCore
 
 /// Wraps a single error from BoringSSL.
-public struct BoringSSLInternalError: Equatable, CustomStringConvertible {
+public struct BoringSSLInternalError: Equatable, CustomStringConvertible, NIOSendable {
     private enum Backing: Hashable {
         case boringSSLErrorCode(UInt32)
         case synthetic(String)


### PR DESCRIPTION
Incremental `Sendable` adoption.
We also need to increase the minimum required `swift-nio` version as `NIOSendable` was moved to `NIOCore` in version `2.34.0`