### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 
 import PackageDescription
 

--- a/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.ManyWrites.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.ManyWrites.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 201948
-}

--- a/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.SimpleHandshake.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.SimpleHandshake.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal": 629000
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/Sources/NIOSSL/ByteBufferBIO.swift
+++ b/Sources/NIOSSL/ByteBufferBIO.swift
@@ -175,12 +175,8 @@ final class ByteBufferBIO {
     /// using a ByteBufferBIO. There will only ever be one value of this in a NIO program,
     /// and it will always be non-NULL. Failure to initialize this structure is fatal to
     /// the program.
-    #if compiler(>=5.10)
     nonisolated(unsafe) private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> =
         buildBoringSSLBIOMethod()
-    #else
-    private static let boringSSLBIOMethod: UnsafeMutablePointer<BIO_METHOD> = buildBoringSSLBIOMethod()
-    #endif
 
     private static func buildBoringSSLBIOMethod() -> UnsafeMutablePointer<BIO_METHOD> {
         guard boringSSLIsInitialized else {

--- a/Sources/NIOSSL/CustomPrivateKey.swift
+++ b/Sources/NIOSSL/CustomPrivateKey.swift
@@ -222,12 +222,8 @@ extension SSLConnection {
 
 // We heap-allocate the SSL_PRIVATE_KEY_METHOD we need because we can't define a static stored property with fixed address
 // in Swift.
-#if compiler(>=5.10)
 nonisolated(unsafe) internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> =
     buildCustomPrivateKeyMethod()
-#else
-internal let customPrivateKeyMethod: UnsafePointer<SSL_PRIVATE_KEY_METHOD> = buildCustomPrivateKeyMethod()
-#endif
 
 private func buildCustomPrivateKeyMethod() -> UnsafePointer<SSL_PRIVATE_KEY_METHOD> {
     let pointer = UnsafeMutablePointer<SSL_PRIVATE_KEY_METHOD>.allocate(capacity: 1)

--- a/Sources/NIOSSLPerformanceTester/main.swift
+++ b/Sources/NIOSSLPerformanceTester/main.swift
@@ -17,11 +17,7 @@ import Foundation
 
 // MARK: Test Harness
 
-#if compiler(>=5.10)
 nonisolated(unsafe) var warning: String = ""
-#else
-var warning: String = ""
-#endif
 
 assert(
     {

--- a/Tests/NIOSSLTests/CustomPrivateKeyTests.swift
+++ b/Tests/NIOSSLTests/CustomPrivateKeyTests.swift
@@ -19,14 +19,10 @@ import XCTest
 
 @testable import NIOSSL
 
-#if compiler(>=5.1)
 #if compiler(>=6.1)
 internal import CNIOBoringSSL
 #else
 @_implementationOnly import CNIOBoringSSL
-#endif
-#else
-import CNIOBoringSSL
 #endif
 
 // This is a helper that lets us work with an EVP_PKEY.

--- a/Tests/NIOSSLTests/SecurityFrameworkVerificationTests.swift
+++ b/Tests/NIOSSLTests/SecurityFrameworkVerificationTests.swift
@@ -226,11 +226,7 @@ extension SecurityFrameworkVerificationTests {
     /// by running the following command, and replacing both served certificates as leaf and intermediate,
     /// in that order:
     /// `openssl s_client -connect www.apple.com:443 -servername www.apple.com -showcerts`
-    #if compiler(>=5.10)
     nonisolated(unsafe) fileprivate static let appleComCertChain: [SecCertificate] = buildAppleComCertChain()
-    #else
-    fileprivate static let appleComCertChain: [SecCertificate] = buildAppleComCertChain()
-    #endif
 
     fileprivate static func buildAppleComCertChain() -> [SecCertificate] {
         #if canImport(Darwin)

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@preconcurrency import Dispatch
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
@@ -26,8 +27,6 @@ internal import CNIOBoringSSL
 #else
 @_implementationOnly import CNIOBoringSSL
 #endif
-
-@preconcurrency import Dispatch
 
 final class ErrorCatcher<T: Error>: ChannelInboundHandler, Sendable {
     public typealias InboundIn = Any

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -27,11 +27,7 @@ internal import CNIOBoringSSL
 @_implementationOnly import CNIOBoringSSL
 #endif
 
-#if compiler(>=5.8)
 @preconcurrency import Dispatch
-#else
-import Dispatch
-#endif
 
 final class ErrorCatcher<T: Error>: ChannelInboundHandler, Sendable {
     public typealias InboundIn = Any


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
