### PR TITLE
fclose takes Nonnull FILE pointer in Swift >=5.9

### DIFF
--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -39,7 +39,12 @@ internal typealias FILEPointer = UnsafeMutablePointer<FILE>
 private let sysFopen: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> FILEPointer? = fopen
 private let sysMlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mlock
 private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = munlock
+
+#if swift(>=5.9) && os(Linux)
+private let sysFclose: @convention(c) (FILEPointer) -> CInt = fclose
+#else
 private let sysFclose: @convention(c) (FILEPointer?) -> CInt = fclose
+#endif
 
 // Sadly, stat, lstat, and readlink have different signatures with glibc and macOS libc.
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)


### PR DESCRIPTION
Closes #429.