### PR TITLE
Add support for shrinking massive ByteBufferBIOs

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -86,7 +86,13 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: NIOSSLHandler.defaultMaxWriteSize)
+        super.init(
+            connection: connection,
+            shutdownTimeout: context.configuration.shutdownTimeout,
+            additionalPeerCertificateVerificationCallback: nil,
+            maxWriteSize: NIOSSLHandler.defaultMaxWriteSize,
+            configuration: Configuration()
+        )
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
@@ -102,7 +108,28 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
     public convenience init(context: NIOSSLContext, serverHostname: String?, customVerificationCallback: @escaping NIOSSLCustomVerificationCallback) throws {
         try self.init(context: context, serverHostname: serverHostname, optionalCustomVerificationCallback: customVerificationCallback, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }
-    
+
+    /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
+    ///     - serverHostname: The hostname of the server we're trying to connect to, if known. This will be used in the SNI extension,
+    ///         and used to validate the server certificate.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
+    ///     - configuration: Configuration for this handler.
+    public convenience init(context: NIOSSLContext, serverHostname: String?, customVerificationCallback: NIOSSLCustomVerificationCallback? = nil, configuration: Configuration) throws {
+        try self.init(
+            context: context,
+            serverHostname: serverHostname,
+            optionalCustomVerificationCallback: customVerificationCallback,
+            optionalAdditionalPeerCertificateVerificationCallback: nil,
+            configuration: configuration
+        )
+    }
+
     /// - warning: This API is not guaranteed to be stable and is likely to be changed without further notice, hence the underscore prefix.
     public static func _makeSSLClientHandler(
         context: NIOSSLContext,
@@ -118,7 +145,8 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
         serverHostname: String?,
         optionalCustomVerificationCallback: NIOSSLCustomVerificationCallback?,
         optionalAdditionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?,
-        maxWriteSize: Int = defaultMaxWriteSize
+        maxWriteSize: Int = defaultMaxWriteSize,
+        configuration: Configuration = .init()
     ) throws {
         guard let connection = context.createConnection() else {
             fatalError("Failed to create new connection in NIOSSLContext")
@@ -144,7 +172,8 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
             connection: connection,
             shutdownTimeout: context.configuration.shutdownTimeout,
             additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback,
-            maxWriteSize: maxWriteSize
+            maxWriteSize: maxWriteSize,
+            configuration: configuration
         )
     }
 }

--- a/Sources/NIOSSL/NIOSSLHandler+Configuration.swift
+++ b/Sources/NIOSSL/NIOSSLHandler+Configuration.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+extension NIOSSLHandler {
+    /// Configuration for a specific instance of ``NIOSSLHandler``, either client or server.
+    ///
+    /// This type is distinct from ``TLSConfiguration`` because it does not contain settings that
+    /// apply to TLS itself. Instead, this configuration manages how the ``NIOSSLHandler`` itself
+    /// operates.
+    public struct Configuration: Hashable, Sendable {
+        /// The maximum number of bytes we'll preserve in the outbound buffer that ``NIOSSLHandler``
+        /// holds.
+        ///
+        /// This buffer is not typically deallocated, as it is re-used throughout the lifetime of
+        /// the program. In cases where there are extremely large peak writes that are outliers in
+        /// the code, the buffer may remain excessively large.
+        ///
+        /// Set this value to a lower value to avoid preserving too much memory. This will cause
+        /// ``NIOSSLHandler`` to reallocate memory more often, which can inhibit performance, so
+        /// avoid lowering this value unless you're running into trouble with memory pressure and
+        /// are confident that ``NIOSSLHandler`` is at fault.
+        public var maximumPreservedOutboundBufferCapacity: Int
+
+        public init() {
+            self.maximumPreservedOutboundBufferCapacity = .max
+        }
+    }
+}

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -38,7 +38,13 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection.setVerificationCallback(verificationCallback)
         }
 
