### PR TITLE
Add support for accessing export key material

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -832,6 +832,17 @@ extension NIOSSLHandler {
     public var peerValidatedCertificateChain: ValidatedCertificateChain? {
         self.connection.customVerificationManager?.verificationMetadata?.validatedCertificateChain
     }
+
+    /// Export connection-specific keying material from the negotiated TLS session.
+    ///
+    /// This variable **is not thread-safe**: you **must** call it from the correct event loop thread.
+    public func exportKeyingMaterial(
+        label: String,
+        context: [UInt8]?,
+        outputByteCount: Int
+    ) throws -> NIOSSLSecureBytes {
+        try self.connection.exportKeyingMaterial(label: label, context: context, outputByteCount: outputByteCount)
+    }
 }
 
 extension Channel {
@@ -855,6 +866,17 @@ extension Channel {
             $0.peerValidatedCertificateChain
         }
     }
+
+    /// API to export keying material from the negotiated TLS session off the `Channel`. See ``NIOSSLHandler/exportKeyingMaterial``.
+    public func nioSSL_exportKeyingMaterial(
+        label: String,
+        context: [UInt8]?,
+        outputByteCount: Int
+    ) -> EventLoopFuture<NIOSSLSecureBytes> {
+        self.pipeline.handler(type: NIOSSLHandler.self).flatMapThrowing {
+            try $0.exportKeyingMaterial(label: label, context: context, outputByteCount: outputByteCount)
+        }
+    }
 }
 
 extension ChannelPipeline.SynchronousOperations {
@@ -874,6 +896,16 @@ extension ChannelPipeline.SynchronousOperations {
     public func nioSSL_peerValidatedCertificateChain() throws -> ValidatedCertificateChain? {
         let handler = try self.handler(type: NIOSSLHandler.self)
         return handler.peerValidatedCertificateChain
+    }
+
+    /// API to export keying material from the negotiated TLS session. See ``NIOSSLHandler/exportKeyingMaterial``.
+    public func nioSSL_exportKeyingMaterial(
+        label: String,
+        context: [UInt8]?,
+        outputByteCount: Int
+    ) throws -> NIOSSLSecureBytes {
+        let handler = try self.handler(type: NIOSSLHandler.self)
+        return try handler.exportKeyingMaterial(label: label, context: context, outputByteCount: outputByteCount)
     }
 }
 

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -406,6 +406,41 @@ internal final class SSLConnection {
         return NIOSSLCertificate.fromUnsafePointer(takingOwnership: certPtr)
     }
 
+    /// Export connection specific keying information for application use.
+    ///
+    /// On connections negotiated using TLS versions before 1.3, setting the value of context to `nil` omits
+    /// the context from the derivation input entirely, while passing an empty array marks the context as
+    /// zero length - resulting in a difference in output. On TLS 1.3 connections context is always hashed,
+    /// subsequently `nil` and an empty array result in the same output.
+    func exportKeyingMaterial(label: String, context: [UInt8]?, outputByteCount: Int) throws -> NIOSSLSecureBytes {
+        CNIOBoringSSL_ERR_clear_error()
+
+        let useContext: CInt = context != nil ? 1 : 0
+        let material = try NIOSSLSecureBytes(unsafeUninitializedCapacity: outputByteCount) { buffer, initializedCount in
+            let out = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            let rc = label.withCString { labelPtr in
+                (context ?? []).withUnsafeBufferPointer { contextPtr in
+                    CNIOBoringSSL_SSL_export_keying_material(
+                        self.ssl,
+                        out,
+                        outputByteCount,
+                        labelPtr,
+                        label.utf8.count,
+                        contextPtr.baseAddress,
+                        contextPtr.count,
+                        useContext
+                    )
+                }
+            }
+            guard rc == 1 else {
+                let errorStack = BoringSSLError.buildErrorStack()
+                throw BoringSSLError.unableToExportKeyingMaterial(errorStack)
+            }
+            initializedCount = outputByteCount
+        }
+        return material
+    }
+
     /// Drops persistent connection state.
     ///
     /// Must only be called when the connection is no longer needed. The rest of this object

--- a/Sources/NIOSSL/SSLErrors.swift
+++ b/Sources/NIOSSL/SSLErrors.swift
@@ -110,6 +110,7 @@ public enum BoringSSLError: Error {
     case unknownError(NIOBoringSSLErrorStack)
     case invalidSNIName(NIOBoringSSLErrorStack)
     case failedToSetALPN(NIOBoringSSLErrorStack)
+    case unableToExportKeyingMaterial(NIOBoringSSLErrorStack)
 }
 
 extension BoringSSLError: Equatable {}

--- a/Tests/NIOSSLTests/NIOSSLExportedKeyingMaterialTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLExportedKeyingMaterialTest.swift
@@ -1,0 +1,163 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+import NIOTLS
+import XCTest
+
+@testable import NIOSSL
+
+final class NIOSSLExportedKeyingMaterialTest: XCTestCase {
+    private static let (cert, key) = generateSelfSignedCert()
+
+    private func connectedChannels(
+        minimumTLSVersion: TLSVersion,
+        maximumTLSVersion: TLSVersion
+    ) throws -> BackToBackEmbeddedChannel {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([Self.cert])
+        clientConfig.minimumTLSVersion = minimumTLSVersion
+        clientConfig.maximumTLSVersion = maximumTLSVersion
+        var serverConfig = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(Self.cert)],
+            privateKey: .privateKey(Self.key)
+        )
+        serverConfig.minimumTLSVersion = minimumTLSVersion
+        serverConfig.maximumTLSVersion = maximumTLSVersion
+
+        let clientContext = try NIOSSLContext(configuration: clientConfig)
+        let serverContext = try NIOSSLContext(configuration: serverConfig)
+        let b2b = BackToBackEmbeddedChannel()
+        try b2b.client.pipeline.syncOperations.addHandlers([
+            try NIOSSLClientHandler(context: clientContext, serverHostname: "localhost"),
+            HandshakeCompletedHandler(),
+        ])
+        try b2b.server.pipeline.syncOperations.addHandlers([
+            NIOSSLServerHandler(context: serverContext),
+            HandshakeCompletedHandler(),
+        ])
+        try b2b.connectInMemory()
+        return b2b
+    }
+
+    func testClientAndServerAgreeOnExportedMaterial_TLS12() throws {
+        let b2b = try connectedChannels(minimumTLSVersion: .tlsv12, maximumTLSVersion: .tlsv12)
+
+        let client = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: nil,
+            outputByteCount: 32
+        )
+        let server = try b2b.server.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: nil,
+            outputByteCount: 32
+        )
+        XCTAssertEqual(client, server)
+        XCTAssertEqual(client.count, 32)
+    }
+
+    func testClientAndServerAgreeOnExportedMaterial_TLS13() throws {
+        let b2b = try connectedChannels(minimumTLSVersion: .tlsv13, maximumTLSVersion: .tlsv13)
+
+        let client = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: [1, 2, 3],
+            outputByteCount: 32
+        )
+        let server = try b2b.server.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: [1, 2, 3],
+            outputByteCount: 32
+        )
+        XCTAssertEqual(client, server)
+    }
+
+    func testDifferentLabels() throws {
+        let b2b = try connectedChannels(minimumTLSVersion: .tlsv12, maximumTLSVersion: .tlsv12)
+
+        let a = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label-a",
+            context: nil,
+            outputByteCount: 32
+        )
+        let b = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label-b",
+            context: nil,
+            outputByteCount: 32
+        )
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testNilAndEmptyContextDifferBelowTLS13() throws {
+        let b2b = try connectedChannels(minimumTLSVersion: .tlsv12, maximumTLSVersion: .tlsv12)
+
+        let withNil = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: nil,
+            outputByteCount: 32
+        )
+        let withEmptyContext = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: [],
+            outputByteCount: 32
+        )
+        XCTAssertNotEqual(withNil, withEmptyContext)
+    }
+
+    func testNilAndEmptyContextMatchOnTLS13() throws {
+        let b2b = try connectedChannels(minimumTLSVersion: .tlsv13, maximumTLSVersion: .tlsv13)
+
+        let withNil = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: nil,
+            outputByteCount: 32
+        )
+        let withEmptyContext = try b2b.client.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+            label: "test label",
+            context: [],
+            outputByteCount: 32
+        )
+        XCTAssertEqual(withNil, withEmptyContext)
+    }
+
+    func testExportingBeforeHandshakeCompletionThrows() throws {
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .noHostnameVerification
+        clientConfig.trustRoots = .certificates([Self.cert])
+        let clientContext = try NIOSSLContext(configuration: clientConfig)
+
+        let channel = EmbeddedChannel()
+        try channel.pipeline.syncOperations.addHandler(
+            try NIOSSLClientHandler(context: clientContext, serverHostname: "localhost")
+        )
+
+        XCTAssertThrowsError(
+            try channel.pipeline.syncOperations.nioSSL_exportKeyingMaterial(
+                label: "label",
+                context: nil,
+                outputByteCount: 32
+            )
+        ) { error in
+            guard let boringSSLError = error as? BoringSSLError, case .unableToExportKeyingMaterial = boringSSLError
+            else {
+                XCTFail("Expected BoringSSLError.unableToExportKeyingMaterial, got \(error)")
+                return
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Motivation:

Some application protocols need access to the keying primitives used in the TLS handshake such as DTLS-SRTP, NTS, amongst others. This interface is defined by RFC 5705 as well as RFC 9846, Section 7.5.

Modifications:

Added function in `SSLConnection` that returns data from `CNIOBoringSSL_SSL_export_keying_material`, included both synchronous and asynchrous functions in `NIOSSLHandler`, and a new test file to validate behaviour including exception throwing and variants.

Result:

Applications can access export keying material without having to resort to desperate measures such as parsing the buffer from `TLSConfiguration.keyLogCallback`.

Resolves #593.