### PR TITLE
Enable macOS CI on merge to main and daily timer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,9 @@ jobs:
         uses: apple/swift-nio/.github/workflows/benchmarks.yml@main
         with:
             benchmark_package_path: "Benchmarks"
+
+    macos-tests:
+        name: macOS tests
+        uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+        with:
+            build_scheme: swift-nio-ssl-Package


### PR DESCRIPTION
Motivation:

* Improve test coverage
* Check test pass/fail status
* Monitor CI throughput

Modifications:

Enable macOS CI to be run on all merges to main and on a daily timer.

Result:

Improved test coverage run out-of-band at the moment so we can get a
feeling for if any changes need to be made in the repo or in the CI
pipelines to ensure timely and stable checks.
