### PR TITLE
.noHostnameNoPeerVerification

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -569,8 +569,10 @@ extension NIOSSLContext {
     private static func configureCertificateValidation(context: OpaquePointer, verification: CertificateVerification, trustRoots: NIOSSLTrustRoots?, additionalTrustRoots: [NIOSSLAdditionalTrustRoots], sendCANames: Bool) throws {
         // If validation is turned on, set the trust roots and turn on cert validation.
         switch verification {
-        case .fullVerification, .noHostnameVerification:
-            CNIOBoringSSL_SSL_CTX_set_verify(context, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nil)
+        case .fullVerification, .noHostnameVerification, .noHostnameNoPeerVerification:
+            let flags = verification == .noHostnameNoPeerVerification ? SSL_VERIFY_PEER
+              : SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT
+            CNIOBoringSSL_SSL_CTX_set_verify(context, flags, nil)
 
             // Also, set TRUSTED_FIRST to work around dumb clients that don't know what they're doing and send
             // untrusted root certs. X509_VERIFY_PARAM will or-in the flags, so we don't need to load them first.

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -140,6 +140,9 @@ public enum CertificateVerification: Sendable {
     /// be checked to see if they are valid for the given hostname.
     case noHostnameVerification
 
+    /// Peer certificate is optional
+    case noHostnameNoPeerVerification
+
     /// Certificates will be validated against the trust store and checked
     /// against the hostname of the service we are contacting.
     case fullVerification

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -390,6 +390,38 @@ class TLSConfigurationTest: XCTestCase {
 
         try assertPostHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["CERTIFICATE_REQUIRED"])
     }
+
+    func testMutualValidationOptionalClientCertificatePreTLS13() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.maximumTLSVersion = .tlsv12
+        serverConfig.certificateVerification = .noHostnameNoPeerVerification
+        serverConfig.trustRoots = .certificates([TLSConfigurationTest.cert2])
+
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+
+    func testMutualValidationOptionalClientCertificatePostTLS13() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.minimumTLSVersion = .tlsv13
+        clientConfig.certificateVerification = .none
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        serverConfig.minimumTLSVersion = .tlsv13
+        serverConfig.certificateVerification = .noHostnameNoPeerVerification
+        serverConfig.trustRoots = .certificates([TLSConfigurationTest.cert2])
+
+        try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
     
     func testIncompatibleSignatures() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()


### PR DESCRIPTION
This option for `TLSConfiguration` is similar to `.noHostname` but will not fail the handshake if the client certificate is not provided. But, if the client certificate _is_ provided, then the `customVerificationCallback` (if provided) will be called.

From an article referenced below, here is a quote:

"Then we tell it to accept requests with no valid certificate. We need this to handle invalid connections as well (for example to display an error message), otherwise, they would just get a cryptic HTTPS error message from the browser (ERR_BAD_SSL_CLIENT_AUTH_CERT to be precise)"

Reference: https://medium.com/@sevcsik/authentication-using-https-client-certificates-3c9d270e8326