### PR TITLE
Reject partial wildcard SAN matches that produce IDNA A-label first label

### DIFF
--- a/Sources/NIOSSL/IdentityVerification.swift
+++ b/Sources/NIOSSL/IdentityVerification.swift
@@ -315,6 +315,10 @@ private struct AnalysedCertificateHostname {
             let (wildcardLabel, remainingComponents) = baseName.splitAroundIndex(firstPeriodIndex)
             let (targetFirstLabel, targetRemainingComponents) = target.splitAroundIndex(firstPeriodIndexForName)
 
+            guard !targetFirstLabel.prefix(4).caseInsensitiveElementsEqual(asciiIDNAIdentifier) else {
+                return false
+            }
+
             guard remainingComponents.caseInsensitiveElementsEqual(targetRemainingComponents) else {
                 // Wildcard is irrelevant, the remaining components don't match.
                 return false

--- a/Tests/NIOSSLTests/IdentityVerificationTest.swift
+++ b/Tests/NIOSSLTests/IdentityVerificationTest.swift
@@ -293,6 +293,41 @@ class IdentityVerificationTest: XCTestCase {
         XCTAssertTrue(matched)
     }
 
+    private static let partialWildcardEncodedIDNAttackCert = """
+        -----BEGIN CERTIFICATE-----
+        MIIDHTCCAgWgAwIBAgIUI2eI+nPJ7N+stqd7yiyMCXl9rE4wDQYJKoZIhvcNAQEL
+        BQAwIDEeMBwGA1UEAwwVcGFydGlhbC13aWxkY2FyZC10ZXN0MCAXDTI2MDUwMjA2
+        NTMxNloYDzIxMjYwNDA4MDY1MzE2WjAgMR4wHAYDVQQDDBVwYXJ0aWFsLXdpbGRj
+        YXJkLXRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvKRD8uJoa
+        OXOlQ1D/xNX4VG9NPkh3yRK1ljON3xyrNqoXUNDwoC0YvzyPorpYiyGxPO5HpsfQ
+        uLvcLSynpom6E/4GKlnk4XMXV3+s+tHwuAIDS/50KigDaZ7CqYvvBZyiBgCuAfBw
+        df/TAOHTbLX6ii12aJ9h/u8NYxI2yHYuGzrvfx6Ncuw9/ytyNgmw045Hd4o0DPji
+        pwhy2C5n7c7vba1KimgzDaDw//Hj2c79gEZTqxxhLeYiTyL43WryScT2x1EHEecf
+        NUFC054e605tQ7W7p7bo6Ic+YSFWhA8oaV1Gq2w3zjWQIRabYAZdYtVcybzMz6Ir
+        CiD9qa0ySHZPAgMBAAGjTTBLMB8GA1UdEQQYMBaCFCotNXdhbzFvLmV4YW1wbGUu
+        Y29tMAkGA1UdEwQCMAAwHQYDVR0OBBYEFAKGYfki9PLNY/HBn7BcPyHT79ShMA0G
+        CSqGSIb3DQEBCwUAA4IBAQCg8IqWYR8TbfzwiWIG4MBqbaf3acxH0x7KDv5mzrd6
+        uZcxHn3z31Rj6CIZ5FTsCl76xP3RBK5FnKHfh3bQ9neOxPg3Od+TJWcLxT3y5rsd
+        HT6hOwVwOyMILur/eKa7nZMlsO2JLpLvtA4gHtzaM1oePSaBjDkgrYRz/+Kebwv7
+        0kyBERowQB9VnhVeXiyOoBEurM3giOdgKk14AnzCGKcnRanXm4qyB4A+FNmNI61d
+        BFMkrH5bLzQ6wgqbXyBkwUkaphU7Cy2b6mdZHiIjd/0XVTJ9QAHGmOVF8ySjAIZA
+        I0V15hkkmOT9flggzSiafRAZ5fqR7sXe/amTZpf2Enbw
+        -----END CERTIFICATE-----
+        """
+
+    func testDoesNotMatchPartialWildcardConstructingEncodedIDNALabel() throws {
+        let cert = try NIOSSLCertificate(
+            bytes: .init(Self.partialWildcardEncodedIDNAttackCert.utf8),
+            format: .pem
+        )
+        let matched = try validIdentityForService(
+            serverHostname: "xn--rksmrgs-5wao1o.example.com",
+            socketAddress: try .init(unixDomainSocketPath: "/path"),
+            leafCertificate: cert
+        )
+        XCTAssertFalse(matched)
+    }
+
     func testDoesNotMatchSANWithEmbeddedNULL() throws {
         let cert = try NIOSSLCertificate(bytes: .init(weirdoPEMCert.utf8), format: .pem)
 


### PR DESCRIPTION
### Motivation

`AnalysedCertificateHostname.init` already refuses to construct a wildcard matcher when the certificate's first label begins with the IDNA A-label prefix `xn--` (line 287). The symmetric case is not enforced: a wildcard SAN whose own first label is plain ASCII can still expand into a target hostname whose first label begins with `xn--`.

A SAN of the form `*-5wao1o.example.com` will currently match a target hostname `xn--rksmrgs-5wao1o.example.com` (the IDNA A-label form of `räksmörgås.example.com`). Both OpenSSL's `equal_wildcard` and CPython's `ssl._dnsname_match` reject that case explicitly; this library accepts it.

Verified by copying `AnalysedCertificateHostname` verbatim from `main` into a standalone executable and running:

```
[OK     ] Sanity: wildcard matches normal subdomain
           cert SAN: *.example.com
           target:   foo.example.com
           expected: true   got: true

[OK     ] Sanity: wildcard does NOT match different parent
           cert SAN: *.example.com
           target:   foo.evil.com
           expected: false   got: false

[OK     ] Sanity: cert that IS an A-label wildcard rejected at parse
           cert SAN: xn--*.example.com
           target:   xn--anything.example.com
           expected: false   got: false

[BROKEN ] VULN: partial wildcard expansion produces A-label target
           cert SAN: *-5wao1o.example.com
           target:   xn--rksmrgs-5wao1o.example.com
           expected: false   got: true
```

After the patch in this PR the BROKEN case becomes OK.

### Modifications

In `validMatchForName`, after splitting the target around its first period, return `false` if the target's first label begins with `xn--`. Mirrors the existing cert-side check at line 287 and the `caseInsensitiveElementsEqual(asciiIDNAIdentifier)` idiom already in use in this file.

### Result

Wildcard SANs no longer expand into IDNA A-label targets, matching the behaviour of OpenSSL and CPython. The existing `testDoesNotMatchIDNALabelWithWildcard` continues to cover the cert-side variant; the target-side variant is the new case this patch addresses.