### PR TITLE
Expose SSL_set_enforce_rsa_key_usage via TLSConfiguration

### DIFF
--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -77,6 +77,13 @@ internal final class SSLConnection {
         CNIOBoringSSL_SSL_set_ex_data(self.ssl, sslConnectionExDataIndex, pointerToSelf)
 
         self.setRenegotiationSupport(self.parentContext.configuration.renegotiationSupport)
+
+        // This is a per-connection setting with no SSL_CTX equivalent, so it has to be applied here.
+        // BoringSSL only consults it when we are a client negotiating TLS 1.2 or below, and ignores
+        // it otherwise.
+        if !self.parentContext.configuration.enforceRSAKeyUsage {
+            CNIOBoringSSL_SSL_set_enforce_rsa_key_usage(self.ssl, 0)
+        }
     }
 
     deinit {

--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -455,6 +455,20 @@ public struct TLSConfiguration {
     /// This instructs the client which identities can be used by evaluating what CA the identity certificate was issued from.
     public var sendCANameList: Bool
 
+    /// Whether the `keyUsage` extension of an RSA leaf certificate is required to be consistent with the
+    /// negotiated TLS usage. Defaults to `true`.
+    ///
+    /// This only has an effect when acting as a client negotiating TLS 1.2 or below, where the check is
+    /// otherwise performed against the cipher suite in use. In all other cases the check is always enforced
+    /// and this property is ignored. Note that setting ``certificateVerification`` to
+    /// ``CertificateVerification/none`` does not relax this check, as it is not part of trust evaluation.
+    ///
+    /// - Warning: Only set this to `false` when a specific interoperability problem requires it, for example
+    ///     talking to a server whose RSA certificate carries only `keyEncipherment` while the handshake
+    ///     negotiates a cipher suite that needs `digitalSignature`. Disabling the check means the peer is
+    ///     using its key in a way its own certificate says it should not be used for.
+    public var enforceRSAKeyUsage: Bool = true
+
     private init(
         cipherSuiteValues: [NIOTLSCipher] = [],
         cipherSuites: String = defaultCipherSuites,
@@ -546,6 +560,7 @@ extension TLSConfiguration {
             && self.renegotiationSupport == comparing.renegotiationSupport
             && self.sendCANameList == comparing.sendCANameList && isSSLContextCallbackEqual && isPSKClientProviderEqual
             && isPSKServerProviderEqual && self.pskHint == comparing.pskHint
+            && self.enforceRSAKeyUsage == comparing.enforceRSAKeyUsage
     }
 
     /// Returns a best effort hash of this TLS configuration.
@@ -582,6 +597,7 @@ extension TLSConfiguration {
             hasher.combine(bytes: closureServerBits)
         }
         hasher.combine(pskHint)
+        hasher.combine(enforceRSAKeyUsage)
     }
 
     /// Creates a TLS configuration for use with client-side contexts.

--- a/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
+++ b/Tests/NIOSSLTests/NIOSSLTestHelpers.swift
@@ -628,7 +628,8 @@ func addExtension(x509: OpaquePointer, nid: CInt, value: String) {
 }
 
 func generateSelfSignedCert(
-    keygenFunction: () -> OpaquePointer = generateRSAPrivateKey
+    keygenFunction: () -> OpaquePointer = generateRSAPrivateKey,
+    keyUsage: String? = nil
 ) -> (NIOSSLCertificate, NIOSSLPrivateKey) {
     let pkey = keygenFunction()
     let x = CNIOBoringSSL_X509_new()!
@@ -675,6 +676,9 @@ func generateSelfSignedCert(
     addExtension(x509: x, nid: NID_subject_key_identifier, value: "hash")
     addExtension(x509: x, nid: NID_subject_alt_name, value: "DNS:localhost")
     addExtension(x509: x, nid: NID_ext_key_usage, value: "critical,serverAuth,clientAuth")
+    if let keyUsage = keyUsage {
+        addExtension(x509: x, nid: NID_key_usage, value: keyUsage)
+    }
 
     CNIOBoringSSL_X509_sign(x, pkey, CNIOBoringSSL_EVP_sha256())
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -90,6 +90,16 @@ class TLSConfigurationTest: XCTestCase {
     static let cert2 = TLSConfigurationTest._certAndKey2.0
     static let key2 = TLSConfigurationTest._certAndKey2.1
 
+    /// An RSA leaf whose keyUsage extension allows encipherment but not signing, which is the shape
+    /// of certificate that trips BoringSSL's RSA keyUsage consistency check on the TLS 1.2 ECDHE_RSA path.
+    /// `keyCertSign` is present only so the certificate can also act as its own trust root in these
+    /// tests. What matters is the absence of `digitalSignature`.
+    static let _keyEnciphermentOnlyCertAndKey = generateSelfSignedCert(
+        keyUsage: "critical,keyEncipherment,dataEncipherment,keyCertSign"
+    )
+    static let keyEnciphermentOnlyCert = TLSConfigurationTest._keyEnciphermentOnlyCertAndKey.0
+    static let keyEnciphermentOnlyKey = TLSConfigurationTest._keyEnciphermentOnlyCertAndKey.1
+
     func assertHandshakeError(
         withClientConfig clientConfig: TLSConfiguration,
         andServerConfig serverConfig: TLSConfiguration,
@@ -2422,6 +2432,67 @@ class TLSConfigurationTest: XCTestCase {
             andServerConfig: serverConfig,
             errorTextContainsAnyOf: ["ALERT_UNKNOWN_CA", "ALERT_CERTIFICATE_UNKNOWN"]
         )
+    }
+
+    private func keyEnciphermentOnlyConfigs() -> (client: TLSConfiguration, server: TLSConfiguration) {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.maximumTLSVersion = .tlsv12
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([TLSConfigurationTest.keyEnciphermentOnlyCert])
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.keyEnciphermentOnlyCert)],
+            privateKey: .privateKey(TLSConfigurationTest.keyEnciphermentOnlyKey)
+        )
+        serverConfig.maximumTLSVersion = .tlsv12
+
+        return (clientConfig, serverConfig)
+    }
+
+    func testRSAKeyUsageIsEnforcedByDefault() throws {
+        // The negotiated ECDHE_RSA suite signs the handshake, so a leaf that only permits
+        // keyEncipherment is rejected. This is the default and is not affected by
+        // certificateVerification, which is why the trust roots below let the chain validate.
+        let (clientConfig, serverConfig) = self.keyEnciphermentOnlyConfigs()
+        XCTAssertTrue(clientConfig.enforceRSAKeyUsage)
+
+        try assertHandshakeError(
+            withClientConfig: clientConfig,
+            andServerConfig: serverConfig,
+            errorTextContains: "KEY_USAGE_BIT_INCORRECT"
+        )
+    }
+
+    func testRSAKeyUsageEnforcementCanBeDisabled() throws {
+        var (clientConfig, serverConfig) = self.keyEnciphermentOnlyConfigs()
+        clientConfig.enforceRSAKeyUsage = false
+
+        try assertHandshakeSucceededInMemory(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+
+    func testRSAKeyUsageEnforcementIsStillAppliedToServers() throws {
+        // The setting is client-only in BoringSSL, so a server that opts out still behaves normally.
+        var (clientConfig, serverConfig) = self.keyEnciphermentOnlyConfigs()
+        serverConfig.enforceRSAKeyUsage = false
+
+        try assertHandshakeError(
+            withClientConfig: clientConfig,
+            andServerConfig: serverConfig,
+            errorTextContains: "KEY_USAGE_BIT_INCORRECT"
+        )
+    }
+
+    func testEnforceRSAKeyUsageParticipatesInBestEffortEquality() {
+        var config = TLSConfiguration.makeClientConfiguration()
+        var relaxedConfig = config
+        relaxedConfig.enforceRSAKeyUsage = false
+
+        XCTAssertFalse(config.bestEffortEquals(relaxedConfig))
+        XCTAssertNotEqual(Wrapper(config: config), Wrapper(config: relaxedConfig))
+
+        config.enforceRSAKeyUsage = false
+        XCTAssertTrue(config.bestEffortEquals(relaxedConfig))
+        XCTAssertEqual(Wrapper(config: config), Wrapper(config: relaxedConfig))
     }
 }
 


### PR DESCRIPTION
BoringSSL rejects a handshake with `KEY_USAGE_BIT_INCORRECT` when a client negotiating TLS 1.2 or below gets an RSA leaf whose `keyUsage` extension is inconsistent with the negotiated cipher, and that check is not part of trust evaluation, so `certificateVerification = .none` does not relax it. `SSL_set_enforce_rsa_key_usage` is the documented escape hatch, but it is a per-`SSL` setting with no `SSL_CTX` equivalent and NIOSSL never surfaced the raw `SSL *`, so there was no way to reach it from the public API.

This adds `TLSConfiguration.enforceRSAKeyUsage`, defaulting to `true` so existing behaviour is unchanged, and applies it in `SSLConnection.init` where the per-connection `SSL` object is available. The docs spell out that it should only be turned off for a specific interoperability reason, since it means accepting a peer that is using its key contrary to its own certificate. The property is also folded into `bestEffortEquals` and `bestEffortHash`.

Verified with four new tests in `TLSConfigurationTest`, backed by a `keyUsage` parameter added to the `generateSelfSignedCert` helper: an RSA leaf carrying only `keyEncipherment` fails the handshake with `KEY_USAGE_BIT_INCORRECT` by default, succeeds once the client sets `enforceRSAKeyUsage = false`, still fails when only the server opts out since the setting is client-only in BoringSSL, and configs differing solely in this flag compare unequal. The success test fails with `KEY_USAGE_BIT_INCORRECT` when the `SSLConnection` change is reverted.

Fixes #589