### PR TITLE
Use Bionic module and new Android overlay in Swift 6

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -19,8 +19,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -18,8 +18,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -18,8 +18,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -24,8 +24,10 @@
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -19,8 +19,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -20,8 +20,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("unsupported os")
 #endif

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -20,8 +20,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #else
 #error("unsupported os")
 #endif
@@ -44,7 +46,7 @@ internal enum FileSystemObject {
         }
 
 #if os(Android) && arch(arm)
-        return (statObj.st_mode & UInt32(Glibc.S_IFDIR)) != 0 ? .directory : .file
+        return (statObj.st_mode & UInt32(S_IFDIR)) != 0 ? .directory : .file
 #else
         return (statObj.st_mode & S_IFDIR) != 0 ? .directory : .file
 #endif
@@ -733,7 +735,7 @@ extension NIOSSLContext {
         let _ = try Posix.lstat(path: path, buf: &buffer)
         // Check the mode to make sure this is a symlink
 #if os(Android) && arch(arm)
-        if (buffer.st_mode & UInt32(Glibc.S_IFMT)) != UInt32(Glibc.S_IFLNK) { return false }
+        if (buffer.st_mode & UInt32(S_IFMT)) != UInt32(S_IFLNK) { return false }
 #else
         if (buffer.st_mode & S_IFMT) != S_IFLNK { return false }
 #endif

--- a/Sources/NIOSSL/SubjectAlternativeName.swift
+++ b/Sources/NIOSSL/SubjectAlternativeName.swift
@@ -20,8 +20,10 @@ import NIOCore
 import Darwin.C
 #elseif canImport(Musl)
 import Musl
-#elseif os(Linux) || os(FreeBSD) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #else
 #error("unsupported os")
 #endif


### PR DESCRIPTION
Swift 6 has switched to this new Android overlay, swiftlang/swift#74758, which I've been testing on this repo without a problem using my daily Android CI for weeks now, finagolfin/swift-android-sdk#151.