### PR TITLE
Enable warnings as errors on Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
         with:
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 


### PR DESCRIPTION
### Motivation:

Enable warnings as errors on Swift 6.0 to lock-in strict concurrency safety.

### Modifications:

Enable warnings as errors on Swift 6.0 to lock-in strict concurrency safety.

### Result:

CI will fail if we encounter strict concurrency warnings on Swift 6.0