### PR TITLE
Adopt `Sendable` incrementally

### DIFF
--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -101,6 +101,22 @@ public typealias NIOSSLCustomVerificationCallback = ([NIOSSLCertificate], EventL
 public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCertificate, Channel) -> EventLoopFuture<Void>
 
 
+#if swift(>=5.6)
+/// A callback that can be used to implement `SSLKEYLOGFILE` support.
+///
+/// Wireshark can decrypt packet captures that contain encrypted TLS connections if they have access to the
+/// session keys used to perform the encryption. These keys are normally stored in a file that has a specific
+/// file format. This callback is the low-level primitive that can be used to write such a file.
+///
+/// When set, this callback will be invoked once per secret. The provided `ByteBuffer` will contain the bytes
+/// that need to be written into the file, including the newline character.
+///
+/// - warning: Please be aware that enabling support for `SSLKEYLOGFILE` through this callback will put the secrecy of
+///     your connections at risk. You should only do so when you are confident that it will not be possible to
+///     extract those secrets unnecessarily.
+///
+public typealias NIOSSLKeyLogCallback = @Sendable (ByteBuffer) -> Void
+#else
 /// A callback that can be used to implement `SSLKEYLOGFILE` support.
 ///
 /// Wireshark can decrypt packet captures that contain encrypted TLS connections if they have access to the
@@ -115,6 +131,7 @@ public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCert
 ///     extract those secrets unnecessarily.
 ///
 public typealias NIOSSLKeyLogCallback = (ByteBuffer) -> Void
+#endif
 
 
 /// An object that provides helpers for working with a NIOSSLKeyLogCallback

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -188,7 +188,7 @@ public struct PSKClientIdentityResponse: NIOSendable {
     }
 }
 
-#if swift(>=5.6)
+#if swift(>=5.7)
 /// The callback used for providing a PSK on the client side.
 ///
 /// The callback is invoked on the event loop with the PSK hint. This callback must complete synchronously: it cannot return a future.
@@ -202,7 +202,7 @@ public typealias NIOPSKClientIdentityCallback = @Sendable (String) throws -> PSK
 public typealias NIOPSKClientIdentityCallback = (String) throws -> PSKClientIdentityResponse
 #endif
 
-#if swift(>=5.6)
+#if swift(>=5.7)
 /// The callback used for providing a PSK on the server side.
 ///
 /// The callback is invoked on the event loop with the PSK hint provided by the server, and the PSK identity provided by the client.

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -101,22 +101,6 @@ public typealias NIOSSLCustomVerificationCallback = ([NIOSSLCertificate], EventL
 public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCertificate, Channel) -> EventLoopFuture<Void>
 
 
-#if swift(>=5.6)
-/// A callback that can be used to implement `SSLKEYLOGFILE` support.
-///
-/// Wireshark can decrypt packet captures that contain encrypted TLS connections if they have access to the
-/// session keys used to perform the encryption. These keys are normally stored in a file that has a specific
-/// file format. This callback is the low-level primitive that can be used to write such a file.
-///
-/// When set, this callback will be invoked once per secret. The provided `ByteBuffer` will contain the bytes
-/// that need to be written into the file, including the newline character.
-///
-/// - warning: Please be aware that enabling support for `SSLKEYLOGFILE` through this callback will put the secrecy of
-///     your connections at risk. You should only do so when you are confident that it will not be possible to
-///     extract those secrets unnecessarily.
-///
-@preconcurrency public typealias NIOSSLKeyLogCallback = @Sendable (ByteBuffer) -> Void
-#else
 /// A callback that can be used to implement `SSLKEYLOGFILE` support.
 ///
 /// Wireshark can decrypt packet captures that contain encrypted TLS connections if they have access to the
@@ -131,7 +115,6 @@ public typealias _NIOAdditionalPeerCertificateVerificationCallback = (NIOSSLCert
 ///     extract those secrets unnecessarily.
 ///
 public typealias NIOSSLKeyLogCallback = (ByteBuffer) -> Void
-#endif
 
 
 /// An object that provides helpers for working with a NIOSSLKeyLogCallback
@@ -188,35 +171,18 @@ public struct PSKClientIdentityResponse: NIOSendable {
     }
 }
 