-        super.init(connection: connection, shutdownTimeout: context.configuration.shutdownTimeout, additionalPeerCertificateVerificationCallback: nil, maxWriteSize: NIOSSLHandler.defaultMaxWriteSize)
+        super.init(
+            connection: connection,
+            shutdownTimeout: context.configuration.shutdownTimeout,
+            additionalPeerCertificateVerificationCallback: nil,
+            maxWriteSize: NIOSSLHandler.defaultMaxWriteSize,
+            configuration: .init()
+        )
     }
 
     /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
@@ -52,7 +58,25 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
     public convenience init(context: NIOSSLContext, customVerificationCallback: @escaping NIOSSLCustomVerificationCallback) {
         self.init(context: context, optionalCustomVerificationCallback: customVerificationCallback, optionalAdditionalPeerCertificateVerificationCallback: nil)
     }
-    
+
+    /// Construct a new ``NIOSSLClientHandler`` with the given `context` and a specific `serverHostname`.
+    ///
+    /// - parameters:
+    ///     - context: The ``NIOSSLContext`` to use on this connection.
+    ///     - customVerificationCallback: A callback to use that will override NIOSSL's normal verification logic.
+    ///
+    ///         If set, this callback is provided the certificates presented by the peer. NIOSSL will not have pre-processed them. The callback will not be used if the
+    ///         ``TLSConfiguration`` that was used to construct the ``NIOSSLContext`` has ``TLSConfiguration/certificateVerification`` set to ``CertificateVerification/none``.
+    ///     - configuration: Configuration for this handler.
+    public convenience init(context: NIOSSLContext, customVerificationCallback: NIOSSLCustomVerificationCallback? = nil, configuration: Configuration) {
+        self.init(
+            context: context,
+            optionalCustomVerificationCallback: customVerificationCallback,
+            optionalAdditionalPeerCertificateVerificationCallback: nil,
+            configuration: configuration
+        )
+    }
+
     /// - warning: This API is not guaranteed to be stable and is likely to be changed without further notice, hence the underscore prefix.
     public static func _makeSSLServerHandler(
         context: NIOSSLContext,
@@ -65,7 +89,8 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
     private init(
         context: NIOSSLContext,
         optionalCustomVerificationCallback: NIOSSLCustomVerificationCallback?,
-        optionalAdditionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?
+        optionalAdditionalPeerCertificateVerificationCallback: _NIOAdditionalPeerCertificateVerificationCallback?,
+        configuration: Configuration = .init()
     ) {
         guard let connection = context.createConnection() else {
             fatalError("Failed to create new connection in NIOSSLContext")
@@ -81,7 +106,8 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
             connection: connection,
             shutdownTimeout: context.configuration.shutdownTimeout,
             additionalPeerCertificateVerificationCallback: optionalAdditionalPeerCertificateVerificationCallback,
-            maxWriteSize: NIOSSLHandler.defaultMaxWriteSize
+            maxWriteSize: NIOSSLHandler.defaultMaxWriteSize,
+            configuration: configuration
         )
     }
 }

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -89,8 +89,8 @@ internal final class SSLConnection {
         self.role = .client
     }
 
