### PR TITLE
Fix optional certificate verification test case

### DIFF
--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -2647,12 +2647,11 @@ class NIOSSLIntegrationTest: XCTestCase {
             connectingTo: serverChannel.localAddress!,
             serverHostname: "localhost"
         )
-        defer {
-            XCTAssertNoThrow(try clientChannel.close().wait())
-        }
 
         // The handshake should fail: certificate verification is optional and the client hasn't presented any certs.
         XCTAssertThrowsError(try handshakeCompletePromise.futureResult.wait())
+        // Wait for the client channel to close as a result of the certificate verification error.
+        XCTAssertNoThrow(try clientChannel.closeFuture.wait())
     }
 
     func testMacOSConnectionSuccessfulIfServerVerificationOptionalAndPeerPresentsTrustedCert() throws {


### PR DESCRIPTION
Motivation:

The [`testMacOSConnectionFailsIfServerVerificationOptionalAndPeerPresentsUntrustedCert`](https://github.com/apple/swift-nio-ssl/blob/3f337058ccd7243c4cac7911477d8ad4c598d4da/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift#L2603) test case in `NIOSSLIntegrationTest` verifies that the handshake fails when the server's certificate verification mode is set to [`.optionalVerification`](https://github.com/apple/swift-nio-ssl/blob/3f337058ccd7243c4cac7911477d8ad4c598d4da/Sources/NIOSSL/TLSConfiguration.swift#L199) and the client presents an untrusted certificate chain.

In that test case, there is a `defer` block in which the client channel is closed:
https://github.com/apple/swift-nio-ssl/blob/3f337058ccd7243c4cac7911477d8ad4c598d4da/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift#L2650-L2652

However, since the handshake will fail in this test case, the `doDecodeData` method will close the client channel (line 630):
https://github.com/apple/swift-nio-ssl/blob/3f337058ccd7243c4cac7911477d8ad4c598d4da/Sources/NIOSSL/NIOSSLHandler.swift#L626-L634

If the client channel has already closed before the test case calls `try clientChannel.close().wait()`, then  a [`ChannelError.alreadyClosed`](https://github.com/apple/swift-nio/blob/32e3d863795292c49e1aa3dc1f72a31802e74a1f/Sources/NIOCore/Channel.swift#L377) will be thrown, which will result in the `XCTAssertNoThrow` failing.

We should instead be waiting for the client channel's `closeFuture` at the end of the test case.

Modifications:

Removed the `defer` block containing the call to `try clientChannel.close().wait()`, and instead added a call to `try clientChannel.closeFuture.wait()` at the end of the test case.

Result:

The `testMacOSConnectionFailsIfServerVerificationOptionalAndPeerPresentsUntrustedCert` test case is no longer flaky.