### PR TITLE
Enabled -require-explicit-sendable compiler flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
         with:
             runner_pool: nightly
             build_scheme: swift-nio-ssl-Package
+            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     static-sdk:
         name: Static SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,6 +60,8 @@ jobs:
         with:
             runner_pool: general
             build_scheme: swift-nio-ssl-Package
+            xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     static-sdk:
         name: Static SDK

--- a/Sources/NIOSSL/NIOSSLClientHandler.swift
+++ b/Sources/NIOSSL/NIOSSLClientHandler.swift
@@ -212,3 +212,6 @@ public final class NIOSSLClientHandler: NIOSSLHandler {
         )
     }
 }
+
+@available(*, unavailable)
+extension NIOSSLClientHandler: Sendable {}

--- a/Sources/NIOSSL/NIOSSLServerHandler.swift
+++ b/Sources/NIOSSL/NIOSSLServerHandler.swift
@@ -130,3 +130,6 @@ public final class NIOSSLServerHandler: NIOSSLHandler {
         )
     }
 }
+
+@available(*, unavailable)
+extension NIOSSLServerHandler: Sendable {}

--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -457,3 +457,6 @@ extension NIOSSLPrivateKey: Hashable {
         }
     }
 }
+
+@available(*, unavailable)
+extension NIOSSLPrivateKey.Representation: Sendable {}

--- a/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
+++ b/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
@@ -159,7 +159,7 @@ extension NIOSSLSecureBytes: RangeReplaceableCollection {
 // MARK: - Heap allocated backing storage.
 extension NIOSSLSecureBytes {
     @usableFromInline
-    internal struct BackingHeader {
+    internal struct BackingHeader: Sendable {
         @usableFromInline
         internal var count: Int
 
@@ -239,6 +239,9 @@ extension NIOSSLSecureBytes {
         }
     }
 }
+
+@available(*, unavailable)
+extension NIOSSLSecureBytes.Backing: Sendable {}
 
 extension NIOSSLSecureBytes.Backing {
     @usableFromInline


### PR DESCRIPTION
Enabled -require-explicit-sendable compiler flag and fixed the errors highlighted by the compiler.