### PR TITLE
Update tools version to 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project


### PR DESCRIPTION
Motivation:

When we dropped 5.8 support we didn't raise the tools version. The result is that 5.8 compilers still resolve newer versions, including 2.29.1. Unfortunately, 2.29.1 doesn't compile.

Modifications:

Lift the tools version to 5.9

Result:

Users won't accidentally resolve this from 5.8.