### PR TITLE
Clean up sendability of statics

### DIFF
--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -171,7 +171,8 @@ final class ByteBufferBIO {
     /// and it will always be non-NULL. Failure to initialize this structure is fatal to
     /// the program.
     #if compiler(>=5.10)
-    nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = buildBoringSSLBIOMethod()
+    nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> =
+        buildBoringSSLBIOMethod()
     #else
     private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = buildBoringSSLBIOMethod()
     #endif

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -170,7 +170,7 @@ final class ByteBufferBIO {
     /// using a ByteBufferBIO. There will only ever be one value of this in a NIO program,
     /// and it will always be non-NULL. Failure to initialize this structure is fatal to
     /// the program.
-    private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = {
+    nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = {
         guard boringSSLIsInitialized else {
             preconditionFailure("Failed to initialize BoringSSL")
         }

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -170,7 +170,13 @@ final class ByteBufferBIO {
     /// using a ByteBufferBIO. There will only ever be one value of this in a NIO program,
     /// and it will always be non-NULL. Failure to initialize this structure is fatal to
     /// the program.
-    nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = {
+    #if compiler(>=5.10)
+    nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = buildBoringSSLBIOMethod()
+    #else
+    private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = buildBoringSSLBIOMethod()
+    #endif
+
+    private static func buildBoringSSLBIOMethod() -> UnsafeMutablePointer<BIO_METHOD> {
         guard boringSSLIsInitialized else {
             preconditionFailure("Failed to initialize BoringSSL")
         }
@@ -189,7 +195,7 @@ final class ByteBufferBIO {
         CNIOBoringSSL_BIO_meth_set_destroy(method, boringSSLBIODestroyFunc)
 
         return method
-    }()
+    }
 
     /// Pointer to the backing BoringSSL BIO object.
     ///

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -218,12 +218,13 @@ extension SSLConnection {
 // We heap-allocate the SSL_PRIVATE_KEY_METHOD we need because we can't define a static stored property with fixed address
 // in Swift.
 #if compiler(>=5.10)
-nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = buildCustomPrivateKeyMethod()
+nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> =
+    buildCustomPrivateKeyMethod()
 #else
 internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = buildCustomPrivateKeyMethod()
 #endif
 
-fileprivate func buildCustomPrivateKeyMethod() -> UnsafePointer<SSL_PRIVATE_KEY_METHOD> {
+private func buildCustomPrivateKeyMethod() -> UnsafePointer<SSL_PRIVATE_KEY_METHOD> {
     let pointer = UnsafeMutablePointer<SSL_PRIVATE_KEY_METHOD>.allocate(capacity: 1)
     pointer.pointee = .init(sign: customKeySign, decrypt: customKeyDecrypt, complete: customKeyComplete)
     return UnsafePointer(pointer)

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -217,7 +217,7 @@ extension SSLConnection {
 
 // We heap-allocate the SSL_PRIVATE_KEY_METHOD we need because we can't define a static stored property with fixed address
 // in Swift.
-internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = {
+nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = {
     let pointer = UnsafeMutablePointer<SSL_PRIVATE_KEY_METHOD>.allocate(capacity: 1)
     pointer.pointee = .init(sign: customKeySign, decrypt: customKeyDecrypt, complete: customKeyComplete)
     return UnsafePointer(pointer)

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -217,11 +217,17 @@ extension SSLConnection {
 
 // We heap-allocate the SSL_PRIVATE_KEY_METHOD we need because we can't define a static stored property with fixed address
 // in Swift.
-nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = {
+#if compiler(>=5.10)
+nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = buildCustomPrivateKeyMethod()
+#else
+internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = buildCustomPrivateKeyMethod()
+#endif
+
+fileprivate func buildCustomPrivateKeyMethod() -> UnsafePointer<SSL_PRIVATE_KEY_METHOD> {
     let pointer = UnsafeMutablePointer<SSL_PRIVATE_KEY_METHOD>.allocate(capacity: 1)
     pointer.pointee = .init(sign: customKeySign, decrypt: customKeyDecrypt, complete: customKeyComplete)
     return UnsafePointer(pointer)
-}()
+}
 
 /// This is our entry point from BoringSSL when we've been asked to do a sign.
 private func customKeySign(

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -44,7 +44,7 @@ private let sysFopen = fopen
 private let sysMlock = mlock
 private let sysMunlock = munlock
 private let sysFclose = fclose
-private let sysStat = { stat($0, $1) }
+private let sysStat = { @Sendable in stat($0, $1) }
 private let sysLstat = lstat
 private let sysReadlink = readlink
 

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -31,7 +31,7 @@ import Android
 // This is a neat trick. Swift lazily initializes module-globals based on when they're first
 // used. This lets us defer BoringSSL intialization as late as possible and only do it if people
 // actually create any object that uses BoringSSL.
-internal var boringSSLIsInitialized: Bool = initializeBoringSSL()
+internal let boringSSLIsInitialized: Bool = initializeBoringSSL()
 
 internal enum FileSystemObject {
     case directory


### PR DESCRIPTION
A number of statics in the product code aren't something the compiler currently believes are Sendable. There are a few tweaks here:

1. Two pointer statics into BoringSSL. These are thread-safe, but the compiler doesn't know. Mark them `nonisolated(unsafe)`.
2. One static `var` should be a static `let`.
3. One instance of reminding the compiler that closures that don't capture anything are Sendable.