### PR TITLE
Update swiftlang link in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ func generateDependencies() -> [Package.Dependency] {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
             .package(url: "https://github.com/apple/swift-nio.git", from: "2.54.0"),
-            .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+            .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.0.0"),
         ]
     } else {
         return [


### PR DESCRIPTION
Update the new link from "https://github.com/apple/swift-docc-plugin" to "https://github.com/swiftlang/swift-docc-plugin.git"