### PR TITLE
Do not log the caCerts value if PKCS#12 parsing goes haywire

### DIFF
--- a/Sources/NIOSSL/SSLPKCS12Bundle.swift
+++ b/Sources/NIOSSL/SSLPKCS12Bundle.swift
@@ -69,7 +69,7 @@ public struct NIOSSLPKCS12Bundle: Hashable {
 
         for idx in 0..<certStackSize {
             guard let stackCertPtr = CNIOBoringSSL_sk_X509_value(caCerts, idx) else {
-                preconditionFailure("Unable to get cert \(idx) from stack \(String(describing: caCerts))")
+                preconditionFailure("Unable to get cert \(idx) from stack")
             }
             certs.append(NIOSSLCertificate.fromUnsafePointer(takingOwnership: stackCertPtr))
         }


### PR DESCRIPTION
The `caCerts` value is, from Swift's perspective, merely an `OpaquePointer?`; logging its value as part of a `preconditionFailure()` is not particularly useful. In addition, including it in the log message causes GitHub's CodeQL code analysis to inaccurately report a high-severity information disclosure vulnerability in any repo using it which has `swift-nio-ssl` as a direct or indirect dependency. Since logging it serves no useful purpose anyway, might as well get rid of it.