### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,3 +144,14 @@ let package = Package(
     ],
     cxxLanguageStandard: .cxx14
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -12,11 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
-
-#if os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
-#endif
+import NIOCore
 
 #if canImport(Darwin)
 import Darwin.C

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -14,6 +14,10 @@
 
 import NIOCore
 
+#if os(Linux) || os(FreeBSD) || os(Android)
+import CNIOLinux
+#endif
+
 #if canImport(Darwin)
 import Darwin.C
 #elseif canImport(Musl)


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.