-#if swift(>=5.6)
-/// The callback used for providing a PSK on the client side.
-///
-/// The callback is invoked on the event loop with the PSK hint. This callback must complete synchronously: it cannot return a future.
-/// Additionally, as it is invoked on the NIO event loop, it is not possible for this to perform any I/O. As a result, lookups must be quick.
-@preconcurrency public typealias NIOPSKClientIdentityCallback = @Sendable (String) throws -> PSKClientIdentityResponse
-#else
 /// The callback used for providing a PSK on the client side.
 ///
 /// The callback is invoked on the event loop with the PSK hint. This callback must complete synchronously: it cannot return a future.
 /// Additionally, as it is invoked on the NIO event loop, it is not possible for this to perform any I/O. As a result, lookups must be quick.
 public typealias NIOPSKClientIdentityCallback = (String) throws -> PSKClientIdentityResponse
-#endif
 
-#if swift(>=5.6)
-/// The callback used for providing a PSK on the server side.
-///
-/// The callback is invoked on the event loop with the PSK hint provided by the server, and the PSK identity provided by the client.
-/// This callback must complete synchronously: it cannot return a future. Additionally, as it is invoked on the NIO event loop, it is
-/// not possible for this to perform any I/O. As a result, lookups must be quick.
-@preconcurrency public typealias NIOPSKServerIdentityCallback = @Sendable (String, String) throws -> PSKServerIdentityResponse
-#else
 /// The callback used for providing a PSK on the server side.
 ///
 /// The callback is invoked on the event loop with the PSK hint provided by the server, and the PSK identity provided by the client.
 /// This callback must complete synchronously: it cannot return a future. Additionally, as it is invoked on the NIO event loop, it is
 /// not possible for this to perform any I/O. As a result, lookups must be quick.
 public typealias NIOPSKServerIdentityCallback = (String, String) throws -> PSKServerIdentityResponse
-#endif
 
 /// A struct that provides helpers for working with a NIOSSLCustomVerificationCallback.
 internal struct CustomVerifyManager {

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -171,18 +171,35 @@ public struct PSKClientIdentityResponse: NIOSendable {
     }
 }
 
+#if swift(>=5.6)
+/// The callback used for providing a PSK on the client side.
+///
+/// The callback is invoked on the event loop with the PSK hint. This callback must complete synchronously: it cannot return a future.
+/// Additionally, as it is invoked on the NIO event loop, it is not possible for this to perform any I/O. As a result, lookups must be quick.
+public typealias NIOPSKClientIdentityCallback = @Sendable (String) throws -> PSKClientIdentityResponse
+#else
 /// The callback used for providing a PSK on the client side.
 ///
 /// The callback is invoked on the event loop with the PSK hint. This callback must complete synchronously: it cannot return a future.
 /// Additionally, as it is invoked on the NIO event loop, it is not possible for this to perform any I/O. As a result, lookups must be quick.
 public typealias NIOPSKClientIdentityCallback = (String) throws -> PSKClientIdentityResponse
+#endif
 
+#if swift(>=5.6)
+/// The callback used for providing a PSK on the server side.
+///
+/// The callback is invoked on the event loop with the PSK hint provided by the server, and the PSK identity provided by the client.
+/// This callback must complete synchronously: it cannot return a future. Additionally, as it is invoked on the NIO event loop, it is
+/// not possible for this to perform any I/O. As a result, lookups must be quick.
+public typealias NIOPSKServerIdentityCallback = @Sendable (String, String) throws -> PSKServerIdentityResponse
+#else
 /// The callback used for providing a PSK on the server side.
 ///
 /// The callback is invoked on the event loop with the PSK hint provided by the server, and the PSK identity provided by the client.
 /// This callback must complete synchronously: it cannot return a future. Additionally, as it is invoked on the NIO event loop, it is
 /// not possible for this to perform any I/O. As a result, lookups must be quick.
 public typealias NIOPSKServerIdentityCallback = (String, String) throws -> PSKServerIdentityResponse
