### PR TITLE
Add support for supplying supported curves to `TLSConfiguration`

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -330,7 +330,13 @@ public final class NIOSSLContext {
         // Cipher suites. We just pass this straight to BoringSSL.
         returnCode = CNIOBoringSSL_SSL_CTX_set_cipher_list(context, configuration.cipherSuites)
         precondition(1 == returnCode)
-        
+
+        // Curves list.
+        if let curves = configuration.curves {
+            returnCode = CNIOBoringSSL_SSL_CTX_set1_curves_list(context, curves)
+            precondition(1 == returnCode)
+        }
+
         // Set the PSK Client Configuration callback.
         if let pskClientConfigurationsCallback = configuration._pskClientIdentityProvider {
             self.pskClientConfigurationCallback = pskClientConfigurationsCallback

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -132,6 +132,29 @@ public struct NIOTLSCipher: RawRepresentable, Hashable, Sendable {
     }
 }
 
+/// Available curves to use for TLS.
+public struct NIOTLSCurve: RawRepresentable, Hashable, Sendable {
+    /// Construct a ``NIOTLSCurve`` from the RFC code point for that curve.
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+
+    /// Construct a ``NIOTLSCurve`` from the RFC code point for that curve.
+    public init(_ rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
+    /// The RFC code point for the given curve.
+    public var rawValue: UInt16
+    public typealias RawValue = UInt16
+
+    public static let secp256r1 = NIOTLSCurve(rawValue: 0x17)
+    public static let secp384r1 = NIOTLSCurve(rawValue: 0x18)
+    public static let secp521r1 = NIOTLSCurve(rawValue: 0x19)
+    public static let x25519    = NIOTLSCurve(rawValue: 0x1D)
+    public static let x448      = NIOTLSCurve(rawValue: 0x1E)
+}
+
 /// Formats NIOSSL supports for serializing keys and certificates.
 public enum NIOSSLSerializationFormats: Sendable {
     case pem
@@ -253,9 +276,8 @@ public struct TLSConfiguration {
     /// TLS 1.3 cipher suites cannot be configured.
     public var cipherSuites: String = defaultCipherSuites
 
-    /// TLS curves supported by this handler.
-    /// Can be used to override the default supported curves.
-    public var curves: String?
+    /// TLS curves supported by this handler. Passing `nil` means that a built-in set of curves will be used.
+    public var curves: [NIOTLSCurve]?
 
     /// Public property used to set the internal ``cipherSuites`` from ``NIOTLSCipher``.
     public var cipherSuiteValues: [NIOTLSCipher] {

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -132,34 +132,6 @@ public struct NIOTLSCipher: RawRepresentable, Hashable, Sendable {
     }
 }
 
-/// Available curves to use for TLS instead of a string based representation.
-public struct NIOTLSCurve: RawRepresentable, Hashable, Sendable {
-    /// Construct a ``NIOTLSCurve`` from the RFC code point for that cipher.
-    public init(rawValue: UInt16) {
-        self.rawValue = rawValue
-    }
-
-    /// Construct a ``NIOTLSCurve`` from the RFC code point for that curve.
-    public init(_ rawValue: RawValue) {
-        self.rawValue = rawValue
-    }
-
-    /// The RFC code point for the given curve.
-    public var rawValue: UInt16
-    public typealias RawValue = UInt16
-
-    public static let secp256r1 = NIOTLSCurve(rawValue: 0x0017)
-    public static let secp384r1 = NIOTLSCurve(rawValue: 0x0018)
-    public static let secp521r1 = NIOTLSCurve(rawValue: 0x0019)
-    public static let x25519    = NIOTLSCurve(rawValue: 0x001D)
-    public static let x448      = NIOTLSCurve(rawValue: 0x001E)
-
-    var standardName: String {
-        let boringSSLName = CNIOBoringSSL_SSL_get_curve_name(self.rawValue)!
-        return String(cString: boringSSLName)
-    }
-}
-
 /// Formats NIOSSL supports for serializing keys and certificates.
 public enum NIOSSLSerializationFormats: Sendable {
     case pem
@@ -498,6 +470,7 @@ extension TLSConfiguration {
         return self.minimumTLSVersion == comparing.minimumTLSVersion &&
             self.maximumTLSVersion == comparing.maximumTLSVersion &&
             self.cipherSuites == comparing.cipherSuites &&
+            self.curves == comparing.curves &&
             self.verifySignatureAlgorithms == comparing.verifySignatureAlgorithms &&
             self.signingSignatureAlgorithms == comparing.signingSignatureAlgorithms &&
             self.certificateVerification == comparing.certificateVerification &&
@@ -525,6 +498,7 @@ extension TLSConfiguration {
         hasher.combine(minimumTLSVersion)
         hasher.combine(maximumTLSVersion)
         hasher.combine(cipherSuites)
+        hasher.combine(curves)
         hasher.combine(verifySignatureAlgorithms)
         hasher.combine(signingSignatureAlgorithms)
         hasher.combine(certificateVerification)

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -132,6 +132,34 @@ public struct NIOTLSCipher: RawRepresentable, Hashable, Sendable {
     }
 }
 
+/// Available curves to use for TLS instead of a string based representation.
+public struct NIOTLSCurve: RawRepresentable, Hashable, Sendable {
+    /// Construct a ``NIOTLSCurve`` from the RFC code point for that cipher.
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+
+    /// Construct a ``NIOTLSCurve`` from the RFC code point for that curve.
+    public init(_ rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+
+    /// The RFC code point for the given curve.
+    public var rawValue: UInt16
+    public typealias RawValue = UInt16
+
+    public static let secp256r1 = NIOTLSCurve(rawValue: 0x0017)
+    public static let secp384r1 = NIOTLSCurve(rawValue: 0x0018)
+    public static let secp521r1 = NIOTLSCurve(rawValue: 0x0019)
+    public static let x25519    = NIOTLSCurve(rawValue: 0x001D)
+    public static let x448      = NIOTLSCurve(rawValue: 0x001E)
+
+    var standardName: String {
+        let boringSSLName = CNIOBoringSSL_SSL_get_curve_name(self.rawValue)!
+        return String(cString: boringSSLName)
+    }
+}
+
 /// Formats NIOSSL supports for serializing keys and certificates.
 public enum NIOSSLSerializationFormats: Sendable {
     case pem
@@ -252,6 +280,10 @@ public struct TLSConfiguration {
     /// The pre-TLS1.3 cipher suites supported by this handler. This uses the OpenSSL cipher string format.
     /// TLS 1.3 cipher suites cannot be configured.
     public var cipherSuites: String = defaultCipherSuites
+
+    /// TLS curves supported by this handler.
+    /// Can be used to override the default supported curves.
+    public var curves: String?
 
     /// Public property used to set the internal ``cipherSuites`` from ``NIOTLSCipher``.
     public var cipherSuiteValues: [NIOTLSCipher] {

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -832,6 +832,7 @@ class TLSConfigurationTest: XCTestCase {
     func testCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
         clientConfig.curves = [.x25519]
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -841,6 +842,7 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
+        serverConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         serverConfig.curves = [.x25519]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
@@ -850,6 +852,7 @@ class TLSConfigurationTest: XCTestCase {
     func testMultipleCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
         clientConfig.curves = [.x25519]
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -860,6 +863,7 @@ class TLSConfigurationTest: XCTestCase {
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
         serverConfig.curves = [.x25519, .secp256r1]
+        serverConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
@@ -867,7 +871,8 @@ class TLSConfigurationTest: XCTestCase {
 
     func testNonCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.curves = [.secp256r1]
+        clientConfig.curves = [.secp521r1]
+        clientConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -877,7 +882,8 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
-        serverConfig.curves = [.secp256r1]
+        serverConfig.curves = [.x25519]
+        serverConfig.cipherSuiteValues = [.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1126,7 +1126,7 @@ class TLSConfigurationTest: XCTestCase {
     func testBestEffortEquatableHashableDifferences() {
         // If this assertion fails, DON'T JUST CHANGE THE NUMBER HERE! Make sure you've added any appropriate transforms below
         // so that we're testing these best effort functions.
-        XCTAssertEqual(MemoryLayout<TLSConfiguration>.size, 242, "TLSConfiguration has changed size: you probably need to update this test!")
+        XCTAssertEqual(MemoryLayout<TLSConfiguration>.size, 234, "TLSConfiguration has changed size: you probably need to update this test!")
 
         let first = TLSConfiguration.makeClientConfiguration()
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -831,7 +831,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func testCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.curves = "X25519"
+        clientConfig.curves = [.x25519]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -841,7 +841,7 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
-        serverConfig.curves = "X25519"
+        serverConfig.curves = [.x25519]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
@@ -849,7 +849,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func testMultipleCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.curves = "X25519"
+        clientConfig.curves = [.x25519]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -859,7 +859,7 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
-        serverConfig.curves = "X25519:prime256v1"
+        serverConfig.curves = [.x25519, .secp256r1]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
@@ -867,7 +867,7 @@ class TLSConfigurationTest: XCTestCase {
 
     func testNonCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.curves = "X25519"
+        clientConfig.curves = [.secp256r1]
         clientConfig.maximumTLSVersion = .tlsv12
         clientConfig.certificateVerification = .noHostnameVerification
         clientConfig.trustRoots = .certificates([TLSConfigurationTest.cert1])
@@ -877,7 +877,7 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
-        serverConfig.curves = "prime256v1"
+        serverConfig.curves = [.secp256r1]
         serverConfig.maximumTLSVersion = .tlsv12
         serverConfig.certificateVerification = .none
         try assertHandshakeError(withClientConfig: clientConfig, andServerConfig: serverConfig, errorTextContains: "ALERT_HANDSHAKE_FAILURE")
@@ -1164,7 +1164,7 @@ class TLSConfigurationTest: XCTestCase {
             { $0.minimumTLSVersion = .tlsv13 },
             { $0.maximumTLSVersion = .tlsv12 },
             { $0.cipherSuites = "AES" },
-            { $0.curves = "X25519" },
+            { $0.curves = [.x25519] },
             { $0.cipherSuiteValues = [.TLS_RSA_WITH_AES_256_CBC_SHA] },
             { $0.verifySignatureAlgorithms = [.ed25519] },
             { $0.signingSignatureAlgorithms = [.ed25519] },


### PR DESCRIPTION
This PR adds the support to specify what ECs the handler supports when doing the handshake.

```swift
var config = TLSConfiguration.makeClientConfiguration()
config.curves = [.x25519]
```