### PR TITLE
Enable certificate verification if trustRoots are set to non-`nil`

### DIFF
--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -315,12 +315,22 @@ public struct TLSConfiguration {
     /// The trust roots to use to validate certificates. This only needs to be provided if you intend to validate
     /// certificates.
     ///
+    /// - NOTE: If you set this field to a non-`none` value, ``certificateVerification`` will be automatically
+    /// set to ``CertificateVerification/noHostnameVerification`` if it was previously set to ``CertificateVerification/none``.
+    /// If the value was set higher, it will not be changed.
+    ///
     /// - NOTE: If certificate validation is enabled and ``trustRoots`` is `nil` then the system default root of
     /// trust is used (as if ``trustRoots`` had been explicitly set to ``NIOSSLTrustRoots/default``).
     ///
     /// - NOTE: If a directory path is used here to load a directory of certificates into a configuration, then the
     ///         certificates in this directory must be formatted by `c_rehash` to create the rehash file format of `HHHHHHHH.D` with a symlink.
-    public var trustRoots: NIOSSLTrustRoots?
+    public var trustRoots: NIOSSLTrustRoots? {
+        didSet {
+            if self.trustRoots != nil && self.certificateVerification == .none {
+                self.certificateVerification = .noHostnameVerification
+            }
+        }
+    }
 
     /// Additional trust roots to use to validate certificates, used in addition to ``trustRoots``.
     public var additionalTrustRoots: [NIOSSLAdditionalTrustRoots]

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -647,6 +647,7 @@ class NIOSSLIntegrationTest: XCTestCase {
             privateKey: .privateKey(NIOSSLIntegrationTest.key)
         )
         config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
+        config.certificateVerification = .none
         config.keyLogCallback = keyLogCallback
         return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
@@ -2418,8 +2419,8 @@ class NIOSSLIntegrationTest: XCTestCase {
             privateKey: .privateKey(NIOSSLIntegrationTest.key)
         )
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.certificateVerification = .none
         clientConfig.trustRoots = .default
+        clientConfig.certificateVerification = .none
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig))
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig))
 


### PR DESCRIPTION
Motivation:

If a user sets the trust roots to a non-`none` value, they presumably want to actually validate them. This patch enables an automatic setting of validation if the trust roots are set.

Modifications:

- Use a didSet on TLSConfiguration to raise hostname validation when the trustRoots are set.
- Fix up cases where the tests were doing the wrong thing

Result:

Safer APIs.