### PR TITLE
Make `NIOSSLContext.configuration` public.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,6 @@ We require that your commit messages match our template. The easiest way to do t
 
     git config commit.template dev/git.commit.template
 
-### Test on Linux
-
-SwiftNIO uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not. For this reason, whenever you add new tests you will want to run a script that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby generate_linux_tests.rb` at the root of the package and check the changes it made.
-
 ### Run CI checks locally
 
 You can run the Github Actions workflows locally using [act](https://github.com/nektos/act). For detailed steps on how to do this please see [https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally](https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally).

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -297,7 +297,7 @@ public final class NIOSSLContext {
     private var keyLogManager: KeyLogCallbackManager?
     internal var pskClientConfigurationCallback: _NIOPSKClientIdentityProvider?
     internal var pskServerConfigurationCallback: _NIOPSKServerIdentityProvider?
-    internal let configuration: TLSConfiguration
+    public let configuration: TLSConfiguration
 
     /// Initialize a context that will create multiple connections, all with the same
     /// configuration.


### PR DESCRIPTION
Motivation:

It is sometimes useful, such as when converting between configuration formats, to be able to recover the `TLSConfiguration` with which an `NIOSSLContext` was created. This is not possible with the current API; since the property is immutable, making it public poses no risk.

Modifications:

The `NIOSSLContext.configuration` property is now `public` instead of `internal`. (Also, an extremely obsolete Linux testing note was removed from `CONTRIBUTING.md`.)

Result:

This change has no functional impact; all behavior remains identical. The only effect is to add the `configuration` property to the public API of `NIOSSLContext`.