### PR TITLE
Fix incorrect filename

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,7 @@ MANGLE_END */
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
             ],
-            resources: includePrivacyManifest ? [.copy("ProcessInfo.xcprivacy")] : []
+            resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : []
         ),
         .executableTarget(
             name: "NIOTLSServer",


### PR DESCRIPTION
PR #459 added this privacy manifest, but refers to it by the wrong name here.

Motivation:

When building a project that references this library (via Tuist, but I assume it would be true for other build tools too), I get the following warning:

```
No files found at: /Users/moshe/projects/myproject/Tuist/.build/checkouts/swift-nio-ssl/Sources/NIOSSL/ProcessInfo.xcprivacy
```

Modifications:

Fixed the filename in `Package.swift`.

Result:

No more warnings.