### PR TITLE
Actually disable hostname validation on Apple platforms when asked

### DIFF
--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -30,10 +30,12 @@ extension SSLConnection {
                 preconditionFailure("This callback should only be used if we are using the system-default trust.")
             }
 
+            let expectedHostname = self.validateHostnames ? self.expectedHostname : nil
+
             // This force-unwrap is safe as we must have decided if we're a client or a server before validation.
             var trust: SecTrust? = nil
             var result: OSStatus
-            let policy = SecPolicyCreateSSL(self.role! == .client, self.expectedHostname as CFString?)
+            let policy = SecPolicyCreateSSL(self.role! == .client, expectedHostname as CFString?)
             result = SecTrustCreateWithCertificates(peerCertificates as CFArray, policy, &trust)
             guard result == errSecSuccess, let actualTrust = trust else {
                 throw NIOSSLError.unableToValidateCertificate


### PR DESCRIPTION
Motivation:

swift-nio-ssl has long had a flag to disable its own certificate validation behaviour. This flag works fine, and had the desired effect.

However, this flag did not take account of the fact that Security.framework _also_ validates the hostname. Due to an implementation bug, setting .noHostnameVerification disabled only one of the two checks.

Modifications:

- Correctly check the flag before passing a hostname to Security.framework
- Write some tests to make sure the behaviour works in all modes.

Result:

Better, more consistent behaviour.