### PR TITLE
Define _WINSOCKAPI_/NOMINMAX/NOCRYPT for CNIOBoringSSL on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,18 @@ let package = Package(
                 .define("_GNU_SOURCE"),
                 .define("_POSIX_C_SOURCE", to: "200112L"),
                 .define("_DARWIN_C_SOURCE"),
+                // Recent Windows SDKs (e.g. 10.0.26100) make <windows.h> pull in headers
+                // whose symbols collide with BoringSSL's: the legacy <winsock.h> (vs the
+                // <winsock2.h> BoringSSL includes), the min()/max() macros, and <wincrypt.h>
+                // (X509_NAME, X509_EXTENSIONS, X509_CERT_PAIR). Suppress just those.
+                .define("_WINSOCKAPI_", .when(platforms: [.windows])),
+                .define("NOMINMAX", .when(platforms: [.windows])),
+                .define("NOCRYPT", .when(platforms: [.windows])),
+            ],
+            cxxSettings: [
+                .define("_WINSOCKAPI_", .when(platforms: [.windows])),
+                .define("NOMINMAX", .when(platforms: [.windows])),
+                .define("NOCRYPT", .when(platforms: [.windows])),
             ]
         ),
         .target(


### PR DESCRIPTION
### Motivation

`CNIOBoringSSL` fails to compile on recent Windows SDKs (e.g. **10.0.26100**, as shipped on the `windows-latest` GitHub runner). BoringSSL includes `<windows.h>` / `<winsock2.h>`, and the SDK transitively pulls in headers whose symbols collide with BoringSSL's own:

- the legacy `<winsock.h>` redefines `sockaddr` / `fd_set` / `WSAData` against the `<winsock2.h>` BoringSSL includes;
- the `min()` / `max()` macros break `std::numeric_limits<>::max()`;
- `<wincrypt.h>` `#define`s `X509_NAME`, `X509_EXTENSIONS` and `X509_CERT_PAIR`, which collide with BoringSSL's types (e.g. `ssl_x509.cc`: *"template argument for template type parameter must be a type"* on `STACK_OF(X509_NAME)`).

### Modifications

Define `_WINSOCKAPI_`, `NOMINMAX` and `NOCRYPT` for the `CNIOBoringSSL` C and C++ sources on Windows, via `cSettings` / `cxxSettings` with `.when(platforms: [.windows])`.

Scoping them to the BoringSSL target (rather than passing them globally, e.g. via `-Xcc`) is deliberate: a global `_WINSOCKAPI_` also reaches the Swift clang module importer, where it makes `IPPROTO_UDP` import as the `IPPROTO` enum instead of an integer and breaks downstream swift-nio (`NIOPosix/System.swift`: `CInt(IPPROTO_UDP)`).

### Result

`CNIOBoringSSL` compiles against current Windows SDKs. No change on any other platform (the defines are Windows-only).

Verified with an isolated `swift build --target CNIOBoringSSL` on `windows-latest` (Swift 6.3.1, Windows SDK 10.0.26100): [green run](https://github.com/odrobnik/swift-nio-ssl/actions/runs/26755253073). `swift-format` and `swift package dump-package` both pass.

Note: I couldn't find a Windows job in this repo's CI, so this isn't exercised by the existing matrix — happy to add one if that'd be useful.