### PR TITLE
Avoid small behaviour change in #550

### DIFF
--- a/Sources/NIOSSL/SSLCertificate.swift
+++ b/Sources/NIOSSL/SSLCertificate.swift
@@ -106,7 +106,7 @@ public final class NIOSSLCertificate {
     /// - parameters:
     ///     - file: The path to the file to load the certificate from.
     ///     - format: The format to use to parse the file.
-    private convenience init(_file file: String, format: NIOSSLSerializationFormats) throws {
+    internal convenience init(_file file: String, format: NIOSSLSerializationFormats) throws {
         let fileObject = try Posix.fopen(file: file, mode: "rb")
         defer {
             fclose(fileObject)

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -688,9 +688,8 @@ extension NIOSSLContext {
             // Load only the certificates that resolve to an existing certificate in the directory.
             for symPath in certificateFilePaths {
                 // c_rehash only support pem files.
-                if let cert = try NIOSSLCertificate.fromPEMFile(symPath).first {
-                    try addCACertificateNameToList(context: context, certificate: cert)
-                }
+                let cert = try NIOSSLCertificate(_file: symPath, format: .pem)
+                try addCACertificateNameToList(context: context, certificate: cert)
             }
         }
     }


### PR DESCRIPTION
Motivation:

In #550 a use of `NIOSSLCertificafe(file:format:)` was replaced with `NIOSSLCertificafe.loadPEMFile(_:).first`, which isn't necessarily the same (the error flow is different for one). To avoid any subtle behaioral changes revert back to the old API in that one instance.

Modifications:

- Use old API

Result:

Fewer behavioural changes