### PR TITLE
Use `Context.environment` in `Package.swift` instead of importing `Foundation`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,6 @@
 
 import PackageDescription
 
-// Used only for environment variables, does not make its way
-// into the product code.
-import class Foundation.ProcessInfo
-
 // This package contains a vendored copy of BoringSSL. For ease of tracking
 // down problems with the copy of BoringSSL in use, we include a copy of the
 // commit hash of the revision of BoringSSL included in the given release.
@@ -34,7 +30,7 @@ import class Foundation.ProcessInfo
 /// of the Swift toolchain, and so need to use local checkouts of our
 /// dependencies.
 func generateDependencies() -> [Package.Dependency] {
-    if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+    if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
             .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0")
         ]


### PR DESCRIPTION
#### Motivation:

Importing `Foundation` in `Package.swift` is undesirable; nowhere else
in the actual `NIOSSL` package is `Foundation` used, it appears only in
tests and examples. This removes the usage from the manifest altogether.
There is no compatibility concern; `Context.environment` has been
available since SwiftPM 5.6.

#### Modifications:

Replaced `ProcessInfo.processInfo.environment` with
`Context.environment`.

#### Result:

There is no functional impact. `Package.swift` no longer imports
`Foundation`.
