### PR TITLE
Remove some redundant suppressed conformances

### DIFF
--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -212,6 +212,3 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
         )
     }
 }
-
-@available(*, unavailable)
-extension NIOSSLClientHandler: Sendable {}

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -130,6 +130,3 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
         )
     }
 }
-
-@available(*, unavailable)
-extension NIOSSLServerHandler: Sendable {}


### PR DESCRIPTION
These suppressed conformances are not necessary, as they are redundant with the suppressed conformance on the parent class.