### PR TITLE
Handle error when private key file type is unknown

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -530,8 +530,7 @@ extension NIOSSLContext {
         case .some("der"), .some("key"):
             fileType = SSL_FILETYPE_ASN1
         default:
-            // TODO(cory): Again, error handling here would be good.
-            fatalError("Unknown private key file type.")
+            throw NIOSSLExtraError.unknownPrivateKeyFileType(path: path)
         }
         
         let result = path.withCString { (pointer) -> CInt in

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -199,6 +199,7 @@ extension NIOSSLExtraError {
         case serverHostnameImpossibleToMatch
         case cannotUseIPAddressInSNI
         case invalidSNIHostname
+        case unknownPrivateKeyFileType
     }
 }
 
@@ -224,6 +225,9 @@ extension NIOSSLExtraError {
     /// - hostname contains the `0` unicode scalar (which would be encoded as the `0` byte which is unsupported).
     public static let invalidSNIHostname = NIOSSLExtraError(baseError: .invalidSNIHostname, description: nil)
 
+    /// The private key file for the TLS configuration has an unknown type.
+    public static let unknownPrivateKeyFileType = NIOSSLExtraError(baseError: .unknownPrivateKeyFileType, description: nil)
+
     @inline(never)
     internal static func failedToValidateHostname(expectedName: String) -> NIOSSLExtraError {
         let description = "Couldn't find \(expectedName) in certificate from peer"
@@ -241,6 +245,12 @@ extension NIOSSLExtraError {
         let description = "IP addresses cannot validly be used for Server Name Indication, got \(ipAddress)"
         return NIOSSLExtraError(baseError: .cannotUseIPAddressInSNI, description: description)
     }
+
+    @inline(never)
+    internal static func unknownPrivateKeyFileType(path: String) -> NIOSSLExtraError {
+        let description = "Unknown private key file type for \(path)"
+        return NIOSSLExtraError(baseError: .unknownPrivateKeyFileType, description: description)
+  }
 }
 
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1288,6 +1288,19 @@ class TLSConfigurationTest: XCTestCase {
         serverConfig.pskHint = "pskHint"
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContainsAnyOf: ["SSLV3_ALERT_BAD_RECORD_MAC"])
     }
+
+    func testUnknownPrivateKeyFileType() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.privateKey = .file("key.invalidExtension")
+
+        XCTAssertThrowsError(try NIOSSLContext(configuration: clientConfig)) { error in
+            guard let sslError = error as? NIOSSLExtraError else {
+                return XCTFail("Expected NIOSSLExtraError but got \(error)")
+            }
+
+            XCTAssertEqual(sslError, .unknownPrivateKeyFileType)
+        }
+    }
 }
 
 extension EmbeddedChannel {


### PR DESCRIPTION
Motivation:

When the private key file for a TLS configuration has an unknown type, the program crashes. Hence, users are unable to catch the error.

Modifications:

A new error was added to `NIOSSLExtraError` and the program throws that error instead of crashing.

Result:

The program now throws an error instead of crashing.