### PR TITLE
Remove per-benchmark wiggle room

### DIFF
--- a/Benchmarks/Benchmarks/NIOSSLBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOSSLBenchmarks/Benchmarks.swift
@@ -28,8 +28,7 @@ let benchmarks = {
             metrics: defaultMetrics,
             scalingFactor: .kilo,
             maxDuration: .seconds(10_000_000),
-            maxIterations: 10,
-            thresholds: [.mallocCountTotal: .init(absolute: [.p90: 2000])]
+            maxIterations: 10
         )
     ) { benchmark in
         try runSimpleHandshake(
@@ -43,8 +42,7 @@ let benchmarks = {
             metrics: defaultMetrics,
             scalingFactor: .kilo,
             maxDuration: .seconds(10_000_000),
-            maxIterations: 10,
-            thresholds: [.mallocCountTotal: .init(absolute: [.p90: 2000])]
+            maxIterations: 10
         )
     ) { benchmark in
         try runManyWrites(

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     targets: [
         .executableTarget(
-            name: "NIOSSHBenchmarks",
+            name: "NIOSSLBenchmarks",
             dependencies: [
                 .product(name: "Benchmark", package: "package-benchmark"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),


### PR DESCRIPTION
Motivation:

The benchmarks have a 2000 alloc wiggle room defined at the per-test level. It's not obvious why this is there as the numbers seem stable. Their presence allows for improvements/regressions to go unnoticed which isn't good.

Modifications:

- Remove the wiggle room
- Rename the benchmark target from NIOSSHBenchmarks to NIOSSLBenchmarks

Result:

Easier to catch regressions/improvements