### PR TITLE
Add if #available for xrOS

### DIFF
--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -66,7 +66,7 @@ extension SSLConnection {
             callbackQueue.async {
                 let result: OSStatus
 
-                if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
+                if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, xrOS 1, *) {
                     result = SecTrustEvaluateAsyncWithError(actualTrust, callbackQueue) { (_, valid, _) in
                         promise.succeed(valid ? .certificateVerified : .failed)
                     }

--- a/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
+++ b/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
@@ -21,7 +21,7 @@ extension String {
         customUnsafeUninitializedCapacity capacity: Int,
         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int
     ) rethrows {
-        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, xrOS 1, *) {
+        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
             try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
         } else {
             try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)

--- a/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
+++ b/Sources/NIOSSL/String+unsafeUninitializedCapacity.swift
@@ -21,7 +21,7 @@ extension String {
         customUnsafeUninitializedCapacity capacity: Int,
         initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int
     ) rethrows {
-        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+        if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, xrOS 1, *) {
             try self.init(unsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
         } else {
             try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)


### PR DESCRIPTION
Xcode 14 Beta 2 is warning about using SecTrustEvaluateAsync method

> **Warning**: SecTrustEvaluateAsync' was deprecated in xrOS 1.0: renamed to 'SecTrustEvaluateAsyncWithError(_:_:_:)'
