### PR TITLE
Demote ImplementationOnlyDeprecated warning in main CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,10 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            # We can't set warnings-as-errors for 6.1 because we can't suppress the ImplementationOnly import warning.
+            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 


### PR DESCRIPTION
The Main CI workflow currently fails on Swift 6.1, 6.2, and 6.3 because `-Xswiftc -warnings-as-errors` is enabled, while the `@_implementationOnly` imports in this codebase emit deprecation warnings (`ImplementationOnlyDeprecated`).
  The PR workflow already handles this correctly; this change brings the main workflow in line.

Specifically:
- 6.1: Drops `-warnings-as-errors` entirely, since this toolchain doesn't support demoting the ImplementationOnlyDeprecated warning. A comment explains why.
- 6.2 / 6.3: Adds `-Xswiftc -Wwarning -Xswiftc` ImplementationOnlyDeprecated to demote the warning while still failing on other warnings.