### PR TITLE
Remove `#if compiler(>=5.5)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ let client = ClientBootstrap(group: group)
     }
 ```
 
-The most recent versions of SwiftNIO SSL support Swift 5.5 and newer. The minimum Swift version supported by SwiftNIO SSL releases are detailed below:
+The most recent versions of SwiftNIO SSL support Swift 5.5.2 and newer. The minimum Swift version supported by SwiftNIO SSL releases are detailed below:
 
 SwiftNIO SSL        | Minimum Swift Version
 --------------------|----------------------
 `2.0.0 ..< 2.14.0`  | 5.0
 `2.14.0 ..< 2.19.0` | 5.2
 `2.19.0 ..< 2.23.0` | 5.4
-`2.23.0 ...`        | 5.5
+`2.23.0 ...`        | 5.5.2

--- a/Sources/NIOSSL/Docs.docc/index.md
+++ b/Sources/NIOSSL/Docs.docc/index.md
@@ -51,14 +51,14 @@ let client = ClientBootstrap(group: group)
     }
 ```
 
-The most recent versions of SwiftNIO SSL support Swift 5.5 and newer. The minimum Swift version supported by SwiftNIO SSL releases are detailed below:
+The most recent versions of SwiftNIO SSL support Swift 5.5.2 and newer. The minimum Swift version supported by SwiftNIO SSL releases are detailed below:
 
 SwiftNIO SSL        | Minimum Swift Version
 --------------------|----------------------
 `2.0.0 ..< 2.14.0`  | 5.0
 `2.14.0 ..< 2.19.0` | 5.2
 `2.19.0 ..< 2.23.0` | 5.4
-`2.23.0 ...`        | 5.5
+`2.23.0 ...`        | 5.5.2
 
 ## Topics
 

--- a/Sources/NIOSSL/ObjectIdentifier.swift
+++ b/Sources/NIOSSL/ObjectIdentifier.swift
@@ -101,10 +101,8 @@ public struct NIOSSLObjectIdentifier {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLObjectIdentifier is immutable and therefore Sendable
 extension NIOSSLObjectIdentifier: @unchecked Sendable {}
-#endif
 
 extension NIOSSLObjectIdentifier: Equatable {
     public static func == (lhs: NIOSSLObjectIdentifier, rhs: NIOSSLObjectIdentifier) -> Bool {

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -235,11 +235,9 @@ public final class NIOSSLCertificate {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLCertificate is publicly immutable and we do not internally mutate it after initialisation.
 // It is therefore Sendable.
 extension NIOSSLCertificate: @unchecked Sendable {}
-#endif
 
 // MARK:- Utility Functions
 // We don't really want to get too far down the road of providing helpers for things like certificates

--- a/Sources/NIOSSL/SSLCertificateExtensions.swift
+++ b/Sources/NIOSSL/SSLCertificateExtensions.swift
@@ -97,10 +97,8 @@ extension NIOSSLCertificate {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLCertificate._Extensions is immutable and therefore Sendable
 extension NIOSSLCertificate._Extensions: @unchecked Sendable {}
-#endif
 
 extension NIOSSLCertificate {
     public var _extensions: NIOSSLCertificate._Extensions {
@@ -170,10 +168,8 @@ extension NIOSSLCertificate {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLCertificate._Extension is immutable and therefore Sendable
 extension NIOSSLCertificate._Extension: @unchecked Sendable {}
-#endif
 
 extension NIOSSLCertificate._Extension {
     public struct Data {
@@ -204,10 +200,8 @@ extension NIOSSLCertificate._Extension {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLCertificate._Extension.Data is immutable and therefore Sendable
 extension NIOSSLCertificate._Extension.Data: @unchecked Sendable {}
-#endif
 
 extension NIOSSLCertificate._Extension.Data: RandomAccessCollection {
     @inlinable public var startIndex: Int { self.buffer.startIndex }

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -470,10 +470,8 @@ public final class NIOSSLContext {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLContext is thread-safe and therefore Sendable
 extension NIOSSLContext: @unchecked Sendable {}
-#endif
 
 
 extension NIOSSLContext {

--- a/Sources/NIOSSL/SubjectAlternativeName.swift
+++ b/Sources/NIOSSL/SubjectAlternativeName.swift
@@ -69,10 +69,8 @@ public struct _SubjectAlternativeNames {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // _SubjectAlternativeNames is immutable and therefore Sendable
 extension _SubjectAlternativeNames: @unchecked Sendable {}
-#endif
 
 extension _SubjectAlternativeNames: RandomAccessCollection {
     
@@ -132,13 +130,11 @@ public struct _SubjectAlternativeName {
     public var contents: Contents
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // _SubjectAlternativeName is immutable and therefore Sendable
 extension _SubjectAlternativeName: @unchecked Sendable {}
 
 // _SubjectAlternativeName.Contents is immutable and therefore Sendable
 extension _SubjectAlternativeName.Contents: @unchecked Sendable {}
-#endif
 
 extension _SubjectAlternativeName.Contents: RandomAccessCollection {
     

--- a/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
+++ b/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
@@ -51,10 +51,8 @@ public struct NIOSSLSecureBytes {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // NIOSSLSecureBytes is a Copy on Write (CoW) type and therefore Sendable
 extension NIOSSLSecureBytes: @unchecked Sendable {}
-#endif
 
 extension NIOSSLSecureBytes {
     /// Append the contents of a collection of bytes to this ``NIOSSLSecureBytes``.

--- a/Tests/NIOSSLTests/UnsafeTransfer.swift
+++ b/Tests/NIOSSLTests/UnsafeTransfer.swift
@@ -25,6 +25,6 @@ final class UnsafeMutableTransferBox<Wrapped> {
         self.wrappedValue = wrappedValue
     }
 }
-#if swift(>=5.5) && canImport(_Concurrency)
+
 extension UnsafeMutableTransferBox: @unchecked Sendable {}
-#endif
+


### PR DESCRIPTION
### Motivation
We only support Swift 5.5.2+. 

### Modification
Remove all `#if swift(>=5.5)` conditional compilation blocks.

### Result
less branching

