### PR TITLE
Delete Thresholds/nightly-6.1 symlink

### DIFF
--- a/Benchmarks/Thresholds/nightly-6.1
+++ b/Benchmarks/Thresholds/nightly-6.1
@@ -1,1 +1,0 @@
-./nightly-next


### PR DESCRIPTION
Following on from https://github.com/apple/swift-nio-ssl/pull/511 delete `Thresholds/nightly-6.1` which is no longer needed now that the shared benchmarks workflow has been updated