### PR TITLE
Reserve a byte for the NUL terminator in the PSK client identity

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -233,15 +233,16 @@ private func clientPSKCallback(
     let clientPSK = pskIdentity.key  // Key from the callback
     let clientIdentity = pskIdentity.identity
 
-    // Use max_identity_len so it does not trigger an overrun.
-    if clientIdentity.utf8.isEmpty || clientIdentity.utf8.count > max_identity_len {
+    // BoringSSL passes `max_identity_len` as the full size of its `identity` buffer (`PSK_MAX_IDENTITY_LEN` + 1),
+    // which includes capacity for the NUL terminator, so we reject any identity that would clobber the terminator.
+    if clientIdentity.utf8.isEmpty || clientIdentity.utf8.count > max_identity_len - 1 {
         return 0
     }
 
     // Map the output identity from the one passed back from the callback.
     // This helps populate the server callback for the key exchange.
-    let _ = clientIdentity.withCString { ptr in
-        memcpy(unwrappedIdentity, ptr, clientIdentity.utf8.count)
+    clientIdentity.utf8CString.withUnsafeBufferPointer { buffer in
+        _ = memcpy(unwrappedIdentity, buffer.baseAddress!, buffer.count)
     }
 
     if clientPSK.isEmpty || clientPSK.count > max_psk_len {

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1933,6 +1933,57 @@ class TLSConfigurationTest: XCTestCase {
         try assertHandshakeSucceeded(withClientConfig: clientConfig, andServerConfig: serverConfig)
     }
 
+    func testTLSPSKClientIdentityLengthBoundary() throws {
+        // BoringSSL's client handshake gives the callback a `char identity[PSK_MAX_IDENTITY_LEN + 1]` buffer and passes
+        // its full size as `max_identity_len`, reserving the final byte for the NUL terminator.  An identity of exactly
+        // `max_identity_len` bytes fills the buffer with no room for the NUL and must be rejected.
+
+        func makeClientConfig(identity: String) -> TLSConfiguration {
+            var config = TLSConfiguration.makeClientConfiguration()
+            config.certificateVerification = .none
+            config.minimumTLSVersion = .tlsv1
+            config.maximumTLSVersion = .tlsv12
+            config.pskHint = "clientPskHint"
+            let provider: NIOPSKClientIdentityProvider = {
+                (_: PSKClientContext) -> PSKClientIdentityResponse in
+                var psk = NIOSSLSecureBytes()
+                psk.append("hello".utf8)
+                return PSKClientIdentityResponse(key: psk, identity: identity)
+            }
+            config.pskClientProvider = provider
+            return config
+        }
+
+        func makeServerConfig(expectedIdentity: String) -> TLSConfiguration {
+            var config = TLSConfiguration.makePreSharedKeyConfiguration()
+            config.minimumTLSVersion = .tlsv1
+            config.maximumTLSVersion = .tlsv12
+            config.pskHint = "serverPskHint"
+            let provider: NIOPSKServerIdentityProvider = {
+                (context: PSKServerContext) -> PSKServerIdentityResponse in
+                XCTAssertEqual(context.clientIdentity, expectedIdentity)
+                var psk = NIOSSLSecureBytes()
+                psk.append("hello".utf8)
+                return PSKServerIdentityResponse(key: psk)
+            }
+            config.pskServerProvider = provider
+            return config
+        }
+
+        let maxValidIdentity = String(repeating: "A", count: Int(PSK_MAX_IDENTITY_LEN))
+        try assertHandshakeSucceeded(
+            withClientConfig: makeClientConfig(identity: maxValidIdentity),
+            andServerConfig: makeServerConfig(expectedIdentity: maxValidIdentity)
+        )
+
+        let overlongIdentity = String(repeating: "A", count: Int(PSK_MAX_IDENTITY_LEN + 1))
+        try assertHandshakeError(
+            withClientConfig: makeClientConfig(identity: overlongIdentity),
+            andServerConfig: makeServerConfig(expectedIdentity: overlongIdentity),
+            errorTextContains: "PSK_IDENTITY_NOT_FOUND"
+        )
+    }
+
     func testTLSPSKWithPinnedCiphers() throws {
         // This test ensures that PSK-TLS is supported with pinned ciphers.
         let pskClientProvider: NIOPSKClientIdentityProvider = {


### PR DESCRIPTION
### Motivation

When a PSK cipher suite is negotiated on the client, BoringSSL's
gives our callback a buffer of length `PSK_MAX_IDENTITY_LEN` + 1, and
passes its full size as `max_identity_len`. The callback is expected to
populate the identity with a NUL-terminated string, which is relied upon
by the subsequent BoringSSL code, which calls `strdup`. However, our
code guarded the adopter-provided identity against the
`max_identity_len`, without taking into account the space for the NUL,
so it permitted identities of length `PSK_MAX_IDENTITY_LEN` and
clobbered the NUL, leading to UB.

### Modifications

- In `clientPSKCallback`, reject identities whose length is `>=
  max_identity_len` (was `>`).
- NUL-terminate the copied identity explicitly. BoringSSL is
  zero-initialising the buffer, but it's not documented to behaviour and
  it doesn't hurt for us to be safe.
- Add a test that shows we accept an identity of `PSK_MAX_IDENTITY_LEN`
- Add a test that shows we reject an identity of `PSK_MAX_IDENTITY_LEN`
  + 1 bytes (previously accepted).

### Result

An adopter-supplied PSK client identity of exactly `max_identity_len`
bytes is now rejected instead of triggering an out-of-bounds read in
BoringSSL's `OPENSSL_strdup`. Identities up to `PSK_MAX_IDENTITY_LEN`
still work.
