### PR TITLE
Replace Lock with NIOLock

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.1"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
             .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         ]
     } else {
         return [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         ]
     } else {
         return [

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -1625,7 +1625,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
 
         var completionPromiseFired: Bool = false
-        let completionPromiseFiredLock = Lock()
+        let completionPromiseFiredLock = NIOLock()
 
         let completionPromise: EventLoopPromise<ByteBuffer> = group.next().makePromise()
         completionPromise.futureResult.whenComplete { _ in
@@ -1689,7 +1689,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         }
 
         var completionPromiseFired: Bool = false
-        let completionPromiseFiredLock = Lock()
+        let completionPromiseFiredLock = NIOLock()
 
         let completionPromise: EventLoopPromise<ByteBuffer> = group.next().makePromise()
         completionPromise.futureResult.whenComplete { _ in


### PR DESCRIPTION
Motivation:

Lock has been deprecated in favour of NIOLock. Warnings aren't great.

Modifications:

- Replace Lock with NIOLock
- Update the minimum required NIO version to 2.42.0.

Result:

Everything builds cleanly