### PR TITLE
NIOSSLContext: fall back to BoringSSL default verify paths on Linux

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,34 @@ jobs:
             name: "Integration test"
             matrix_string: '${{ needs.construct-integration-test-matrix.outputs.integration-test-matrix }}'
 
+    construct-non-fhs-matrix:
+        name: Construct non-FHS trust store matrix
+        runs-on: ubuntu-latest
+        outputs:
+            non-fhs-matrix: '${{ steps.generate-matrix.outputs.non-fhs-matrix }}'
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+            - id: generate-matrix
+              run: echo "non-fhs-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+              env:
+                  # Remove the platform trust store so that the fallback to
+                  # BoringSSL's default verify paths (SSL_CERT_FILE/SSL_CERT_DIR)
+                  # is exercised by the test. Dependencies must be resolved
+                  # first: removing the CA bundle breaks TLS for git.
+                  MATRIX_LINUX_SETUP_COMMAND: swift package resolve && rm -rf /etc/ssl/certs /etc/pki/tls/certs
+                  MATRIX_LINUX_COMMAND: swift test --filter testPlatformDefaultTrustStoreFallsBackToBoringSSLDefaults
+
+    non-fhs-trust-store-test:
+        name: Non-FHS trust store test
+        needs: construct-non-fhs-matrix
+        uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+        with:
+            name: "Non-FHS trust store test"
+            matrix_string: '${{ needs.construct-non-fhs-matrix.outputs.non-fhs-matrix }}'
+
     benchmarks:
         name: Benchmarks
         uses: apple/swift-nio/.github/workflows/benchmarks.yml@main

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -743,7 +743,20 @@ extension NIOSSLContext {
         // On Linux, we use our searched heuristics to guess about where the platform trust store is.
         // On Darwin, we use a custom callback that is set later, in createConnection
         #if os(Linux) || os(FreeBSD)
-        try platformDefaultConfiguration(context: context, rootCAFile: rootCAFilePath, rootCADirectory: rootCADirectoryPath)
+        let result = rootCAFilePath.withCString { rootCAFilePointer in
+            rootCADirectoryPath.withCString { rootCADirectoryPointer in
+                CNIOBoringSSL_SSL_CTX_load_verify_locations(context, rootCAFilePointer, rootCADirectoryPointer)
+            }
+        }
+
+        if result == 0 {
+            // The hardcoded search paths above only cover FHS-style system
+            // layouts. On systems that keep the trust store elsewhere (for
+            // example minimal container images or non-standard prefixes),
+            // fall back to BoringSSL's defaults, which also respect the
+            // SSL_CERT_FILE and SSL_CERT_DIR environment variables.
+            try loadBoringSSLDefaultVerifyPaths(context: context)
+        }
         #elseif os(Android)
         let result = rootCADirectoryPath.withCString { rootCADirectoryPointer in
             CNIOBoringSSL_SSL_CTX_load_verify_locations(context, nil, rootCADirectoryPointer)
@@ -757,31 +770,10 @@ extension NIOSSLContext {
     }
 
     #if os(Linux) || os(FreeBSD)
-    /// Loads the platform default trust store into the given context, using
-    /// the provided search paths and falling back to BoringSSL's defaults.
-    ///
-    /// Internal, rather than private, to allow testing the fallback path.
-    static func platformDefaultConfiguration(
-        context: OpaquePointer,
-        rootCAFile: String?,
-        rootCADirectory: String?
-    ) throws {
-        var result = rootCAFile.withCString { rootCAFilePointer in
-            rootCADirectory.withCString { rootCADirectoryPointer in
-                CNIOBoringSSL_SSL_CTX_load_verify_locations(context, rootCAFilePointer, rootCADirectoryPointer)
-            }
-        }
-
-        if result == 0 {
-            // The hardcoded search paths only cover FHS-style system
-            // layouts. On systems that keep the trust store elsewhere (for
-            // example minimal container images or non-standard prefixes),
-            // fall back to BoringSSL's defaults, which also respect the
-            // SSL_CERT_FILE and SSL_CERT_DIR environment variables.
-            result = CNIOBoringSSL_SSL_CTX_set_default_verify_paths(context)
-        }
-
-        if result == 0 {
+    /// Loads BoringSSL's default verify paths into the given context. These
+    /// respect the SSL_CERT_FILE and SSL_CERT_DIR environment variables.
+    private static func loadBoringSSLDefaultVerifyPaths(context: OpaquePointer) throws {
+        guard CNIOBoringSSL_SSL_CTX_set_default_verify_paths(context) == 1 else {
             let errorStack = BoringSSLError.buildErrorStack()
             throw BoringSSLError.unknownError(errorStack)
         }

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -743,16 +743,7 @@ extension NIOSSLContext {
         // On Linux, we use our searched heuristics to guess about where the platform trust store is.
         // On Darwin, we use a custom callback that is set later, in createConnection
         #if os(Linux) || os(FreeBSD)
-        let result = rootCAFilePath.withCString { rootCAFilePointer in
-            rootCADirectoryPath.withCString { rootCADirectoryPointer in
-                CNIOBoringSSL_SSL_CTX_load_verify_locations(context, rootCAFilePointer, rootCADirectoryPointer)
-            }
-        }
-
-        if result == 0 {
-            let errorStack = BoringSSLError.buildErrorStack()
-            throw BoringSSLError.unknownError(errorStack)
-        }
+        try platformDefaultConfiguration(context: context, rootCAFile: rootCAFilePath, rootCADirectory: rootCADirectoryPath)
         #elseif os(Android)
         let result = rootCADirectoryPath.withCString { rootCADirectoryPointer in
             CNIOBoringSSL_SSL_CTX_load_verify_locations(context, nil, rootCADirectoryPointer)
@@ -764,6 +755,38 @@ extension NIOSSLContext {
         }
         #endif
     }
+
+    #if os(Linux) || os(FreeBSD)
+    /// Loads the platform default trust store into the given context, using
+    /// the provided search paths and falling back to BoringSSL's defaults.
+    ///
+    /// Internal, rather than private, to allow testing the fallback path.
+    static func platformDefaultConfiguration(
+        context: OpaquePointer,
+        rootCAFile: String?,
+        rootCADirectory: String?
+    ) throws {
+        var result = rootCAFile.withCString { rootCAFilePointer in
+            rootCADirectory.withCString { rootCADirectoryPointer in
+                CNIOBoringSSL_SSL_CTX_load_verify_locations(context, rootCAFilePointer, rootCADirectoryPointer)
+            }
+        }
+
+        if result == 0 {
+            // The hardcoded search paths only cover FHS-style system
+            // layouts. On systems that keep the trust store elsewhere (for
+            // example minimal container images or non-standard prefixes),
+            // fall back to BoringSSL's defaults, which also respect the
+            // SSL_CERT_FILE and SSL_CERT_DIR environment variables.
+            result = CNIOBoringSSL_SSL_CTX_set_default_verify_paths(context)
+        }
+
+        if result == 0 {
+            let errorStack = BoringSSLError.buildErrorStack()
+            throw BoringSSLError.unknownError(errorStack)
+        }
+    }
+    #endif
 
     private static func setKeylogCallback(context: OpaquePointer) throws {
         CNIOBoringSSL_SSL_CTX_set_keylog_callback(context) { (ssl, linePointer) in

--- a/Tests/NIOSSLTests/SSLContextTests.swift
+++ b/Tests/NIOSSLTests/SSLContextTests.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CNIOBoringSSL
-import Foundation
 import NIOCore
 import NIOEmbedded
 import NIOPosix
@@ -208,48 +206,4 @@ final class SSLContextTest: XCTestCase {
     func testSNIContextError() throws {
         try assertSniError(sniField: "httpbin.org", expectedError: .contextError)
     }
-
-    #if os(Linux) || os(FreeBSD)
-    func testPlatformDefaultTrustStoreFallsBackToBoringSSLDefaults() throws {
-        // Simulate a system where none of the hardcoded search paths exist:
-        // the fallback should load the bundle named by SSL_CERT_FILE.
-        let bundlePath = NSTemporaryDirectory() + "/nio-ssl-test-ca-bundle-\(UUID().uuidString).pem"
-        try samplePemCert.write(toFile: bundlePath, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(atPath: bundlePath) }
-
-        setenv("SSL_CERT_FILE", bundlePath, 1)
-        // Point SSL_CERT_DIR at a path that does not exist, to ensure that
-        // only the bundle above provides trust roots.
-        setenv("SSL_CERT_DIR", bundlePath + ".dir", 1)
-        defer {
-            unsetenv("SSL_CERT_FILE")
-            unsetenv("SSL_CERT_DIR")
-        }
-
-        let sslContext = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_client_method())!
-        defer { CNIOBoringSSL_SSL_CTX_free(sslContext) }
-
-        XCTAssertNoThrow(
-            try NIOSSLContext.platformDefaultConfiguration(
-                context: sslContext,
-                rootCAFile: nil,
-                rootCADirectory: nil
-            )
-        )
-
-        // The self-signed CA certificate from the bundle must now be trusted.
-        let certificate = try NIOSSLCertificate(bytes: Array(samplePemCert.utf8), format: .pem)
-        let store = CNIOBoringSSL_SSL_CTX_get_cert_store(sslContext)
-        let storeContext = CNIOBoringSSL_X509_STORE_CTX_new()!
-        defer { CNIOBoringSSL_X509_STORE_CTX_free(storeContext) }
-
-        let verifyResult = certificate.withUnsafeMutableX509Pointer { certificatePointer in
-            guard CNIOBoringSSL_X509_STORE_CTX_init(storeContext, store, certificatePointer, nil) == 1 else {
-                return CInt(0)
-            }
-            return CNIOBoringSSL_X509_verify_cert(storeContext)
-        }
-        XCTAssertEqual(verifyResult, 1)
-    }
-    #endif
 }

--- a/Tests/NIOSSLTests/SSLContextTests.swift
+++ b/Tests/NIOSSLTests/SSLContextTests.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CNIOBoringSSL
+import Foundation
 import NIOCore
 import NIOEmbedded
 import NIOPosix
@@ -206,4 +208,48 @@ final class SSLContextTest: XCTestCase {
     func testSNIContextError() throws {
         try assertSniError(sniField: "httpbin.org", expectedError: .contextError)
     }
+
+    #if os(Linux) || os(FreeBSD)
+    func testPlatformDefaultTrustStoreFallsBackToBoringSSLDefaults() throws {
+        // Simulate a system where none of the hardcoded search paths exist:
+        // the fallback should load the bundle named by SSL_CERT_FILE.
+        let bundlePath = NSTemporaryDirectory() + "/nio-ssl-test-ca-bundle-\(UUID().uuidString).pem"
+        try samplePemCert.write(toFile: bundlePath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: bundlePath) }
+
+        setenv("SSL_CERT_FILE", bundlePath, 1)
+        // Point SSL_CERT_DIR at a path that does not exist, to ensure that
+        // only the bundle above provides trust roots.
+        setenv("SSL_CERT_DIR", bundlePath + ".dir", 1)
+        defer {
+            unsetenv("SSL_CERT_FILE")
+            unsetenv("SSL_CERT_DIR")
+        }
+
+        let sslContext = CNIOBoringSSL_SSL_CTX_new(CNIOBoringSSL_TLS_client_method())!
+        defer { CNIOBoringSSL_SSL_CTX_free(sslContext) }
+
+        XCTAssertNoThrow(
+            try NIOSSLContext.platformDefaultConfiguration(
+                context: sslContext,
+                rootCAFile: nil,
+                rootCADirectory: nil
+            )
+        )
+
+        // The self-signed CA certificate from the bundle must now be trusted.
+        let certificate = try NIOSSLCertificate(bytes: Array(samplePemCert.utf8), format: .pem)
+        let store = CNIOBoringSSL_SSL_CTX_get_cert_store(sslContext)
+        let storeContext = CNIOBoringSSL_X509_STORE_CTX_new()!
+        defer { CNIOBoringSSL_X509_STORE_CTX_free(storeContext) }
+
+        let verifyResult = certificate.withUnsafeMutableX509Pointer { certificatePointer in
+            guard CNIOBoringSSL_X509_STORE_CTX_init(storeContext, store, certificatePointer, nil) == 1 else {
+                return CInt(0)
+            }
+            return CNIOBoringSSL_X509_verify_cert(storeContext)
+        }
+        XCTAssertEqual(verifyResult, 1)
+    }
+    #endif
 }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -509,6 +509,59 @@ class TLSConfigurationTest: XCTestCase {
         )
     }
 
+    #if os(Linux) || os(FreeBSD)
+    func testPlatformDefaultTrustStoreFallsBackToBoringSSLDefaults() throws {
+        // The fallback to BoringSSL's default verify paths only runs when
+        // none of the hardcoded FHS trust store locations exist. On systems
+        // with a standard layout the heuristic load succeeds first, so there
+        // is no way to exercise the fallback through the public API.
+        try XCTSkipUnless(
+            rootCAFilePath == nil && rootCADirectoryPath == nil,
+            "platform trust store found at standard FHS paths, fallback will not run"
+        )
+
+        // Simulate a system with a non-standard trust store location: point
+        // BoringSSL's defaults (via SSL_CERT_FILE) at a bundle containing
+        // only the test CA certificate.
+        let derBytes = try TLSConfigurationTest.cert1.toDERBytes()
+        let base64 = Data(derBytes).base64EncodedString()
+        var pemLines = ["-----BEGIN CERTIFICATE-----"]
+        var index = base64.startIndex
+        while index < base64.endIndex {
+            let end = base64.index(index, offsetBy: 64, limitedBy: base64.endIndex) ?? base64.endIndex
+            pemLines.append(String(base64[index..<end]))
+            index = end
+        }
+        pemLines.append("-----END CERTIFICATE-----")
+
+        let bundlePath = NSTemporaryDirectory() + "/nio-ssl-test-ca-bundle-\(UUID().uuidString).pem"
+        try (pemLines.joined(separator: "\n") + "\n").write(toFile: bundlePath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: bundlePath) }
+
+        setenv("SSL_CERT_FILE", bundlePath, 1)
+        // Point SSL_CERT_DIR at a path that does not exist, to ensure that
+        // only the bundle above provides trust roots.
+        setenv("SSL_CERT_DIR", bundlePath + ".dir", 1)
+        defer {
+            unsetenv("SSL_CERT_FILE")
+            unsetenv("SSL_CERT_DIR")
+        }
+
+        // The client uses the platform default trust store, which must pick
+        // up the bundle above for the handshake to succeed. Hostname
+        // verification is disabled: the in-memory handshake uses no server
+        // hostname, and only chain verification is under test here.
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        let serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(TLSConfigurationTest.cert1)],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+
+        try assertHandshakeSucceededInMemory(withClientConfig: clientConfig, andServerConfig: serverConfig)
+    }
+    #endif
+
     func testServerCannotValidateClientPreTLS13() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
         clientConfig.maximumTLSVersion = .tlsv12


### PR DESCRIPTION
On Linux/FreeBSD, `platformDefaultConfiguration` locates the system trust store via a hardcoded list of FHS paths (`/etc/ssl/certs/...`, `/etc/pki/...`). On systems that do not follow this layout (for example minimal container images or installations using non-standard prefixes), neither path exists, `SSL_CTX_load_verify_locations(NULL, NULL)` fails, and `BoringSSLError.unknownError([])` is thrown — with no way for users to point NIOSSL at their trust store.

This change falls back to `SSL_CTX_set_default_verify_paths`, which uses BoringSSL's compiled-in `OPENSSLDIR` defaults and, importantly, the standard `SSL_CERT_FILE`/`SSL_CERT_DIR` environment variables — the same mechanism OpenSSL users expect.

Systems with the standard FHS layout are unaffected: the heuristic load succeeds first and the fallback never runs.