### PR TITLE
Use underscore version of `NIOPreconcurrencySendable` to silence warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.51.0"),
             .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -32,7 +32,7 @@ import NIOCore
 /// is imposed by SwiftNIO. The calls to the protocol requirements will be made on event loop threads, so if further
 /// synchronization is required it is up to the implementer to provide it. Note that it is unacceptable to block in
 /// these functions, and so potentially blocking operations must delegate to another thread.
-public protocol NIOSSLCustomPrivateKey: NIOPreconcurrencySendable {
+public protocol NIOSSLCustomPrivateKey: _NIOPreconcurrencySendable {
     /// The signature algorithms supported by this key.
     var signatureAlgorithms: [SignatureAlgorithm] { get }
 


### PR DESCRIPTION
### Motivation
`swift-nio` has deprecated `NIOPreconcurrencySendable` in `2.51.0`. Removing the protocol conformance would be an API breaking change. Keeping the conformance is low cost and not worth the risk.

### Changes
- replace `NIOPreconcurrencySendable` with underscore version `_NIOPreconcurrencySendable`

### Result
We compile again with the latest `swift-nio` release without warnings