### PR TITLE
Cleanup missing internal Sendable annotation and missing preconcurrency import

### DIFF
--- a/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
+++ b/Sources/NIOSSL/SecurityFrameworkCertificateVerification.swift
@@ -18,7 +18,7 @@ import NIOCore
 #if canImport(Darwin)
 import Dispatch
 import Foundation
-import Security
+@preconcurrency import Security
 
 extension SSLConnection {
     func performSecurityFrameworkValidation(

--- a/Sources/NIOSSL/SubjectAlternativeName.swift
+++ b/Sources/NIOSSL/SubjectAlternativeName.swift
@@ -75,6 +75,9 @@ public struct _SubjectAlternativeNames {
 // _SubjectAlternativeNames is immutable and therefore Sendable
 extension _SubjectAlternativeNames: @unchecked Sendable {}
 
+// _SubjectAlternativeNames.Storage is immutable and therefore Sendable
+extension _SubjectAlternativeNames.Storage: @unchecked Sendable {}
+
 extension _SubjectAlternativeNames: RandomAccessCollection {
 
     @inlinable public subscript(position: Int) -> _SubjectAlternativeName {


### PR DESCRIPTION
The backing storage for SubjectAlternativeNames is Sendable (it's immutable), and Security hasn't been annotated with sendability.