### PR TITLE
Add explicit API support for X25519_MLKEM768 hybrid KEM

### DIFF
--- a/Sources/NIOSSL/Docs.docc/index.md
+++ b/Sources/NIOSSL/Docs.docc/index.md
@@ -67,6 +67,10 @@ SwiftNIO SSL        | Minimum Swift Version
 
 ## Topics
 
+### Articles
+
+- <doc:quantum-secure-tls>
+
 ### Channel Handlers
 
 - ``NIOSSLClientHandler``

--- a/Sources/NIOSSL/Docs.docc/quantum-secure-tls.md
+++ b/Sources/NIOSSL/Docs.docc/quantum-secure-tls.md
@@ -1,0 +1,15 @@
+# Quantum-secure TLS
+
+To enable quantum-secure algorithms in swift-nio-ssl requires minimal configuration changes. While the algorithms are being standardised they are off by default, but once the code points are final we will be enabling them by default.
+
+In the meantime, if you wish to add support, you can enable ``NIOTLSCurve/x25519_MLKEM768`` with the following change:
+
+```swift
+tlsConfiguration.curves = [.x25519_MLKEM768, .x25519, .secp384r1]
+```
+
+This configuration offers both a post-quantum hybrid key-establishment mechanism, as well as classical options. This is an appropriate choice for general-purpose use as it can support older clients, but it may not be appropriate for your use-case. If you are aiming to support _only_ post-quantum key exchange, you can do so by setting only PQ or hybrid KEMs:
+
+```swift
+tlsConfiguration.curves = [.x25519_MLKEM768]
+```

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the SwiftNIO project authors
+// Copyright (c) 2017-2025 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -163,6 +163,7 @@ public struct NIOTLSCurve: RawRepresentable, Hashable, Sendable {
     public static let secp521r1 = NIOTLSCurve(rawValue: 0x19)
     public static let x25519 = NIOTLSCurve(rawValue: 0x1D)
     public static let x448 = NIOTLSCurve(rawValue: 0x1E)
+    public static let x25519_MLKEM768 = NIOTLSCurve(rawValue: 0x11EC)
 }
 
 /// Formats NIOSSL supports for serializing keys and certificates.


### PR DESCRIPTION
Motivation:

While we've supported the hybrid quantum-resistant KEM for a while
(because BoringSSL has), users have had to define the constant themselves.
This patch makes the quantum-resistant KEM part of our API.

Modifications:

- Expose x25519_MLKEM768 as a curve type.
- Add tests

Result:

More quantum-resistance.