### PR TITLE
Bump minimum NIO version to 2.54.0 to fix test crashes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ import class Foundation.ProcessInfo
 func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.51.0"),
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.54.0"),
             .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         ]
     } else {


### PR DESCRIPTION
## Summary

We need to use 2.54.0 of NIO to get the fix from https://github.com/apple/swift-nio/pull/2429.

Without it, if your NIO resolved locally to an older version, tests would crash.

## Test Plan

Tests don't crash now, because you can't get an older version resolved than the one that supports the new flag.