+#endif
 
 /// A struct that provides helpers for working with a NIOSSLCustomVerificationCallback.
 internal struct CustomVerifyManager {

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -288,11 +288,21 @@ public struct TLSConfiguration {
     /// The private key associated with the leaf certificate.
     public var privateKey: NIOSSLPrivateKeySource?
     
+    #if swift(>=5.6)
+    /// PSK Client Callback to get the key based on hint and identity.
+    @preconcurrency public var pskClientCallback: NIOPSKClientIdentityCallback? = nil
+    #else
     /// PSK Client Callback to get the key based on hint and identity.
     public var pskClientCallback: NIOPSKClientIdentityCallback? = nil
-
+    #endif
+    
+    #if swift(>=5.6)
+    /// PSK Server Callback to get the key based on hint and identity.
+    @preconcurrency public var pskServerCallback: NIOPSKServerIdentityCallback? = nil
+    #else
     /// PSK Server Callback to get the key based on hint and identity.
     public var pskServerCallback: NIOPSKServerIdentityCallback? = nil
+    #endif
     
     /// Optional PSK hint to be used during SSLContext create.
     public var pskHint: String? = nil

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -325,9 +325,14 @@ public struct TLSConfiguration {
     /// The amount of time to wait after initiating a shutdown before performing an unclean
     /// shutdown. Defaults to 5 seconds.
     public var shutdownTimeout: TimeAmount
-
+    
+    #if swift(>=5.6)
+    /// A callback that can be used to implement `SSLKEYLOGFILE` support.
+    @preconcurrency public var keyLogCallback: NIOSSLKeyLogCallback?
+    #else
     /// A callback that can be used to implement `SSLKEYLOGFILE` support.
     public var keyLogCallback: NIOSSLKeyLogCallback?
+    #endif
 
     /// Whether renegotiation is supported.
     public var renegotiationSupport: NIORenegotiationSupport

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -370,10 +370,6 @@ public struct TLSConfiguration {
     }
 }
 
-#if swift(>=5.6)
-extension TLSConfiguration: Sendable {}
-#endif
-
 // MARK: BestEffortHashable
 extension TLSConfiguration {
     /// Returns a best effort result of whether two ``TLSConfiguration`` objects are equal.

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -370,6 +370,10 @@ public struct TLSConfiguration {
     }
 }
 
+#if swift(>=5.6)
+extension TLSConfiguration: Sendable {}
+#endif
+
 // MARK: BestEffortHashable
 extension TLSConfiguration {
     /// Returns a best effort result of whether two ``TLSConfiguration`` objects are equal.

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -288,21 +288,11 @@ public struct TLSConfiguration {
     /// The private key associated with the leaf certificate.
     public var privateKey: NIOSSLPrivateKeySource?
     
-    #if swift(>=5.6)
-    /// PSK Client Callback to get the key based on hint and identity.
-    @preconcurrency public var pskClientCallback: NIOPSKClientIdentityCallback? = nil
-    #else
     /// PSK Client Callback to get the key based on hint and identity.
     public var pskClientCallback: NIOPSKClientIdentityCallback? = nil
-    #endif
     
-    #if swift(>=5.6)
-    /// PSK Server Callback to get the key based on hint and identity.
-    @preconcurrency public var pskServerCallback: NIOPSKServerIdentityCallback? = nil
-    #else
     /// PSK Server Callback to get the key based on hint and identity.
     public var pskServerCallback: NIOPSKServerIdentityCallback? = nil
-    #endif
     
     /// Optional PSK hint to be used during SSLContext create.
     public var pskHint: String? = nil
@@ -326,13 +316,8 @@ public struct TLSConfiguration {
     /// shutdown. Defaults to 5 seconds.
     public var shutdownTimeout: TimeAmount
     
-    #if swift(>=5.6)
-    /// A callback that can be used to implement `SSLKEYLOGFILE` support.
-    @preconcurrency public var keyLogCallback: NIOSSLKeyLogCallback?
-    #else
     /// A callback that can be used to implement `SSLKEYLOGFILE` support.
     public var keyLogCallback: NIOSSLKeyLogCallback?
-    #endif
 
     /// Whether renegotiation is supported.
     public var renegotiationSupport: NIORenegotiationSupport

--- a/Sources/NIOSSL/UniversalBootstrapSupport.swift
+++ b/Sources/NIOSSL/UniversalBootstrapSupport.swift
@@ -35,9 +35,32 @@ public struct NIOSSLClientTLSProvider<Bootstrap: NIOClientTCPBootstrapProtocol>:
 
     let context: NIOSSLContext
     let serverHostname: String?
+    #if swift(>=5.7)
+    /// See ``NIOSSLCustomVerificationCallback`` for more documentation
+    let customVerificationCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)?
+    /// See ``_NIOAdditionalPeerCertificateVerificationCallback`` for more documentation
+    let additionalPeerCertificateVerificationCallback: (@Sendable (NIOSSLCertificate, Channel) -> EventLoopFuture<Void>)?
+    #else
     let customVerificationCallback: NIOSSLCustomVerificationCallback?
     let additionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?
+    #endif
 
+    #if swift(>=5.7)
+    internal init(
+        context: NIOSSLContext,
+        serverHostname: String?,
+        customVerificationCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
+        additionalPeerCertificateVerificationCallback: (@Sendable (NIOSSLCertificate, Channel) -> EventLoopFuture<Void>)? = nil
+    ) throws {
+        try serverHostname.map {
+            try $0.validateSNIServerName()
+        }
+        self.context = context
+        self.serverHostname = serverHostname
+        self.customVerificationCallback = customVerificationCallback
+        self.additionalPeerCertificateVerificationCallback = additionalPeerCertificateVerificationCallback
+    }
+    #else
     internal init(
         context: NIOSSLContext,
         serverHostname: String?,
@@ -52,7 +75,28 @@ public struct NIOSSLClientTLSProvider<Bootstrap: NIOClientTCPBootstrapProtocol>:
         self.customVerificationCallback = customVerificationCallback
         self.additionalPeerCertificateVerificationCallback = additionalPeerCertificateVerificationCallback
     }
+    #endif
     
+    #if swift(>=5.7)
+    /// Construct the TLS provider with the necessary configuration.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use with the connection.
+    ///     - serverHostname: The hostname of the server we're trying to connect to, if known. This will be used in the SNI extension,
+    ///         and used to validate the server certificate.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic. See ``NIOSSLCustomVerificationCallback`` for complete documentation.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
+    @preconcurrency
+    public init(
+        context: NIOSSLContext,
+        serverHostname: String?,
+        customVerificationCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil
+    ) throws {
+        try self.init(context: context, serverHostname: serverHostname, customVerificationCallback: customVerificationCallback, additionalPeerCertificateVerificationCallback: nil)
+    }
+    #else
     /// Construct the TLS provider with the necessary configuration.
     ///
     /// - parameters:
@@ -70,6 +114,7 @@ public struct NIOSSLClientTLSProvider<Bootstrap: NIOClientTCPBootstrapProtocol>:
     ) throws {
         try self.init(context: context, serverHostname: serverHostname, customVerificationCallback: customVerificationCallback, additionalPeerCertificateVerificationCallback: nil)
     }
+    #endif
 
     /// Enable TLS on the bootstrap. This is not a function you will typically call as a user, it is called by
     /// `NIOClientTCPBootstrap`.

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1061,14 +1061,14 @@ class TLSConfigurationTest: XCTestCase {
 
         let first = TLSConfiguration.makeClientConfiguration()
         
-        func pskClientCallback(hint: String) -> PSKClientIdentityResponse {
+        let pskClientCallback: NIOPSKClientIdentityCallback = { (hint: String) -> PSKClientIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
             return PSKClientIdentityResponse(key: psk, identity: "world")
         }
         
-        func pskServerCallback(hint: String, identity: String) -> PSKServerIdentityResponse {
+        let pskServerCallback: NIOPSKServerIdentityCallback = { (hint: String, identity: String) -> PSKServerIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
@@ -1149,14 +1149,14 @@ class TLSConfigurationTest: XCTestCase {
     func testTLSPSKWithTLS13() throws {
         // The idea here is that adding PSKs with certificates in TLS 1.3 should NOT cause a failure.
         // Also note that the usage here of PSKs with TLS 1.3 is not supported by BoringSSL at this point.
-        func pskClientCallback(hint: String) -> PSKClientIdentityResponse {
+        let pskClientCallback: NIOPSKClientIdentityCallback = { (hint: String) -> PSKClientIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
             return PSKClientIdentityResponse(key: psk, identity: "world")
         }
         
-        func pskServerCallback(hint: String, identity: String) -> PSKServerIdentityResponse {
+        let pskServerCallback: NIOPSKServerIdentityCallback = { (hint: String, identity: String) -> PSKServerIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
@@ -1185,14 +1185,14 @@ class TLSConfigurationTest: XCTestCase {
     
     func testTLSPSKWithTLS12() throws {
         // This test ensures that PSK-TLS is supported for TLS 1.2.
-        func pskClientCallback(hint: String) -> PSKClientIdentityResponse {
+        let pskClientCallback: NIOPSKClientIdentityCallback = { (hint: String) -> PSKClientIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
             return PSKClientIdentityResponse(key: psk, identity: "world")
         }
         
-        func pskServerCallback(hint: String, identity: String) throws -> PSKServerIdentityResponse {
+        let pskServerCallback: NIOPSKServerIdentityCallback = { (hint: String, identity: String) -> PSKServerIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
@@ -1216,14 +1216,14 @@ class TLSConfigurationTest: XCTestCase {
     
     func testTLSPSKWithPinnedCiphers() throws {
         // This test ensures that PSK-TLS is supported with pinned ciphers.
-        func pskClientCallback(hint: String) -> PSKClientIdentityResponse {
+        let pskClientCallback: NIOPSKClientIdentityCallback = { (hint: String) -> PSKClientIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
             return PSKClientIdentityResponse(key: psk, identity: "world")
         }
         
-        func pskServerCallback(hint: String, identity: String) -> PSKServerIdentityResponse {
+        let pskServerCallback: NIOPSKServerIdentityCallback = { (hint: String, identity: String) -> PSKServerIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
@@ -1255,14 +1255,14 @@ class TLSConfigurationTest: XCTestCase {
     
     func testTLSPSKFailure() throws {
         // This test ensures that different PSKs used on the client and server fail when passed in.
-        func pskClientCallback(hint: String) -> PSKClientIdentityResponse {
+        let pskClientCallback: NIOPSKClientIdentityCallback = { (hint: String) -> PSKClientIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("hello".utf8)
             return PSKClientIdentityResponse(key: psk, identity: "world")
         }
         
-        func pskServerCallback(hint: String, identity: String) -> PSKServerIdentityResponse {
+        let pskServerCallback: NIOPSKServerIdentityCallback = { (hint: String, identity: String) -> PSKServerIdentityResponse in
             // Evaluate hint and clientIdentity to send back proper  PSK.
             var psk = NIOSSLSecureBytes()
             psk.append("server".utf8) // Failure

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -19,6 +19,11 @@ import NIOPosix
 import NIOEmbedded
 @testable import NIOSSL
 import NIOTLS
+#if swift(>=5.8)
+@preconcurrency import Dispatch
+#else
+import Dispatch
+#endif
 
 class ErrorCatcher<T: Error>: ChannelInboundHandler {
     public typealias InboundIn = Any

--- a/Tests/NIOSSLTests/UnsafeTransfer.swift
+++ b/Tests/NIOSSLTests/UnsafeTransfer.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
+/// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
+@usableFromInline
+final class UnsafeMutableTransferBox<Wrapped> {
+    @usableFromInline
+    var wrappedValue: Wrapped
+    
+    @inlinable
+    init(_ wrappedValue: Wrapped) {
+        self.wrappedValue = wrappedValue
+    }
+}
+#if swift(>=5.5) && canImport(_Concurrency)
+extension UnsafeMutableTransferBox: @unchecked Sendable {}
+#endif


### PR DESCRIPTION
Incremental `Sendable` adoption. Follow up of https://github.com/apple/swift-nio-ssl/pull/392

Properties are not marked with `@preconcurrency` because we otherwise get warnings because of https://github.com/apple/swift/issues/60508
I think that the latest Swift 5.7 toolchain doesn't produces any errors related to `Sendable` requirements in this context and we therefore don't actually need `@preconcurrency` here.