### PR TITLE
Add DocC extension page to provide curation for TLSConfiguration

### DIFF
--- a/Sources/NIOSSL/Docs.docc/TLSConfiguration.md
+++ b/Sources/NIOSSL/Docs.docc/TLSConfiguration.md
@@ -1,0 +1,56 @@
+# ``TLSConfiguration``
+
+## Topics
+
+### Creating a TLS configuration
+
+- ``clientDefault``
+- ``makeClientConfiguration()``
+- ``makeServerConfiguration(certificateChain:privateKey:)``
+- ``makePreSharedKeyConfiguration()``
+
+### Inspecting a configuration
+
+- ``minimumTLSVersion``
+- ``maximumTLSVersion``
+- ``certificateVerification``
+- ``trustRoots``
+- ``certificateChain``
+- ``privateKey``
+- ``applicationProtocols``
+- ``shutdownTimeout``
+- ``keyLogCallback``
+- ``renegotiationSupport``
+- ``sslContextCallback``
+
+### Inspecting configuration ciphers
+
+- ``cipherSuites``
+- ``verifySignatureAlgorithms``
+- ``signingSignatureAlgorithms``
+- ``cipherSuiteValues``
+- ``curves``
+- ``additionalTrustRoots``
+- ``sendCANameList``
+
+### Inspecting pre-shared key configurations
+
+- ``pskClientProvider``
+- ``pskHint``
+- ``pskServerProvider``
+- ``pskClientCallback``
+- ``pskServerCallback``
+
+### Comparing and Hashing TLS configurations
+
+- ``bestEffortEquals(_:)``
+- ``bestEffortHash(into:)``
+
+### Deprecated initializers
+
+- ``forClient(cipherSuites:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:certificateChain:privateKey:applicationProtocols:shutdownTimeout:keyLogCallback:)``
+- ``forClient(cipherSuites:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:certificateChain:privateKey:applicationProtocols:shutdownTimeout:keyLogCallback:renegotiationSupport:)``
+- ``forClient(cipherSuites:verifySignatureAlgorithms:signingSignatureAlgorithms:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:certificateChain:privateKey:applicationProtocols:shutdownTimeout:keyLogCallback:renegotiationSupport:)``
+
+- ``forServer(certificateChain:privateKey:cipherSuites:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:applicationProtocols:shutdownTimeout:keyLogCallback:)``
+- ``forServer(certificateChain:privateKey:cipherSuites:verifySignatureAlgorithms:signingSignatureAlgorithms:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:applicationProtocols:shutdownTimeout:keyLogCallback:)``


### PR DESCRIPTION
Motivation:

When viewing the documentation, deprecated methods clutter up available options, sometimes below, making those options hard to find for a developer working out how to add or create a TLSConfiguration.

Modifications:

Adds a DocC extension file (markdown format) the provides curation (organization of the symbols) to order by task and ideally usefulness, with deprecated methods pushed downward.

Result:

The documentation at
https://swiftpackageindex.com/apple/swift-nio-ssl/main/documentation/niossl/tlsconfiguration (and future releases) will include this organization and be easier to read through for developers.