### PR TITLE
Add empty privacy manifest

### DIFF
--- a/.PrivacyInfo.xcprivacy
+++ b/.PrivacyInfo.xcprivacy
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+</dict>
+</plist>
+

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,15 @@ func generateDependencies() -> [Package.Dependency] {
     }
 }
 
+// This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
+// Foundation will be linked. This is, however, strictly better than unconditionally adding the
+// resource.
+#if os(Linux) || os(Android)
+let includePrivacyManifest = false
+#else
+let includePrivacyManifest = true
+#endif
+
 let package = Package(
     name: "swift-nio-ssl",
     products: [
@@ -82,7 +91,9 @@ MANGLE_END */
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
-            ]),
+            ],
+            resources: includePrivacyManifest ? [.copy("ProcessInfo.xcprivacy")] : []
+        ),
         .executableTarget(
             name: "NIOTLSServer",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -49,10 +49,10 @@ func generateDependencies() -> [Package.Dependency] {
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
 // Foundation will be linked. This is, however, strictly better than unconditionally adding the
 // resource.
-#if os(Linux) || os(Android)
-let includePrivacyManifest = false
-#else
+#if canImport(Darwin)
 let includePrivacyManifest = true
+#else
+let includePrivacyManifest = false
 #endif
 
 let package = Package(

--- a/Sources/NIOSSL/PrivacyInfo.xcprivacy
+++ b/Sources/NIOSSL/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy


### PR DESCRIPTION
Motivation:

NIOSSL distributes a copy of BoringSSL, which means it needs a privacy manifest.

Modifications:

- Add a privacy manifest

Result:

NIOSSL shouldn't be rejected from app submission by not declaring a privacy manifest.