### PR TITLE
`NIOSSLHandler`: behave sensibly on `close(mode: .output)`

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -870,9 +870,7 @@ extension NIOSSLHandler {
             }
         } catch {
             // We encountered an error, it's cleanup time. Close ourselves down.
-            // TODO: refactor
-            if case .outputClosed = self.state {
-            } else {
+            if case .outputClosed = self.state {} else {
                 channelClose(context: context, reason: error)
             }
             // Fail any writes we've previously encoded but not flushed.

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -250,7 +250,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
         case .idle, .handshaking, .additionalVerification:
             // we should not flush immediately as we have not completed the handshake and instead buffer the flush
             self.bufferFlush()
-        case .active, .unwrapping, .closingOutput, .closing, .unwrapped, .inputClosed, .outputClosed, .closed: // TODO: .closingOutput + .inputClosed correct here?
+        case .active, .unwrapping, .closingOutput, .closing, .unwrapped, .inputClosed, .outputClosed, .closed:
             self.bufferFlush()
             self.doUnbufferWrites(context: context)
         }
@@ -262,7 +262,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             self.closeOutput(context: context, promise: promise)
         case .all:
             self.closeAll(context: context, promise: promise)
-        default:
+        case .input:
             promise?.fail(ChannelError.operationUnsupported)
         }
     }

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -472,6 +472,8 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
 
             switch targetCompleteState {
             case .outputClosed:
+                // No channel close here. We would expect users to invoke a full close regardless of
+                // previously completed half closures.
                 break
             case .closed:
                 self.channelClose(context: context, reason: NIOTLSUnwrappingError.closeRequestedDuringUnwrap)

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -803,6 +803,11 @@ extension NIOSSLHandler {
     private typealias BufferedWrite = (data: ByteBuffer, promise: EventLoopPromise<Void>?)
 
     private func bufferWrite(data: ByteBuffer, promise: EventLoopPromise<Void>?) {
+        if case .outputClosed = self.state {
+            promise?.fail(ChannelError.outputClosed)
+            return
+        }
+
         var data = data
 
         // Here we guard against the possibility that any of these writes are larger than CInt.max.

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -43,7 +43,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
         case additionalVerification
         case active
         case unwrapping(Scheduled<Void>)
-        case closingOutput(Scheduled<Void>)
+        case closingOutput(Scheduled<Void>) // TODO: remove this state (in removable commit)
         case closing(Scheduled<Void>)
         case unwrapped
         case inputClosed
@@ -291,10 +291,8 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             // This prevents any further writes to this channel.
             self.state = .closingOutput(self.scheduleTimedOutShutdown(context: context))
             self.closeOutputPromise = promise
-            self.doShutdownStep(context: context)
-
-            // TODO: hoist flush
             self.flush(context: context)
+            self.doShutdownStep(context: context)
         }
     }
 

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -231,8 +231,8 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
             // these writes.
             channelError = NIOSSLError.uncleanShutdown
         }
-        context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
         context.fireErrorCaught(channelError)
+        context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
     }
 
     public func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
