### PR TITLE
Remove giant write test

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -86,7 +86,7 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: defaultMaxWriteSize)
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
@@ -117,7 +117,8 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
         context: NIOSSLContext,
         serverHostname: String?,
         optionalCustomVerificationCallback: NIOSSLCustomVerificationCallback?,
-        optionalAdditionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?
+        optionalAdditionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?,
+        maxWriteSize: Int = defaultMaxWriteSize
     ) throws {
         guard let connection = context.createConnection() else {
             fatalError("Failed to create new connection in NIOSSLContext")
@@ -139,7 +140,12 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection.setCustomVerificationCallback(CustomVerifyManager(callback: verificationCallback))
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback)
+        super.init(
+            connection: connection,
+            shutdownTimeout: context.configuration.shutdownTimeout,
+            additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback,
+            maxWriteSize: maxWriteSize
+        )
     }
 }
 

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -86,7 +86,7 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: defaultMaxWriteSize)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: NIOSSLHandler.defaultMaxWriteSize)
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -16,12 +16,6 @@ import NIOCore
 @_implementationOnly import CNIOBoringSSL
 import NIOTLS
 
-/// The default maximum write size. We cannot pass writes larger than this size to
-/// BoringSSL.
-///
-/// We have this default here instead of hardcoded into the software for testing purposes.
-internal let defaultMaxWriteSize = Int(CInt.max)
-
 /// The base class for all NIOSSL handlers.
 ///
 /// This class cannot actually be instantiated by users directly: instead, users must select
@@ -32,6 +26,12 @@ internal let defaultMaxWriteSize = Int(CInt.max)
 /// For this reason almost the entirety of the implementation for the channel and server
 /// handlers in NIOSSL is shared, in the form of this parent class.
 public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, RemovableChannelHandler {
+    /// The default maximum write size. We cannot pass writes larger than this size to
+    /// BoringSSL.
+    ///
+    /// We have this default here instead of hardcoded into the software for testing purposes.
+    internal static let defaultMaxWriteSize = Int(CInt.max)
+
     public typealias OutboundIn = ByteBuffer
     public typealias OutboundOut = ByteBuffer
     public typealias InboundIn = ByteBuffer

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -38,7 +38,7 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: defaultMaxWriteSize)
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
@@ -77,7 +77,12 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection.setCustomVerificationCallback(.init(callback: customVerificationCallback))
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback)
+        super.init(
+            connection: connection,
+            shutdownTimeout: context.configuration.shutdownTimeout,
+            additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback,
+            maxWriteSize: defaultMaxWriteSize
+        )
     }
 }
 

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -38,7 +38,7 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: defaultMaxWriteSize)
+        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: NIOSSLHandler.defaultMaxWriteSize)
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
@@ -81,7 +81,7 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection: connection,
             shutdownTimeout: context.configuration.shutdownTimeout,
             additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback,
-            maxWriteSize: defaultMaxWriteSize
+            maxWriteSize: NIOSSLHandler.defaultMaxWriteSize
         )
     }
 }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest+XCTest.swift
@@ -69,7 +69,7 @@ extension NIOSSLIntegrationTest {
                 ("testWriteFromFailureOfWrite", testWriteFromFailureOfWrite),
                 ("testChannelInactiveDuringHandshakeSucceeded", testChannelInactiveDuringHandshakeSucceeded),
                 ("testTrustedFirst", testTrustedFirst),
-                ("testGiantWrite", testGiantWrite),
+                ("testWriteSplitting", testWriteSplitting),
            ]
    }
 }

--- a/Tests/NIOSSLTests/TLS13RecordObserver.swift
+++ b/Tests/NIOSSLTests/TLS13RecordObserver.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIOCore
+
+final class TLS13RecordObserver: ChannelDuplexHandler {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    var writtenRecords: [Record] = []
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        var payload = self.unwrapOutboundIn(data)
+
+        while let record = payload.readTLS13Record() {
+            writtenRecords.append(record)
+        }
+
+        // We should have consumed everything as NIO only writes full records.
+        precondition(payload.readableBytes == 0)
+
+        // Forward the original payload on.
+        context.write(data, promise: promise)
+    }
+}
+
+extension TLS13RecordObserver {
+    struct Record: Hashable {
+        var contentType: ContentType
+        var legacyRecordVersion: UInt16
+        var encryptedRecord: ByteBuffer
+    }
+}
+
+extension TLS13RecordObserver.Record {
+    struct ContentType: RawRepresentable, Hashable {
+        var rawValue: UInt8
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+
+        static let invalid = Self(rawValue: 0)
+        static let changeCipherSpec = Self(rawValue: 20)
+        static let alert = Self(rawValue: 21)
+        static let handshake = Self(rawValue: 22)
+        static let applicationData = Self(rawValue: 23)
+    }
+}
+
+extension ByteBuffer {
+    fileprivate mutating func readTLS13Record() -> TLS13RecordObserver.Record? {
+        guard let (contentType, legacyRecordVersion, length) = self.readMultipleIntegers(as: (UInt8, UInt16, UInt16).self) else {
+            return nil
+        }
+
+        guard let encryptedRecord = self.readSlice(length: Int(length)) else {
+            return nil
+        }
+
+        return .init(contentType: .init(rawValue: contentType), legacyRecordVersion: legacyRecordVersion, encryptedRecord: encryptedRecord)
+    }
+}


### PR DESCRIPTION
Motivation:

The giant write test requires an enormous commitment of RAM to run it.
This has caused problems for both our own CI and a number of downstream
CI systems, leading to long execution times or outright failures.

Unfortunately, we can't defend against the original failure using this
test suite, but we can at least exercise the new machinery we added and
trust that the configuration is right.

Modifications:

- Make the maximum write size configurable internally
- Test the maximum write size at a different value.

Result:

We feel confident that the write splitting continues to work correctly.

Resolves #388.