### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -21,7 +21,7 @@ import NIOPosix
 @testable import NIOSSL
 import NIOTLS
 
-public func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
+public func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, file: StaticString = #filePath, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {
@@ -253,7 +253,7 @@ private class WriteDelayHandler: ChannelOutboundHandler {
 internal func serverTLSChannel(context: NIOSSLContext,
                                handlers: [ChannelHandler],
                                group: EventLoopGroup,
-                               file: StaticString = #file,
+                               file: StaticString = #filePath,
                                line: UInt = #line) throws -> Channel {
     return try assertNoThrowWithValue(serverTLSChannel(context: context,
                                                        preHandlers: [],
@@ -269,7 +269,7 @@ internal func serverTLSChannel(context: NIOSSLContext,
                                postHandlers: [ChannelHandler],
                                group: EventLoopGroup,
                                customVerificationCallback: NIOSSLCustomVerificationCallback? = nil,
-                               file: StaticString = #file,
+                               file: StaticString = #filePath,
                                line: UInt = #line) throws -> Channel {
     return try assertNoThrowWithValue(ServerBootstrap(group: group)
         .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
@@ -303,7 +303,7 @@ internal func clientTLSChannel(context: NIOSSLContext,
                                group: EventLoopGroup,
                                connectingTo: SocketAddress,
                                serverHostname: String? = nil,
-                               file: StaticString = #file,
+                               file: StaticString = #filePath,
                                line: UInt = #line) throws -> Channel {
     func tlsFactory() -> NIOSSLClientTLSProvider<ClientBootstrap> {
         return try! .init(context: context, serverHostname: serverHostname, additionalPeerCertificateVerificationCallback: additionalPeerCertificateVerificationCallback)
@@ -348,7 +348,7 @@ internal func clientTLSChannel(context: NIOSSLContext,
                                connectingTo: SocketAddress,
                                serverHostname: String? = nil,
                                verificationCallback: @escaping NIOSSLVerificationCallback,
-                               file: StaticString = #file,
+                               file: StaticString = #filePath,
                                line: UInt = #line) throws -> Channel {
     func tlsFactory() -> DeprecatedTLSProviderForTests<ClientBootstrap> {
         return .init(context: context, serverHostname: serverHostname, verificationCallback: verificationCallback)
@@ -369,7 +369,7 @@ internal func clientTLSChannel(context: NIOSSLContext,
                                connectingTo: SocketAddress,
                                serverHostname: String? = nil,
                                customVerificationCallback: @escaping NIOSSLCustomVerificationCallback,
-                               file: StaticString = #file,
+                               file: StaticString = #filePath,
                                line: UInt = #line) throws -> Channel {
     func tlsFactory() -> NIOSSLClientTLSProvider<ClientBootstrap> {
         return try! .init(context: context,
@@ -391,7 +391,7 @@ fileprivate func _clientTLSChannel<TLS: NIOClientTLSProvider>(context: NIOSSLCon
                                                               group: EventLoopGroup,
                                                               connectingTo: SocketAddress,
                                                               tlsFactory: @escaping () -> TLS,
-                                                              file: StaticString = #file,
+                                                              file: StaticString = #filePath,
                                                               line: UInt = #line) throws -> Channel where TLS.Bootstrap == ClientBootstrap {
     let bootstrap = NIOClientTCPBootstrap(ClientBootstrap(group: group),
                                           tls: tlsFactory())
@@ -450,7 +450,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         _ = unlink(NIOSSLIntegrationTest.encryptedKeyPath)
     }
 
-    private func configuredSSLContext(keyLogCallback: NIOSSLKeyLogCallback? = nil, file: StaticString = #file, line: UInt = #line) throws -> NIOSSLContext {
+    private func configuredSSLContext(keyLogCallback: NIOSSLKeyLogCallback? = nil, file: StaticString = #filePath, line: UInt = #line) throws -> NIOSSLContext {
         var config = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
             privateKey: .privateKey(NIOSSLIntegrationTest.key)
@@ -461,7 +461,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     private func configuredSSLContext<T: Collection>(passphraseCallback: @escaping NIOSSLPassphraseCallback<T>,
-                                                     file: StaticString = #file, line: UInt = #line) throws -> NIOSSLContext
+                                                     file: StaticString = #filePath, line: UInt = #line) throws -> NIOSSLContext
                                                      where T.Element == UInt8 {
         var config = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
@@ -472,7 +472,7 @@ class NIOSSLIntegrationTest: XCTestCase {
     }
 
     private func configuredClientContext(
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> NIOSSLContext {
         var config = TLSConfiguration.makeClientConfiguration()

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -98,7 +98,7 @@ class TLSConfigurationTest: XCTestCase {
     func assertHandshakeError(withClientConfig clientConfig: TLSConfiguration,
                               andServerConfig serverConfig: TLSConfiguration,
                               errorTextContains message: String,
-                              file: StaticString = #file,
+                              file: StaticString = #filePath,
                               line: UInt = #line) throws {
         return try assertHandshakeError(withClientConfig: clientConfig,
                                         andServerConfig: serverConfig,
@@ -110,7 +110,7 @@ class TLSConfigurationTest: XCTestCase {
     func assertHandshakeError(withClientConfig clientConfig: TLSConfiguration,
                               andServerConfig serverConfig: TLSConfiguration,
                               errorTextContainsAnyOf messages: [String],
-                              file: StaticString = #file,
+                              file: StaticString = #filePath,
                               line: UInt = #line) throws {
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig), file: file, line: line)
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig), file: file, line: line)
@@ -145,7 +145,7 @@ class TLSConfigurationTest: XCTestCase {
     func assertPostHandshakeError(withClientConfig clientConfig: TLSConfiguration,
                                   andServerConfig serverConfig: TLSConfiguration,
                                   errorTextContainsAnyOf messages: [String],
-                                  file: StaticString = #file,
+                                  file: StaticString = #filePath,
                                   line: UInt = #line) throws {
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig), file: file, line: line)
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig), file: file, line: line)
@@ -184,7 +184,7 @@ class TLSConfigurationTest: XCTestCase {
     /// callback in use, otherwise it will not be thread-safe.
     func assertHandshakeSucceededInMemory(withClientConfig clientConfig: TLSConfiguration,
                                           andServerConfig serverConfig: TLSConfiguration,
-                                          file: StaticString = #file,
+                                          file: StaticString = #filePath,
                                           line: UInt = #line) throws {
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig))
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig))
@@ -216,7 +216,7 @@ class TLSConfigurationTest: XCTestCase {
     /// This function is thread-safe in the presence of custom verification callbacks.
     func assertHandshakeSucceededEventLoop(withClientConfig clientConfig: TLSConfiguration,
                                            andServerConfig serverConfig: TLSConfiguration,
-                                           file: StaticString = #file,
+                                           file: StaticString = #filePath,
                                            line: UInt = #line) throws {
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig), file: file, line: line)
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig), file: file, line: line)
@@ -247,7 +247,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func assertHandshakeSucceeded(withClientConfig clientConfig: TLSConfiguration,
                                   andServerConfig serverConfig: TLSConfiguration,
-                                  file: StaticString = #file,
+                                  file: StaticString = #filePath,
                                   line: UInt = #line) throws {
         // The only use of a custom callback is on Darwin...
         #if os(Linux)

--- a/Tests/NIOSSLTests/UnwrappingTests.swift
+++ b/Tests/NIOSSLTests/UnwrappingTests.swift
@@ -26,7 +26,7 @@ func connectInMemory(client: EmbeddedChannel, server: EmbeddedChannel) throws {
 }
 
 extension ChannelPipeline {
-    func assertContains(handler: ChannelHandler, file: StaticString = #file, line: UInt = #line) {
+    func assertContains(handler: ChannelHandler, file: StaticString = #filePath, line: UInt = #line) {
         do {
             _ = try self.context(handler: handler).wait()
         } catch {
@@ -34,7 +34,7 @@ extension ChannelPipeline {
         }
     }
 
-    func assertDoesNotContain(handler: ChannelHandler, file: StaticString = #file, line: UInt = #line) {
+    func assertDoesNotContain(handler: ChannelHandler, file: StaticString = #filePath, line: UInt = #line) {
         do {
             _ = try self.context(handler: handler).wait()
             XCTFail("Handler \(handler) present in \(self)", file: (file), line: line)
@@ -61,7 +61,7 @@ final class UnwrappingTests: XCTestCase {
         _ = unlink(NIOSSLIntegrationTest.encryptedKeyPath)
     }
 
-    private func configuredSSLContext(file: StaticString = #file, line: UInt = #line) throws -> NIOSSLContext {
+    private func configuredSSLContext(file: StaticString = #filePath, line: UInt = #line) throws -> NIOSSLContext {
         var config = TLSConfiguration.makeServerConfiguration(
             certificateChain: [.certificate(NIOSSLIntegrationTest.cert)],
             privateKey: .privateKey(NIOSSLIntegrationTest.key)


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on situation