@@ -411,7 +411,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
         context.eventLoop.preconditionInEventLoop()
 
         switch self.state {
-        case .idle, .handshaking, .active:
+        case .idle, .handshaking, .active, .inputClosed, .outputClosed:
             preconditionFailure("invalid state \(self.state)")
         case .additionalVerification:
             switch result {
@@ -423,7 +423,7 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
                 state = .active
                 completeHandshake(context: context)
             }
-        case .unwrapping, .closing, .unwrapped, .closed, .inputClosed, .outputClosed:
+        case .unwrapping, .closing, .unwrapped, .closed:
             break
             // we are already about to close, we can safely ignore this event
         }

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -576,7 +576,12 @@ public class NIOSSLHandler : ChannelInboundHandler, ChannelOutboundHandler, Remo
                 self.doFlushReadData(context: context, receiveBuffer: receiveBuffer, readOnEmptyBuffer: false)
 
                 if allowRemoteHalfClosure {
-                    self.state = .inputClosed
+                    switch self.state {
+                    case .active, .outputClosed, .unwrapping:
+                        self.state = .inputClosed
+                    default:
+                        break
+                    }
                     context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
                 } else {
                     self.doShutdownStep(context: context)

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -646,6 +646,47 @@ class NIOSSLIntegrationTest: XCTestCase {
         XCTAssertEqual(expectedEvents, serverHandler.events)
     }
 
+    // TODO: remove
+    func testVanillaTCPHalfClose() throws {
+        // This is just a demo of how a half-close behaves when the NIOSSLHandler is not in place.
+        // It is important to note, that the .allowRemoteHalfClosure ChannelOption has to be set on the server channel.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+//        let completionPromise: EventLoopPromise<ByteBuffer> = group.next().makePromise()
+
+        // TODO: add half-closure option to serverChannel
+        let serverChannel: Channel = try ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+
+        let clientChannel = try ClientBootstrap(group: group)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .connect(to: serverChannel.localAddress!)
+            .wait()
+
+        defer {
+            // TODO: atm this is expected to fail as server channel does not support half-closure yet and ends the TCP connection before us
+            XCTAssertNoThrow(try clientChannel.close().wait())
+        }
+
+        var buffer = clientChannel.allocator.buffer(capacity: 5)
+        buffer.writeString("Hello")
+        XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
+
+        XCTAssertNoThrow(try clientChannel.close(mode: .output).wait())
+        XCTAssertThrowsError(try clientChannel.writeAndFlush(buffer).wait()) { error in
+            XCTAssertEqual(.outputClosed, error as? ChannelError)
+        }
+    }
+
     // TODO: test event sequencing
     // TODO: test subsequent close mode output
     // TODO: test close all while closing output

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -646,6 +646,9 @@ class NIOSSLIntegrationTest: XCTestCase {
         XCTAssertEqual(expectedEvents, serverHandler.events)
     }
 
+    // TODO: test event sequencing
+    // TODO: test subsequent close mode output
+    // TODO: test close all while closing output
     func testSubsequentWritesFailAfterCloseModeOutput() throws {
         let context = try configuredSSLContext()
 
@@ -677,7 +680,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         XCTAssertNoThrow(try clientChannel.close(mode: .output).wait())
         XCTAssertThrowsError(try clientChannel.writeAndFlush(buffer).wait()) { error in
-            XCTAssertEqual(.outputClosed, error as? ChannelError)
+            XCTAssertEqual(.ioOnClosedChannel, error as? ChannelError)
         }
     }
 

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -681,7 +681,7 @@ class NIOSSLIntegrationTest: XCTestCase {
         buffer.writeString("Hello")
         XCTAssertNoThrow(try clientChannel.writeAndFlush(buffer).wait())
 
-        XCTAssertNoThrow(try clientChannel.close(mode: .output).wait())
+        try clientChannel.close(mode: .output).wait()
         XCTAssertThrowsError(try clientChannel.writeAndFlush(buffer).wait()) { error in
             XCTAssertEqual(.outputClosed, error as? ChannelError)
         }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -754,8 +754,24 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let completionPromise: EventLoopPromise<ByteBuffer> = group.next().makePromise()
 
-        // TODO: have a server channel with half-closure enabled here
-        let serverChannel: Channel = try serverTLSChannel(context: context, handlers: [SimpleEchoServer()], group: group)
+        let preHandlers: [ChannelHandler] = []
+        let postHandlers = [SimpleEchoServer()]
+        let serverChannel: Channel = try ServerBootstrap(group: group)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true) // Important!
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .childChannelInitializer { channel in
+                let results = preHandlers.map { channel.pipeline.addHandler($0) }
+                return EventLoopFuture<Void>.andAllSucceed(results, on: channel.eventLoop).map {
+                    return NIOSSLServerHandler(context: context)
+                }.flatMap {
+                    channel.pipeline.addHandler($0)
+                }.flatMap {
+                    let results = postHandlers.map { channel.pipeline.addHandler($0) }
+                    return EventLoopFuture<Void>.andAllSucceed(results, on: channel.eventLoop)
+                }
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
         defer {
             XCTAssertNoThrow(try serverChannel.close().wait())
         }

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -754,6 +754,7 @@ class NIOSSLIntegrationTest: XCTestCase {
 
         let completionPromise: EventLoopPromise<ByteBuffer> = group.next().makePromise()
 
+        // TODO: have a server channel with half-closure enabled here
         let serverChannel: Channel = try serverTLSChannel(context: context, handlers: [SimpleEchoServer()], group: group)
         defer {
             XCTAssertNoThrow(try serverChannel.close().wait())


### PR DESCRIPTION
### Motivation

If NIOSSLHandler receives `close(mode: .output) or close(mode: .input)`, it ignores them, optionally failing their promises. This is weird behaviour. It should do better.

### Modifications

* flush outstanding messages on `NIOSSLHandler.close(mode: .output)`
* close SSL Connection on `NIOSSLHandler.close(mode: .output)`
* support closing the input of `NIOSSLHandler` when used as a server with `ChannelOptions.Types.AllowRemoteHalfClosureOption` enabled
* trigger TCP close when NIOSSLHandler.state == .inputClose
* write integration tests to verify the behaviour

> **Warning**: This PR relies on `EmbeddedChannel` supporting `ChannelOptions.Types.AllowRemoteHalfClosureOption`, which is currently not possible and [proposed as a Patch to `swift-nio`](https://github.com/apple/swift-nio/pull/2429)

> **Note**: I have removed a lot of whitespace, so consider selecting `Hide Whitespace` in the GitHub `Files Changed` tab