### PR TITLE
Switch integration tests to newer Swift test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,29 @@ jobs:
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
-    integration-tests:
+    construct-integration-test-matrix:
+        name: Construct integration matrix
+        runs-on: ubuntu-latest
+        outputs:
+            integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+            - id: generate-matrix
+              run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+              env:
+                  MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq execstack lsof dnsutils netcat-openbsd net-tools expect curl jq
+                  MATRIX_LINUX_COMMAND: ./scripts/integration_tests.sh -f test_01_renegotiation
+
+    integration-test:
         name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+        needs: construct-integration-test-matrix
+        uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
         with:
             name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq execstack lsof dnsutils netcat-openbsd net-tools expect curl jq && ./scripts/integration_tests.sh -f test_01_renegotiation"
+            matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
 
     benchmarks:
         name: Benchmarks

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,12 +20,29 @@ jobs:
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
-    integration-tests:
+    construct-integration-test-matrix:
+        name: Construct integration matrix
+        runs-on: ubuntu-latest
+        outputs:
+            integration-test-matrix: '${{ steps.generate-matrix.outputs.integration-test-matrix }}'
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+            - id: generate-matrix
+              run: echo "integration-test-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+              env:
+                  MATRIX_LINUX_SETUP_COMMAND: apt-get update -y && apt-get install -yq execstack lsof dnsutils netcat-openbsd net-tools expect curl jq
+                  MATRIX_LINUX_COMMAND: ./scripts/integration_tests.sh -f test_01_renegotiation
+
+    integration-test:
         name: Integration test
-        uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+        needs: construct-integration-test-matrix
+        uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
         with:
             name: "Integration test"
-            matrix_linux_command: "apt-get update -yq && apt-get install -yq execstack lsof dnsutils netcat-openbsd net-tools expect curl jq && ./scripts/integration_tests.sh"
+            matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
 
     benchmarks:
         name: Benchmarks


### PR DESCRIPTION
### Motivation:

To remove all uses of the older workflow so it can be removed to simplify the workflows.

### Modifications:

* Switch integration tests to use the newer Swift test matrix workflow, `swift_test_matrix.yml`

### Result:

This should make no difference to the running of integration tests.