### PR TITLE
Unify main.yml and scheduled.yml, remove 5_8 ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
-name: Scheduled
+name: Main
 
 on:
+    push:
+        branches: [main]
     schedule:
         - cron: "0 8,20 * * *"
 
@@ -9,7 +11,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"


### PR DESCRIPTION
### Motivation:

* `main.yml` and `scheduled.yml` are mostly duplicative.
* Scheduled runs failed because of a deprecated reference to a Swift 5.8 pipeline

### Modifications:

* Unify `main.yml` and `scheduled.yml`
* Remove the reference to the 5.8 pipeline

### Result:

Working scheduled runs.