### PR TITLE
Fix incorrect callback caching

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -411,7 +411,7 @@ public class NIOSSLHandler: ChannelInboundHandler, ChannelOutboundHandler, Remov
             }
 
             // If there's a failed custom context operation, we fire both errors.
-            if let customContextError = self.connection.parentContext.customContextManager?.loadContextError {
+            if let customContextError = self.connection.customContextManager?.loadContextError {
                 context.fireErrorCaught(customContextError)
             }
 

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -342,7 +342,7 @@ extension CustomContextManager {
                 // Ensure we execute any completion on the next event loop tick
                 // This ensures that we suspend before calling resume
                 eventLoop.assumeIsolated().execute {
-                    connection.parentContext.customContextManager?.state = .complete(result)
+                    connection.customContextManager?.state = .complete(result)
                     connection.parentHandler?.resumeHandshake()
                 }
             }

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -58,6 +58,7 @@ internal final class SSLConnection {
     private var verificationCallback: NIOSSLVerificationCallback?
     internal var customVerificationManager: CustomVerifyManager?
     internal var customPrivateKeyResult: Result<ByteBuffer, Error>?
+    internal var customContextManager: CustomContextManager?
 
     /// Whether certificate hostnames should be validated.
     var validateHostnames: Bool {
@@ -70,6 +71,10 @@ internal final class SSLConnection {
     init(ownedSSL: OpaquePointer, parentContext: NIOSSLContext) {
         self.ssl = ownedSSL
         self.parentContext = parentContext
+
+        if let customContextCallback = parentContext.configuration.sslContextCallback {
+            self.customContextManager = CustomContextManager(callback: customContextCallback)
+        }
 
         // We pass the SSL object an unowned reference to this object.
         let pointerToSelf = Unmanaged.passUnretained(self).toOpaque()

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -250,7 +250,7 @@ private func sslContextCallback(ssl: OpaquePointer?, arg: UnsafeMutableRawPointe
         )
     }
 
-    let parentSwiftContext = NIOSSLContext.lookupFromRawContext(ssl: ssl)
+    let parentSwiftContext = SSLConnection.loadConnectionFromSSL(ssl)
 
     // This is a safe force unwrap as this callback is only register directly after setting the manager
     var contextManager = parentSwiftContext.customContextManager!
@@ -295,7 +295,6 @@ public final class NIOSSLContext {
     fileprivate let sslContext: OpaquePointer
     private let callbackManager: CallbackManagerProtocol?
     private var keyLogManager: KeyLogCallbackManager?
-    internal var customContextManager: CustomContextManager?
     internal var pskClientConfigurationCallback: _NIOPSKClientIdentityProvider?
     internal var pskServerConfigurationCallback: _NIOPSKServerIdentityProvider?
     internal let configuration: TLSConfiguration
@@ -372,8 +371,8 @@ public final class NIOSSLContext {
         }
 
         // Set the SSL Context Configuration callback.
-        if let sslContextConfigurationCallback = configuration.sslContextCallback {
-            self.customContextManager = CustomContextManager(callback: sslContextConfigurationCallback)
+        // The state is managed on the connection.
+        if configuration.sslContextCallback != nil {
             CNIOBoringSSL_SSL_CTX_set_cert_cb(context, sslContextCallback, nil)
         }
 


### PR DESCRIPTION
Motivation:

The certificate override callback incorrectly cached results on the SSLContext, instead of the SSLConnection. The result is that it would only fire once for a given SSLContext, instead of on every connection, incorrectly caching the result indefinitely.

Modifications:

Move the callback state to SSLConnection
Write tests to validate that the callback is called the right
    number of times.

Result:

Better behaviour.