### PR TITLE
Make CNIOBoringSSLShims compatible with C++ interop

### DIFF
--- a/Sources/CNIOBoringSSLShims/include/CNIOBoringSSLShims.h
+++ b/Sources/CNIOBoringSSLShims/include/CNIOBoringSSLShims.h
@@ -22,6 +22,10 @@
 #include "CNIOBoringSSL.h"
 #endif
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 X509_EXTENSION *CNIOBoringSSLShims_sk_X509_EXTENSION_value(const STACK_OF(X509_EXTENSION) *sk, size_t i);
 size_t CNIOBoringSSLShims_sk_X509_EXTENSION_num(const STACK_OF(X509_EXTENSION) *sk);
 
@@ -33,5 +37,9 @@ int CNIOBoringSSLShims_SSL_CTX_set_app_data(SSL_CTX *ctx, void *data);
 
 int CNIOBoringSSLShims_ERR_GET_LIB(uint32_t err);
 int CNIOBoringSSLShims_ERR_GET_REASON(uint32_t err);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
 
 #endif  // C_NIO_BORINGSSL_SHIMS_H


### PR DESCRIPTION
This fixes linker errors such as
```
"CNIOBoringSSLShims_SSL_CTX_get_app_data(CNIOBoringSSL_ssl_ctx_st const*)", referenced from:
      static NIOSSL.NIOSSLContext.(lookupFromRawContext in <...>)(ssl: Swift.OpaquePointer) -> NIOSSL.NIOSSLContext in SSLContext.swift.o
```
when building with Swift/C++ interoperability enabled.

This is similar to https://github.com/apple/swift-nio/pull/3251.