### PR TITLE
Changes to support building with Musl.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,11 +58,19 @@ MANGLE_END */
     ],
     dependencies: generateDependencies(),
     targets: [
-        .target(name: "CNIOBoringSSL"),
+        .target(
+            name: "CNIOBoringSSL",
+            cSettings: [
+              .define("_GNU_SOURCE"),
+              .define("_POSIX_C_SOURCE", to: "200112L")
+            ]),
         .target(
             name: "CNIOBoringSSLShims",
             dependencies: [
                 "CNIOBoringSSL"
+            ],
+            cSettings: [
+              .define("_GNU_SOURCE"),
             ]),
         .target(
             name: "NIOSSL",

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -17,6 +17,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -16,6 +16,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -16,6 +16,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -22,6 +22,8 @@
 // can lift anything missing from there and move it over without change.
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else
@@ -36,29 +38,13 @@ internal typealias FILEPointer = OpaquePointer
 internal typealias FILEPointer = UnsafeMutablePointer<FILE>
 #endif
 
-#if os(Android)
-private let sysFopen: @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> FILEPointer? = fopen
-private let sysMlock: @convention(c) (UnsafeRawPointer, size_t) -> CInt = mlock
-private let sysMunlock: @convention(c) (UnsafeRawPointer, size_t) -> CInt = munlock
-#else
-private let sysFopen: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> FILEPointer? = fopen
-private let sysMlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = mlock
-private let sysMunlock: @convention(c) (UnsafeRawPointer?, size_t) -> CInt = munlock
-#endif
-private let sysFclose: @convention(c) (FILEPointer?) -> CInt =  { fclose($0!) }
-
-// Sadly, stat, lstat, and readlink have different signatures with glibc and macOS libc.
-#if canImport(Darwin)
-private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat(_:_:)
-private let sysReadlink: @convention(c) (UnsafePointer<Int8>?, UnsafeMutablePointer<Int8>?, Int) -> Int = readlink
-private let sysLstat:  @convention(c) (UnsafePointer<Int8>?, UnsafeMutablePointer<stat>?) -> Int32 = lstat
-
-#elseif os(Linux) || os(FreeBSD) || os(Android)
-private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat(_:_:)
-private let sysReadlink: @convention(c) (UnsafePointer<Int8>, UnsafeMutablePointer<Int8>, Int) -> Int = readlink
-private let sysLstat:  @convention(c) (UnsafePointer<Int8>, UnsafeMutablePointer<stat>) -> Int32 = lstat
-#endif
-
+private let sysFopen = fopen
+private let sysMlock = mlock
+private let sysMunlock = munlock
+private let sysFclose = fclose
+private let sysStat = stat
+private let sysLstat = lstat
+private let sysReadlink = readlink
 
 // MARK:- Copied code from SwiftNIO
 private func isUnacceptableErrno(_ code: CInt) -> Bool {

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -17,6 +17,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -18,6 +18,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -18,6 +18,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/NIOSSL/SubjectAlternativeName.swift
+++ b/Sources/NIOSSL/SubjectAlternativeName.swift
@@ -18,6 +18,8 @@ import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else


### PR DESCRIPTION
Define `_GNU_SOURCE` in the `Package.swift`.

Add imports for Musl in relevant places.

Remove types from `sysXXX` static variables.