-    func setAllocator(_ allocator: ByteBufferAllocator) {
-        self.bio = ByteBufferBIO(allocator: allocator)
+    func setAllocator(_ allocator: ByteBufferAllocator, maximumPreservedOutboundBufferCapacity: Int) {
+        self.bio = ByteBufferBIO(allocator: allocator, maximumPreservedOutboundBufferCapacity: maximumPreservedOutboundBufferCapacity)
 
         // This weird dance where we pass the *exact same* pointer in to both objects is because, weirdly,
         // the BoringSSL docs claim that only one reference count will be consumed here. We therefore need to

--- a/Tests/NIOSSLTests/ByteBufferBIOTest.swift
+++ b/Tests/NIOSSLTests/ByteBufferBIOTest.swift
@@ -27,13 +27,13 @@ final class ByteBufferBIOTest: XCTestCase {
 
     /// This leaks on purpose!
     private func retainedBIO() -> UnsafeMutablePointer<BIO> {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         swiftBIO.close()
         return swiftBIO.retainedBIO()
     }
 
     func testExtractingBIOWrite() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -55,7 +55,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testManyBIOWritesAreCoalesced() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -81,7 +81,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testReadWithNoDataInBIO() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -97,7 +97,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testReadWithDataInBIO() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -127,7 +127,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testShortReads() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -180,7 +180,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testZeroLengthReadsAlwaysSucceed() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -194,7 +194,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testWriteWhenHoldingBufferTriggersCoW() throws {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -228,7 +228,7 @@ final class ByteBufferBIOTest: XCTestCase {
             return swiftBIO.outboundCiphertext()?.baseAddress()
         }
 
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -246,7 +246,7 @@ final class ByteBufferBIOTest: XCTestCase {
         // This test works by emulating testWriteWhenHoldingBufferTriggersCoW, but
         // with the second write at zero length. This will not trigger a CoW, as no
         // actual write will occur.
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -269,7 +269,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testSimplePuts() {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -290,7 +290,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testGetsNotSupported() {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -311,7 +311,7 @@ final class ByteBufferBIOTest: XCTestCase {
     }
 
     func testBasicCtrlDance() {
-        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator())
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: .max)
         let cBIO = swiftBIO.retainedBIO()
         defer {
             CNIOBoringSSL_BIO_free(cBIO)
@@ -332,6 +332,49 @@ final class ByteBufferBIOTest: XCTestCase {
 
         let newShutdown2 = CNIOBoringSSL_BIO_ctrl(cBIO, BIO_CTRL_GET_CLOSE, 0, nil)
         XCTAssertEqual(newShutdown2, CLong(BIO_CLOSE))
+    }
+
+    func testMaximumPreservedCapacityIsObeyed() throws {
+        let swiftBIO = ByteBufferBIO(allocator: ByteBufferAllocator(), maximumPreservedOutboundBufferCapacity: 64)
+        let cBIO = swiftBIO.retainedBIO()
+        defer {
+            CNIOBoringSSL_BIO_free(cBIO)
+            swiftBIO.close()
+        }
+
+        XCTAssertNil(swiftBIO.outboundCiphertext())
+
+        // We're going to write 1kb, then 1 byte, in a loop. After the 1kB write, the capacity of the buffer will be 1kB (or more).
+        // After the 1 byte write, the capacity will be 64 (exactly).
+        var bytesToWrite: [UInt8] = .init(repeating: 0, count: 1024)
+
+        for _ in 0..<10 {
+            var rc = CNIOBoringSSL_BIO_write(cBIO, &bytesToWrite, CInt(bytesToWrite.count))
+            XCTAssertEqual(rc, CInt(bytesToWrite.count))
+
+            let capacity = swiftBIO._testOnly_outboundBufferCapacity
+            XCTAssertGreaterThanOrEqual(capacity, 1024)
+
+            guard swiftBIO.outboundCiphertext() != nil else {
+                XCTFail("No received bytes")
+                return
+            }
+
+            // Capacity hasn't changed yet.
+            XCTAssertEqual(capacity, swiftBIO._testOnly_outboundBufferCapacity)
+
+            // Now write a short chunk.
+            rc = CNIOBoringSSL_BIO_write(cBIO, &bytesToWrite, 1)
+            XCTAssertEqual(rc, 1)
+
+            // Check the capacity. It should be exactly 64.
+            XCTAssertEqual(swiftBIO._testOnly_outboundBufferCapacity, 64)
+
+            guard swiftBIO.outboundCiphertext() != nil else {
+                XCTFail("No received bytes")
+                return
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Motivation:

ByteBufferBIOs will grow their outbound buffer until flush is called. They will retain their capacity at however large it got to avoid reallocating, as they assume that your write pattern will be fairly consistent.

In some cases this is a bad strategy, because it overcommits data. To allow users to reclaim this data, we can add a configuration option that will shrink the playload on the next write.

Modifications:

- Added support for ByteBufferBIO to shrink the payload.
- Plumbed up support for handler configuration.
- Tests that shrinkage actually works.

Result:

Users can reclaim memory.