### PR TITLE
Update test helper to use SocketAddressError.UnknownHost

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ import PackageDescription
 func generateDependencies() -> [Package.Dependency] {
     if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         return [
-            .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0")
+            .package(url: "https://github.com/apple/swift-nio.git", from: "2.98.0")
         ]
     } else {
         return [

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -54,7 +54,7 @@ func ipv6Supported() throws -> Bool {
     do {
         _ = try SocketAddress.makeAddressResolvingHost("2001:db8::1", port: 443)
         return true
-    } catch SocketAddressError.unknown {
+    } catch is SocketAddressError.UnknownHost {
         return false
     }
 }


### PR DESCRIPTION
Motivation:

In https://github.com/apple/swift-nio/pull/3558, `SocketAddressError.unknown` was deprecated and replaced with a richer `SocketAddressError.UnknownHost` type.

However, in `IdentityVerificationTest.ipv6Supported()` (a test helper method), we are catching the `SocketAddressError.unknown` case to determine whether IPv6 is supported (line 57):
https://github.com/apple/swift-nio-ssl/blob/3f337058ccd7243c4cac7911477d8ad4c598d4da/Tests/NIOSSLTests/IdentityVerificationTest.swift#L53-L60

Since `SocketAddress.makeAddressResolvingHost(_:port:)` now throws `SocketAddressError.UnknownHost` instead of `SocketAddressError.unknown`, the `IdentityVerificationTest.ipv6Supported()` method no longer works as expected. This is causing CI failures over the past few days.

Modifications:

- Updated `IdentityVerificationTest.ipv6Supported()` to catch `SocketAddressError.UnknownHost` instead of the deprecated `SocketAddressError.unknown` enum case.
- Raised the `swift-nio` dependency to [`v2.98.0`](https://github.com/apple/swift-nio/releases/tag/2.98.0) (the version that `SocketAddressError.UnknownHost` was introduced in).

Result:
 
`IdentityVerificationTest.ipv6Supported()` now works as expected.