### PR TITLE
Android: update Bionic declarations for nullability annotations added in NDK 26

### DIFF
--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -36,18 +36,24 @@ internal typealias FILEPointer = OpaquePointer
 internal typealias FILEPointer = UnsafeMutablePointer<FILE>
 #endif
 
+#if os(Android)
+private let sysFopen: @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> FILEPointer? = fopen
+private let sysMlock: @convention(c) (UnsafeRawPointer, size_t) -> CInt = mlock
+private let sysMunlock: @convention(c) (UnsafeRawPointer, size_t) -> CInt = munlock
+#else
 private let sysFopen: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> FILEPointer? = fopen
 private let sysMlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mlock
 private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = munlock
+#endif
 private let sysFclose: @convention(c) (FILEPointer?) -> CInt =  { fclose($0!) }
 
 // Sadly, stat, lstat, and readlink have different signatures with glibc and macOS libc.
-#if canImport(Darwin) || os(Android)
+#if canImport(Darwin)
 private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)
 private let sysReadlink: @convention(c) (UnsafePointer<Int8>?, UnsafeMutablePointer<Int8>?, Int) -> Int = readlink
 private let sysLstat:  @convention(c) (UnsafePointer<Int8>?, UnsafeMutablePointer<stat>?) -> Int32 = lstat
 
-#elseif os(Linux) || os(FreeBSD)
+#elseif os(Linux) || os(FreeBSD) || os(Android)
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
 private let sysReadlink: @convention(c) (UnsafePointer<Int8>, UnsafeMutablePointer<Int8>, Int) -> Int = readlink
 private let sysLstat:  @convention(c) (UnsafePointer<Int8>, UnsafeMutablePointer<stat>) -> Int32 = lstat

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -853,7 +853,7 @@ internal class DirectoryContents: Sequence, IteratorProtocol {
     
     init(path: String) {
         self.path = path
-        self.dir = opendir(path)
+        self.dir = opendir(path)!
     }
     
     func next() -> String? {


### PR DESCRIPTION
Also, force unwrap an `opendir()` call that could be null.

This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/7d2df8be98f10150b2c30e18186c9ecbb724549a%5E%21/#F0). I made sure this pull doesn't break anything by testing it on linux x86_64, and the force unwrap with the previous NDK 25c too. I used this patch with others to build the Swift toolchain and this package for my Android CI, finagolfin/swift-android-sdk#122.