### PR TITLE
Exclude privacy manifest when it isn't a resource

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,7 @@ MANGLE_END */
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOTLS", package: "swift-nio"),
             ],
+            exclude: includePrivacyManifest ? [] : ["PrivacyInfo.xcprivacy"],
             resources: includePrivacyManifest ? [.copy("PrivacyInfo.xcprivacy")] : []
         ),
         .executableTarget(


### PR DESCRIPTION
Motivation:

swift build warns when the privacy manifest isn't a package resource.

Modifications:

- Add it do the excluded files when it isn't a resource

Result:

- Resolves #466