### PR TITLE
Add subjectName, issuerName, and access to the peerCert

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -810,6 +810,10 @@ extension NIOSSLHandler {
     public var tlsVersion: TLSVersion? {
         self.connection.getTLSVersionForConnection()
     }
+
+    public var peerCertificate: NIOSSLCertificate? {
+        self.connection.getPeerCertificate()
+    }
 }
 
 extension Channel {
@@ -819,6 +823,13 @@ extension Channel {
             $0.tlsVersion
         }
     }
+
+    public func nioSSL_peerCertificate() -> EventLoopFuture<NIOSSLCertificate?> {
+        self.pipeline.handler(type: NIOSSLHandler.self).map {
+            $0.peerCertificate
+        }
+    }
+
 }
 
 extension ChannelPipeline.SynchronousOperations {
@@ -826,6 +837,11 @@ extension ChannelPipeline.SynchronousOperations {
     public func nioSSL_tlsVersion() throws -> TLSVersion? {
         let handler = try self.handler(type: NIOSSLHandler.self)
         return handler.tlsVersion
+    }
+
+    public func nioSSL_peerCertificate() throws -> NIOSSLCertificate? {
+        let handler = try self.handler(type: NIOSSLHandler.self)
+        return handler.peerCertificate
     }
 }
 

--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -811,6 +811,9 @@ extension NIOSSLHandler {
         self.connection.getTLSVersionForConnection()
     }
 
+    /// Return a NIOSSLCertificate from the verified peer after handshake has completed.
+    ///
+    /// Similar to getTlsVersionForConnection this **is not thread safe**.
     public var peerCertificate: NIOSSLCertificate? {
         self.connection.getPeerCertificate()
     }
@@ -824,6 +827,7 @@ extension Channel {
         }
     }
 
