### PR TITLE
Revert "Enable certificate verification if trustRoots are set to non-`nil`"

### DIFF
--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -315,22 +315,12 @@ public struct TLSConfiguration {
     /// The trust roots to use to validate certificates. This only needs to be provided if you intend to validate
     /// certificates.
     ///
-    /// - NOTE: If you set this field to a non-`none` value, ``certificateVerification`` will be automatically
-    /// set to ``CertificateVerification/noHostnameVerification`` if it was previously set to ``CertificateVerification/none``.
-    /// If the value was set higher, it will not be changed.
-    ///
     /// - NOTE: If certificate validation is enabled and ``trustRoots`` is `nil` then the system default root of
     /// trust is used (as if ``trustRoots`` had been explicitly set to ``NIOSSLTrustRoots/default``).
     ///
     /// - NOTE: If a directory path is used here to load a directory of certificates into a configuration, then the
     ///         certificates in this directory must be formatted by `c_rehash` to create the rehash file format of `HHHHHHHH.D` with a symlink.
-    public var trustRoots: NIOSSLTrustRoots? {
-        didSet {
-            if self.trustRoots != nil && self.certificateVerification == .none {
-                self.certificateVerification = .noHostnameVerification
-            }
-        }
-    }
+    public var trustRoots: NIOSSLTrustRoots?
 
     /// Additional trust roots to use to validate certificates, used in addition to ``trustRoots``.
     public var additionalTrustRoots: [NIOSSLAdditionalTrustRoots]

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -647,7 +647,6 @@ class NIOSSLIntegrationTest: XCTestCase {
             privateKey: .privateKey(NIOSSLIntegrationTest.key)
         )
         config.trustRoots = .certificates([NIOSSLIntegrationTest.cert])
-        config.certificateVerification = .none
         config.keyLogCallback = keyLogCallback
         return try assertNoThrowWithValue(NIOSSLContext(configuration: config), file: file, line: line)
     }
@@ -2419,8 +2418,8 @@ class NIOSSLIntegrationTest: XCTestCase {
             privateKey: .privateKey(NIOSSLIntegrationTest.key)
         )
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.trustRoots = .default
         clientConfig.certificateVerification = .none
+        clientConfig.trustRoots = .default
         let serverContext = try assertNoThrowWithValue(NIOSSLContext(configuration: serverConfig))
         let clientContext = try assertNoThrowWithValue(NIOSSLContext(configuration: clientConfig))
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -667,6 +667,8 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
+        serverConfig.trustRoots = .default
+        serverConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert2])]
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
@@ -682,6 +684,8 @@ class TLSConfigurationTest: XCTestCase {
             certificateChain: [.certificate(TLSConfigurationTest.cert1)],
             privateKey: .privateKey(TLSConfigurationTest.key1)
         )
+        serverConfig.trustRoots = .certificates([])
+        serverConfig.additionalTrustRoots = [.certificates([TLSConfigurationTest.cert2])]
 
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
@@ -1595,8 +1599,8 @@ class TLSConfigurationTest: XCTestCase {
         }
 
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.trustRoots = .certificates([])
         clientConfig.certificateVerification = .none
+        clientConfig.trustRoots = .certificates([])
         clientConfig.minimumTLSVersion = .tlsv13
         clientConfig.maximumTLSVersion = .tlsv13
         clientConfig.pskClientCallback = pskClientCallback
@@ -1787,8 +1791,8 @@ class TLSConfigurationTest: XCTestCase {
         }
 
         var clientConfig = TLSConfiguration.makeClientConfiguration()
-        clientConfig.trustRoots = .certificates([])
         clientConfig.certificateVerification = .none
+        clientConfig.trustRoots = .certificates([])
         clientConfig.minimumTLSVersion = .tlsv13
         clientConfig.maximumTLSVersion = .tlsv13
         clientConfig.pskClientProvider = pskClientProvider
@@ -2182,78 +2186,6 @@ class TLSConfigurationTest: XCTestCase {
         }
 
         XCTAssertEqual(callbackCount.withLockedValue { $0 }, 5)
-    }
-
-    func testSettingTrustRootsForcesHostnameVerificationUp() throws {
-        var config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        XCTAssertEqual(config.certificateVerification, .none)
-        config.trustRoots = .default
-        XCTAssertEqual(config.certificateVerification, .noHostnameVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        XCTAssertEqual(config.certificateVerification, .none)
-        config.trustRoots = .certificates([TLSConfigurationTest.cert2])
-        XCTAssertEqual(config.certificateVerification, .noHostnameVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        XCTAssertEqual(config.certificateVerification, .none)
-        config.trustRoots = .file("/foo/bar")
-        XCTAssertEqual(config.certificateVerification, .noHostnameVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        XCTAssertEqual(config.certificateVerification, .none)
-        config.trustRoots = .none
-        XCTAssertEqual(config.certificateVerification, .none)
-    }
-
-    func testSettingTrustRootsDoesNotForceVerificationDown() throws {
-        var config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        config.certificateVerification = .fullVerification
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-        config.trustRoots = .default
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        config.certificateVerification = .fullVerification
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-        config.trustRoots = .certificates([TLSConfigurationTest.cert2])
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        config.certificateVerification = .fullVerification
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-        config.trustRoots = .file("/foo/bar")
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-
-        config = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(TLSConfigurationTest.cert2)],
-            privateKey: .privateKey(TLSConfigurationTest.key2)
-        )
-        config.certificateVerification = .fullVerification
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
-        config.trustRoots = .none
-        XCTAssertEqual(config.certificateVerification, .fullVerification)
     }
 }
 


### PR DESCRIPTION
Reverts apple/swift-nio-ssl#543

This may have resulted in a behavior change which would adversely affect downstream, we should back it out whilst we investigate.