### PR TITLE
Define _DARWIN_C_SOURCE on Darwin to fix the build in Xcode.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,8 @@ MANGLE_END */
             name: "CNIOBoringSSL",
             cSettings: [
               .define("_GNU_SOURCE"),
-              .define("_POSIX_C_SOURCE", to: "200112L")
+              .define("_POSIX_C_SOURCE", to: "200112L"),
+              .define("_DARWIN_C_SOURCE")
             ]),
         .target(
             name: "CNIOBoringSSLShims",


### PR DESCRIPTION
For some reason, we need this in order to build in Xcode, but using SwiftPM directly from the command line works.  Anyway, defining it should be harmless for non-Darwin platforms.