+    /// API to retrieve the verified NIOSSLCertificate of the peer off the 'Channel'
     public func nioSSL_peerCertificate() -> EventLoopFuture<NIOSSLCertificate?> {
         self.pipeline.handler(type: NIOSSLHandler.self).map {
             $0.peerCertificate
@@ -839,6 +843,7 @@ extension ChannelPipeline.SynchronousOperations {
         return handler.tlsVersion
     }
 
+    /// API to retrieve the verified NIOSSLCertificate of the peer directly from the 'ChannelPipeline'
     public func nioSSL_peerCertificate() throws -> NIOSSLCertificate? {
         let handler = try self.handler(type: NIOSSLHandler.self)
         return handler.peerCertificate

--- a/Sources/NIOSSL/SSLCertificateName.swift
+++ b/Sources/NIOSSL/SSLCertificateName.swift
@@ -1,7 +1,26 @@
-@_implementationOnly import CNIOBoringSSL
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 
+#if compiler(>=6.1)
+internal import CNIOBoringSSL
+#else
+@_implementationOnly import CNIOBoringSSL
+#endif
+
+/// Defines the type of X509 name
 public struct SSLCertificateNameType: Equatable, Hashable, Sendable {
-    public var nid: Int32
+    internal var nid: Int32
     public static let organization = SSLCertificateNameType(nid: NID_organizationName)
     public static let organizationalUnit = SSLCertificateNameType(nid: NID_organizationalUnitName)
     public static let state = SSLCertificateNameType(nid: NID_stateOrProvinceName)
@@ -12,6 +31,7 @@ public struct SSLCertificateNameType: Equatable, Hashable, Sendable {
     public static let userId = SSLCertificateNameType(nid: NID_userId)
 }
 
+/// Contains the string value of a X509 name
 public struct SSLCertificateName: Equatable, Hashable, Sendable {
     public var value: String
     public var type: SSLCertificateNameType
@@ -47,10 +67,13 @@ extension NIOSSLCertificate {
             guard let namePtr = encodedName else {
                 continue
             }
+
+            defer {
+                CNIOBoringSSL_OPENSSL_free(namePtr)
+            }
+
             let arr = UnsafeBufferPointer(start: namePtr, count: Int(stringLength))
             let nameString = String(decoding: arr, as: UTF8.self)
-            CNIOBoringSSL_OPENSSL_free(namePtr)
-
             let nid = CNIOBoringSSL_OBJ_obj2nid(object)
             names.append(SSLCertificateName(nameString, .init(nid: nid)))
         }

--- a/Sources/NIOSSL/SSLCertificateName.swift
+++ b/Sources/NIOSSL/SSLCertificateName.swift
@@ -1,0 +1,81 @@
+@_implementationOnly import CNIOBoringSSL
+
+public struct SSLCertificateNameType: Equatable, Hashable, Sendable {
+    public var nid: Int32
+    public static let organization = SSLCertificateNameType(nid: NID_organizationName)
+    public static let organizationalUnit = SSLCertificateNameType(nid: NID_organizationalUnitName)
+    public static let state = SSLCertificateNameType(nid: NID_stateOrProvinceName)
+    public static let country = SSLCertificateNameType(nid: NID_countryName)
+    public static let city = SSLCertificateNameType(nid: NID_localityName)
+    public static let commonName = SSLCertificateNameType(nid: NID_commonName)
+    public static let emailAddress = SSLCertificateNameType(nid: NID_pkcs9_emailAddress)
+    public static let userId = SSLCertificateNameType(nid: NID_userId)
+}
+
+public struct SSLCertificateName: Equatable, Hashable, Sendable {
+    public var value: String
+    public var type: SSLCertificateNameType
+
+    public init(_ value: String, _ type: SSLCertificateNameType) {
+        self.value = value
+        self.type = type
+    }
+}
+
+extension NIOSSLCertificate {
+    private static func convertName(_ name: OpaquePointer) -> [SSLCertificateName] {
+
+        let count = CNIOBoringSSL_X509_NAME_entry_count(name)
+        var names = [SSLCertificateName]()
+        names.reserveCapacity(Int(count))
+        for index in 0..<count {
+            guard let entry = CNIOBoringSSL_X509_NAME_get_entry(name, index) else {
+                continue
+            }
+
+            guard let object = CNIOBoringSSL_X509_NAME_ENTRY_get_object(entry) else {
+                continue
+            }
+
+            guard let data = CNIOBoringSSL_X509_NAME_ENTRY_get_data(entry) else {
+                continue
+            }
+
+            var encodedName: UnsafeMutablePointer<UInt8>? = nil
+            let stringLength = CNIOBoringSSL_ASN1_STRING_to_UTF8(&encodedName, data)
+
+            guard let namePtr = encodedName else {
+                continue
+            }
+            let arr = UnsafeBufferPointer(start: namePtr, count: Int(stringLength))
+            let nameString = String(decoding: arr, as: UTF8.self)
+            CNIOBoringSSL_OPENSSL_free(namePtr)
+
+            let nid = CNIOBoringSSL_OBJ_obj2nid(object)
+            names.append(SSLCertificateName(nameString, .init(nid: nid)))
+        }
+
+        return names
+    }
+
+    /// Return an array of SSLCertificateName enums containing the subject name of the
+    /// underlying X509 Certificate
+    public var subjectName: [SSLCertificateName] {
+        guard let subjectName = CNIOBoringSSL_X509_get_subject_name(self._ref) else {
+            return []
+        }
+
+        return Self.convertName(subjectName)
+
+    }
+
+    /// Return an array of SSLCertificateName enums containing the issuer name of the
+    /// underlying X509 Certificate
+    public var issuerName: [SSLCertificateName] {
+        guard let issuerName = CNIOBoringSSL_X509_get_issuer_name(self._ref) else {
+            return []
+        }
+
+        return Self.convertName(issuerName)
+    }
+}

--- a/Tests/NIOSSLTests/SSLCertificateTest.swift
+++ b/Tests/NIOSSLTests/SSLCertificateTest.swift
@@ -424,6 +424,26 @@ class SSLCertificateTest: XCTestCase {
         XCTAssertEqual(String(decoding: sans[6].contents, as: UTF8.self), "http://example.org/")
     }
 
+    func testSubjectName() throws {
+        let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
+        XCTAssertEqual(
+            cert.subjectName,
+            [
+                SSLCertificateName("US", .country),
+                SSLCertificateName("California", .state),
+                SSLCertificateName("San Fransokyo", .city),
+                SSLCertificateName("San Fransokyo Institute of Technology", .organization),
+                SSLCertificateName("Robotics Lab", .organizationalUnit),
+                SSLCertificateName("robots.sanfransokyo.edu", .commonName),
+            ]
+        )
+    }
+
+    func testIssuerName() throws {
+        let cert = try NIOSSLCertificate(bytes: .init(sampleIntermediateCA.utf8), format: .pem)
+        XCTAssertEqual(cert.issuerName, [SSLCertificateName("badCertificateAuthority", .commonName)])
+    }
+
     func testNonexistentSan() throws {
         let cert = try NIOSSLCertificate(bytes: .init(samplePemCert.utf8), format: .pem)
         XCTAssertTrue(cert._subjectAlternativeNames().isEmpty)


### PR DESCRIPTION
Motivation:

While swift-nio-ssl supports mTLS on the server, there's no api available to get the verified X509 certificate after the handshake completes.

Additionally, the existing API for NIOSSLCertificate doesn't have an API to access the issuer and subject names.

Result:

These changes add new APIs. Specifically:
- nioSSL_peerCertificate() to the channel extension. Similar to retrieving the tls version, this gets the verified peer X509 certificate after the handshake completes.
- subjectName extension to NIOSSLCertificate. Grabs the subjectName from the BoringSSL X509 object as an array of SSLCertificateName
- issuerName extension to the NIOSSLCertificate. Grabs the issuerName from the BoringSSL X509 object as an array of SSLCertificateName