### PR TITLE
Skipping testNotValidAfter on 32-bit platform

### DIFF
--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -480,12 +480,14 @@ class SSLCertificateTest: XCTestCase {
     }
 
     func testNotValidAfter() throws {
+        #if arch(arm64) || arch(x86_64)
         let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
         let notValidBeforeSeconds = cert.notValidAfter
 
         let expectedDate = self.dateFromComponents(year: 2047, month: 10, day: 9, hour: 21, minute: 01, second: 02)
         let expectedSeconds = time_t(expectedDate.timeIntervalSince1970)
         XCTAssertEqual(notValidBeforeSeconds, expectedSeconds)
+        #endif
     }
 
     func testNotBeforeAfterGeneratedCert() throws {

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -480,9 +480,7 @@ class SSLCertificateTest: XCTestCase {
     }
 
     func testNotValidAfter() throws {
-        guard MemoryLayout<time_t>.size >= 8 else {
-            throw XCTSkip()
-        }
+        try XCTSkipUnless(MemoryLayout<time_t>.size >= 8, "size of time_t must be 64bit or greater")
         let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
         let notValidBeforeSeconds = cert.notValidAfter
 

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -480,14 +480,15 @@ class SSLCertificateTest: XCTestCase {
     }
 
     func testNotValidAfter() throws {
-        #if arch(arm64) || arch(x86_64)
+        guard MemoryLayout<time_t>.size >= 8 else {
+            throw XCTSkip()
+        }
         let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
         let notValidBeforeSeconds = cert.notValidAfter
 
         let expectedDate = self.dateFromComponents(year: 2047, month: 10, day: 9, hour: 21, minute: 01, second: 02)
         let expectedSeconds = time_t(expectedDate.timeIntervalSince1970)
         XCTAssertEqual(notValidBeforeSeconds, expectedSeconds)
-        #endif
     }
 
     func testNotBeforeAfterGeneratedCert() throws {


### PR DESCRIPTION
Fixes #344