### PR TITLE
Make sslContextCallback overrides replace the existing chain, rather than adding to it

### DIFF
--- a/Sources/NIOSSL/UnsafeKeyAndChainTarget.swift
+++ b/Sources/NIOSSL/UnsafeKeyAndChainTarget.swift
@@ -24,6 +24,9 @@ enum UnsafeKeyAndChainTarget {
     func useCertificateChain(
         _ certificateChain: [NIOSSLCertificateSource]
     ) throws {
+        // Clear the existing chain first.
+        // So that when this function is called, `certificateChain` becomes the only certificates in the context.
+        self.clearAdditionalChainCertificates()
         var leaf = true
         for source in certificateChain {
             switch source {
@@ -65,6 +68,15 @@ enum UnsafeKeyAndChainTarget {
         }
         guard rc == 1 else {
             throw NIOSSLError.failedToLoadCertificate
+        }
+    }
+
+    func clearAdditionalChainCertificates() {
+        switch self {
+        case .sslContext(let context):
+            CNIOBoringSSL_SSL_CTX_clear_chain_certs(context)
+        case .ssl(let ssl):
+            CNIOBoringSSL_SSL_clear_chain_certs(ssl)
         }
     }
 

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -376,6 +376,10 @@ internal func serverTLSChannel(
     context: NIOSSLContext,
     handlers: @autoclosure @escaping @Sendable () -> [ChannelHandler],
     group: EventLoopGroup,
+    customVerificationCallback: (
+        @Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) ->
+            Void
+    )? = nil,
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws -> Channel {
@@ -385,6 +389,7 @@ internal func serverTLSChannel(
             preHandlers: [],
             postHandlers: handlers(),
             group: group,
+            customVerificationCallback: customVerificationCallback,
             file: file,
             line: line
         ),


### PR DESCRIPTION
Currently, the certs returned by the sslContextCallback are added to the context, rather than replacing the certs already in the context.

This means that, if a callback is used to return a new chain to be used, the old and new chains are both presented (but only the new leaf). This should not cause any problem, but it is inefficient

Change: Clear the additional certs before adding the new ones