### PR TITLE
OpenBSD support.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,7 @@ let package = Package(
         .target(
             name: "CNIOBoringSSL",
             cSettings: [
+                .define("_BSD_SOURCE"),
                 .define("_GNU_SOURCE"),
                 .define("_POSIX_C_SOURCE", to: "200112L"),
                 .define("_DARWIN_C_SOURCE"),

--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -15,6 +15,10 @@
 import CNIOLinux
 import NIOCore
 
+#if canImport(CNIOOpenBSD)
+import CNIOOpenBSD
+#endif
+
 #if canImport(Darwin)
 import Darwin.C
 #elseif canImport(Musl)

--- a/Sources/NIOSSL/PosixPort.swift
+++ b/Sources/NIOSSL/PosixPort.swift
@@ -34,7 +34,7 @@ import Android
 #error("unsupported os")
 #endif
 
-#if os(Android)
+#if os(Android) || os(OpenBSD)
 internal typealias FILEPointer = OpaquePointer
 #else
 internal typealias FILEPointer = UnsafeMutablePointer<FILE>

--- a/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
+++ b/Sources/NIOSSL/SwiftCrypto/NIOSSLSecureBytes.swift
@@ -66,7 +66,8 @@ extension NIOSSLSecureBytes {
     @inlinable
     mutating public func append<C: Collection>(_ data: C) where C.Element == UInt8 {
         let requiredCapacity = self.count + data.count
-        if !isKnownUniquelyReferenced(&self.backing) || requiredCapacity > self.backing.capacity {
+        let backingCapacity = self.backing.allocatedCapacity
+        if !isKnownUniquelyReferenced(&self.backing) || requiredCapacity > backingCapacity {
             let newBacking = Backing.create(capacity: requiredCapacity)
             newBacking._appendBytes(self.backing, inRange: 0..<self.count)
             self.backing = newBacking
@@ -75,7 +76,8 @@ extension NIOSSLSecureBytes {
     }
 
     mutating public func reserveCapacity(_ n: Int) {
-        if self.backing.capacity >= n {
+        let backingCapacity = self.backing.allocatedCapacity
+        if backingCapacity >= n {
             return
         }
 
@@ -134,8 +136,9 @@ extension NIOSSLSecureBytes: RangeReplaceableCollection {
     mutating public func replaceSubrange<C: Collection>(_ subrange: Range<Index>, with newElements: C)
     where C.Element == UInt8 {
         let requiredCapacity = self.backing.count - subrange.count + newElements.count
+        let backingCapacity = self.backing.allocatedCapacity
 
-        if !isKnownUniquelyReferenced(&self.backing) || requiredCapacity > self.backing.capacity {
+        if !isKnownUniquelyReferenced(&self.backing) || requiredCapacity > backingCapacity {
             // We have to allocate anyway, so let's use a nice straightforward copy.
             let newBacking = Backing.create(capacity: requiredCapacity)
 
@@ -191,7 +194,7 @@ extension NIOSSLSecureBytes {
                     targetPtr.copyMemory(from: bytesPtr)
                 }
                 backing.count = bytesPtr.count
-                precondition(backing.count <= backing.capacity)
+                precondition(backing.count <= backing.allocatedCapacity)
                 return backing
             }
         }
@@ -248,6 +251,15 @@ extension NIOSSLSecureBytes.Backing: Sendable {}
 
 extension NIOSSLSecureBytes.Backing {
     @usableFromInline
+    var allocatedCapacity: Int {
+        #if os(OpenBSD)
+        return self.header.capacity
+        #else
+        return self.capacity
+        #endif
+    }
+
+    @usableFromInline
     func replaceSubrangeFittingWithinCapacity<C: Collection>(_ subrange: Range<Int>, with newElements: C)
     where C.Element == UInt8 {
         // This function is called when have a unique reference to the backing storage, and we have enough room to store these bytes without
@@ -268,7 +280,7 @@ extension NIOSSLSecureBytes.Backing {
         // for R1 and then move the suffix, as if R2 is larger than R1 we'll have thrown some suffix bytes away. So we have
         // to move suffix first. What we do is take the bytes in suffix, and move them (via memmove). We can then copy
         // R2 in, and feel confident that the space in memory is right.
-        precondition(self.count - subrange.count + newElements.count <= self.capacity, "Insufficient capacity")
+        precondition(self.count - subrange.count + newElements.count <= self.allocatedCapacity, "Insufficient capacity")
 
         let moveDistance = newElements.count - subrange.count
         let suffixRange = subrange.upperBound..<self.count
@@ -283,7 +295,7 @@ extension NIOSSLSecureBytes.Backing {
         let byteCount = bytes.count
 
         precondition(
-            self.capacity - self.count - byteCount >= 0,
+            self.allocatedCapacity - self.count - byteCount >= 0,
             "Insufficient space for byte copying, must have reallocated!"
         )
 
@@ -303,9 +315,9 @@ extension NIOSSLSecureBytes.Backing {
         inRange range: Range<Int>
     ) {
         precondition(range.lowerBound >= 0)
-        precondition(range.upperBound <= backing.capacity)
+        precondition(range.upperBound <= backing.allocatedCapacity)
         precondition(
-            self.capacity - self.count - range.count >= 0,
+            self.allocatedCapacity - self.count - range.count >= 0,
             "Insufficient space for byte copying, must have reallocated!"
         )
 
@@ -328,11 +340,11 @@ extension NIOSSLSecureBytes.Backing {
     func _moveBytes(range: Range<Int>, by delta: Int) {
         // We have to check that the range is within the delta, as is the new location.
         precondition(range.lowerBound >= 0)
-        precondition(range.upperBound <= self.capacity)
+        precondition(range.upperBound <= self.allocatedCapacity)
 
         let shiftedRange = (range.lowerBound + delta)..<(range.upperBound + delta)
         precondition(shiftedRange.lowerBound > 0)
-        precondition(shiftedRange.upperBound <= self.capacity)
+        precondition(shiftedRange.upperBound <= self.allocatedCapacity)
 
         self._withVeryUnsafeMutableBytes { backingPtr in
             let source = UnsafeRawBufferPointer(rebasing: backingPtr[range])
@@ -345,7 +357,7 @@ extension NIOSSLSecureBytes.Backing {
     @inlinable  // private but inlinable
     func _copyBytes<C: Collection>(_ bytes: C, at offset: Int) where C.Element == UInt8 {
         precondition(offset >= 0)
-        precondition(offset + bytes.count <= self.capacity)
+        precondition(offset + bytes.count <= self.allocatedCapacity)
 
         let byteRange = offset..<(offset + bytes.count)
 
@@ -377,7 +389,7 @@ extension NIOSSLSecureBytes.Backing {
     func _withVeryUnsafeMutableBytes<T>(
         _ body: (UnsafeMutableRawBufferPointer) throws -> T
     ) rethrows -> T {
-        let capacity = self.capacity
+        let capacity = self.allocatedCapacity
 
         return try self.withUnsafeMutablePointerToElements { elementsPtr in
             try body(UnsafeMutableRawBufferPointer(start: elementsPtr, count: capacity))

--- a/Tests/NIOSSLTests/NIOSSLSecureBytesTests.swift
+++ b/Tests/NIOSSLTests/NIOSSLSecureBytesTests.swift
@@ -121,28 +121,28 @@ final class NIOSSLSecureBytesTests: XCTestCase {
 
     func testResizingByMakingLarger() {
         var base = NIOSSLSecureBytes(count: 12)
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 16)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 16)
         XCTAssertEqual(base.count, 12)
 
         base.append(contentsOf: 0..<16)
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 32)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 32)
         XCTAssertEqual(base.count, 28)
 
         base.append(contentsOf: 0..<4)
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 32)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 32)
         XCTAssertEqual(base.count, 32)
     }
 
     func testCountInitializerGeneratesSomewhatRandomData() {
         let base = NIOSSLSecureBytes(count: 16)
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 16)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 16)
         XCTAssertEqual(base.count, 16)
         XCTAssertNotEqual(Array(repeating: UInt8(0), count: 16), Array(base))
     }
 
     func testBackingBytesAreAppropriatelySized() {
         let base = NIOSSLSecureBytes(repeating: 0, count: 10)
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 16)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 16)
 
         base.withUnsafeBytes { XCTAssertEqual($0.count, 10) }
         base.backing.withUnsafeMutableBytes { XCTAssertEqual($0.count, 10) }
@@ -156,7 +156,7 @@ final class NIOSSLSecureBytesTests: XCTestCase {
             initializedCapacity = 4
         }
 
-        XCTAssertGreaterThanOrEqual(base.backing.capacity, 8)
+        XCTAssertGreaterThanOrEqual(base.backing.allocatedCapacity, 8)
         XCTAssertEqual(Array(base), [1, 2, 3, 4])
 
         let testThrowingInitialization: () throws -> Void = {


### PR DESCRIPTION
* `_BSD_SOURCE` is required for `getentropy`, and `FILE *` is opaque on
  recent versions of OpenBSD.

* The copy of SecureBytes from Swift Crypto now incorporates upstream
  changes to deal with the unavailability of ManagedBuffer.capacity on
  the platform and the tests are updated to match