### PR TITLE
Add explicit import of NIOCore

### DIFF
--- a/Tests/NIOSSLTests/SecurityFrameworkVerificationTests.swift
+++ b/Tests/NIOSSLTests/SecurityFrameworkVerificationTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
 import XCTest
 
 @testable import NIOSSL


### PR DESCRIPTION
Motivation:

Nightly CI builders need all the imports to be correct, and we were missing a NIOCore import in the tests.

Modifications:

import NIOCore

Result:

Nice builds in the 6.1 nightlies