### PR TITLE
test compiler version not language version

### DIFF
--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -19,7 +19,7 @@ import NIOPosix
 import NIOEmbedded
 @testable import NIOSSL
 import NIOTLS
-#if swift(>=5.8)
+#if compiler(>=5.8)
 @preconcurrency import Dispatch
 #else
 import Dispatch


### PR DESCRIPTION
Technically we should test the SDK version here but that's more difficult, especially given that on Linux we ship the SDK with the compiler.

See https://github.com/apple/swift-nio/issues/2718