### PR TITLE
Avoid unconditional plaintext read buffer reallocations

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -68,6 +68,10 @@ public class NIOSSLHandler: ChannelInboundHandler, ChannelOutboundHandler, Remov
         self.storedContext?.channel
     }
 
+    internal var _testOnly_plaintextReadBufferCapacity: Int? {
+        self.plaintextReadBuffer?.capacity
+    }
+
     internal init(
         connection: SSLConnection,
         shutdownTimeout: TimeAmount,
@@ -95,7 +99,7 @@ public class NIOSSLHandler: ChannelInboundHandler, ChannelOutboundHandler, Remov
         self.connection.parentHandler = self
         self.connection.eventLoop = context.eventLoop
 
-        self.plaintextReadBuffer = context.channel.allocator.buffer(capacity: SSL_MAX_RECORD_SIZE)
+        self.plaintextReadBuffer = context.channel.allocator.buffer(capacity: 2 * SSL_MAX_RECORD_SIZE)
         // If this channel is already active, immediately begin handshaking.
         if context.channel.isActive {
             doHandshakeStep(context: context)

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -1272,6 +1272,19 @@ class NIOSSLIntegrationTest: XCTestCase {
         XCTAssertNoThrow(try closePromise.futureResult.wait())
     }
 
+    func testPlaintextReadBufferCanHoldTwoRecords() throws {
+        let context = try configuredSSLContext()
+        let handler = try NIOSSLClientHandler(context: context, serverHostname: nil)
+        let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
+
+        try channel.pipeline.syncOperations.addHandler(handler)
+
+        XCTAssertEqual(handler._testOnly_plaintextReadBufferCapacity, 2 * SSL_MAX_RECORD_SIZE)
+    }
+
     func testAddingTlsToActiveChannelStillHandshakes() throws {
         let context = try configuredSSLContext()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -1474,6 +1474,19 @@ class NIOSSLIntegrationTest: XCTestCase {
         XCTAssertNoThrow(try closePromise.futureResult.wait())
     }
 
+    func testPlaintextReadBufferCanHoldTwoRecords() throws {
+        let context = try configuredSSLContext()
+        let handler = try NIOSSLClientHandler(context: context, serverHostname: nil)
+        let channel = EmbeddedChannel()
+        defer {
+            XCTAssertNoThrow(try channel.finish())
+        }
+
+        try channel.pipeline.syncOperations.addHandler(handler)
+
+        XCTAssertEqual(handler._testOnly_plaintextReadBufferCapacity, 2 * SSL_MAX_RECORD_SIZE)
+    }
+
     func testAddingTlsToActiveChannelStillHandshakes() throws {
         let context = try configuredSSLContext()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)


### PR DESCRIPTION
### Motivation

Fixes #227.

`NIOSSLHandler` initially reserves one maximum TLS record, while the read loop immediately asks for another record's worth of writable space after consuming the first. Reserve two records up front so the normal loop does not force an unconditional buffer growth.

The test-only capacity accessor follows the existing `ByteBufferBIO` test seam pattern and verifies the reservation at handler installation.

### Testing

- Negative control on current `main`: expected 32768 bytes, received 16384
- Focused regression: passed
- Full macOS suite: 325 tests passed
- Production build with the Swift 6.3 CI warning, dependency-import, and explicit-Sendable flags: passed
- Release benchmark package build: passed
- Renegotiation integration test: passed
- `git diff --check`: passed
- Commit signature: verified

### Maintainer note

This is a patch-level performance fix. The fork author cannot apply the required `🔨 semver/patch` label to the upstream PR, so a maintainer will need to add it.