### PR TITLE
Use EVP_PKEY_assign_RSA instead of EVP_PKEY_assign

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -569,7 +569,7 @@ func generateRSAPrivateKey() -> OpaquePointer {
     precondition(generateRC == 1)
 
     let pkey = CNIOBoringSSL_EVP_PKEY_new()!
-    let assignRC = CNIOBoringSSL_EVP_PKEY_assign(pkey, EVP_PKEY_RSA, rsa)
+    let assignRC = CNIOBoringSSL_EVP_PKEY_assign_RSA(pkey, rsa)
     
     precondition(assignRC == 1)
     return pkey


### PR DESCRIPTION
EVP_PKEY_assign_RSA, at least in C, is more type-safe. It also is compatible with an upcoming BoringSSL change to make the RSA struct opaque. For some Swift reasons I don't fully understand (but relating to the OpaquePointer mess), when RSA becomes opaque, EVP_PKEY_assign no longer works.

I assume it could be made to work with some appropriate cast, but since EVP_PKEY_assign_RSA already exists (and will, in the future, be more binary-size-friendly), just use that.