### PR TITLE
Remove incorrect documentation

### DIFF
--- a/Sources/NIOSSL/SSLPrivateKey.swift
+++ b/Sources/NIOSSL/SSLPrivateKey.swift
@@ -228,7 +228,7 @@ public final class NIOSSLPrivateKey {
     }
 
     /// Create a ``NIOSSLPrivateKey`` from a file at a given path in either PEM or
-    /// DER format, providing a passphrase callback.
+    /// DER format.
     ///
     /// - parameters:
     ///     - file: The path to the file to load.


### PR DESCRIPTION
Motivation:

Documentation should accurately explain the methods.

Modifications:

Removed the phrase "providing a passphrase callback"

Result:

Documentation is more accurate