### PR TITLE
Fix comparing TLSConfiguration objects with some closures

### DIFF
--- a/Sources/NIOSSL/TLSConfiguration.swift
+++ b/Sources/NIOSSL/TLSConfiguration.swift
@@ -521,6 +521,57 @@ public struct TLSConfiguration {
 extension TLSConfiguration: Sendable {}
 
 // MARK: BestEffortHashable
+
+/// The raw representation of a closure: a function pointer plus a context pointer.
+///
+/// Closure values cannot safely be inspected byte-wise by passing them directly to a generic
+/// parameter such as `withUnsafeBytes(of:)` or `unsafeBitCast(_:to:)`. Swift's calling
+/// convention requires generic arguments in their maximally abstract form (arguments and
+/// results passed indirectly), so a closure stored in its concrete form must be converted
+/// before it can be passed. That conversion emits a "reabstraction thunk", and the thunk
+/// needs a freshly heap-allocated box to capture the original function. The bytes that
+/// reach the closure are then the thunk's pointer and the box's address — a new address on
+/// every call — and never the closure that was actually stored.
+///
+/// The effect is that two byte-wise comparisons of the same closure can often disagree,
+/// which turns `bestEffortEquals` into "never equal" for any configuration carrying a
+/// callback.
+///
+/// Reading the words out of a concrete wrapper struct keeps the function away from any
+/// generic parameter, so no thunk is emitted and the stored bytes are observed as they are.
+private struct ClosureBits: Hashable {
+    /// See ``ClosureBits``.
+    private struct KeyLogCallbackBox {
+        var callback: NIOSSLKeyLogCallback?
+    }
+
+    private struct SSLContextCallbackBox {
+        var callback: NIOSSLContextCallback?
+    }
+
+    private var function: UInt
+    private var context: UInt
+
+    init(_ closure: NIOSSLKeyLogCallback?) {
+        self.init(KeyLogCallbackBox(callback: closure))
+    }
+
+    init(_ closure: NIOSSLContextCallback?) {
+        self.init(SSLContextCallbackBox(callback: closure))
+    }
+
+    // Never call this with the closure directly, only the boxes.
+    private init(_ box: some Any) {
+        precondition(MemoryLayout.size(ofValue: box) == 2 * MemoryLayout<UInt>.size)
+        (self.function, self.context) = withUnsafeBytes(of: box) { raw in
+            (
+                raw.load(fromByteOffset: 0, as: UInt.self),
+                raw.load(fromByteOffset: MemoryLayout<UInt>.size, as: UInt.self)
+            )
+        }
+    }
+}
+
 extension TLSConfiguration {
     /// Returns a best effort result of whether two ``TLSConfiguration`` objects are equal.
     ///
@@ -528,11 +579,7 @@ extension TLSConfiguration {
     ///
     /// - warning: You should probably not use this function. This function can return false-negatives, but not false-positives.
     public func bestEffortEquals(_ comparing: TLSConfiguration) -> Bool {
-        let isKeyLoggerCallbacksEqual = withUnsafeBytes(of: self.keyLogCallback) { callbackPointer1 in
-            withUnsafeBytes(of: comparing.keyLogCallback) { callbackPointer2 in
-                callbackPointer1.elementsEqual(callbackPointer2)
-            }
-        }
+        let isKeyLoggerCallbacksEqual = ClosureBits(self.keyLogCallback) == ClosureBits(comparing.keyLogCallback)
         let isPSKClientProviderEqual = withUnsafeBytes(of: self._pskClientIdentityProvider) { pskClientProvider1 in
             withUnsafeBytes(of: comparing._pskClientIdentityProvider) { pskClientProvider2 in
                 pskClientProvider1.elementsEqual(pskClientProvider2)
@@ -543,11 +590,8 @@ extension TLSConfiguration {
                 pskServerProvider1.elementsEqual(pskServerProvider2)
             }
         }
-        let isSSLContextCallbackEqual = withUnsafeBytes(of: self.sslContextCallback) { sslContextCallback1 in
-            withUnsafeBytes(of: comparing.sslContextCallback) { sslContextCallback2 in
-                sslContextCallback1.elementsEqual(sslContextCallback2)
-            }
-        }
+        let isSSLContextCallbackEqual =
+            ClosureBits(self.sslContextCallback) == ClosureBits(comparing.sslContextCallback)
 
         return self.minimumTLSVersion == comparing.minimumTLSVersion
             && self.maximumTLSVersion == comparing.maximumTLSVersion && self.cipherSuites == comparing.cipherSuites
@@ -582,9 +626,7 @@ extension TLSConfiguration {
         hasher.combine(privateKey)
         hasher.combine(encodedApplicationProtocols)
         hasher.combine(shutdownTimeout)
-        withUnsafeBytes(of: keyLogCallback) { closureBits in
-            hasher.combine(bytes: closureBits)
-        }
+        hasher.combine(ClosureBits(keyLogCallback))
         hasher.combine(renegotiationSupport)
         hasher.combine(sendCANameList)
         withUnsafeBytes(of: _pskClientIdentityProvider) { closureClientBits in
@@ -593,9 +635,7 @@ extension TLSConfiguration {
         withUnsafeBytes(of: _pskServerIdentityProvider) { closureServerBits in
             hasher.combine(bytes: closureServerBits)
         }
-        withUnsafeBytes(of: sslContextCallback) { closureServerBits in
-            hasher.combine(bytes: closureServerBits)
-        }
+        hasher.combine(ClosureBits(sslContextCallback))
         hasher.combine(pskHint)
     }
 

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1151,6 +1151,150 @@ class TLSConfigurationTest: XCTestCase {
         XCTAssertFalse(config.bestEffortEquals(differentConfig))
     }
 
+    func testSSLContextCallbackConfigEqualsItself() {
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        config.sslContextCallback = { _, _ in }
+        let theSameConfig = config
+
+        // `bestEffortEquals` is documented to return false-negatives but not false-positives.
+        // Comparing a configuration against a copy of itself must therefore still be equal:
+        // the closure is literally the same closure, so there is no negative to be had.
+        XCTAssertTrue(config.bestEffortEquals(theSameConfig))
+        XCTAssertTrue(config.bestEffortEquals(config))
+    }
+
+    func testSSLContextCallbackConfigHashesEqualToItself() {
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        config.sslContextCallback = { _, _ in }
+        let theSameConfig = config
+
+        var hasher = Hasher()
+        var hasher2 = Hasher()
+        config.bestEffortHash(into: &hasher)
+        theSameConfig.bestEffortHash(into: &hasher2)
+        XCTAssertEqual(hasher.finalize(), hasher2.finalize())
+    }
+
+    func testKeyLogCallbackConfigEqualsItself() {
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        config.keyLogCallback = { _ in }
+        let theSameConfig = config
+
+        XCTAssertTrue(config.bestEffortEquals(theSameConfig))
+
+        var hasher = Hasher()
+        var hasher2 = Hasher()
+        config.bestEffortHash(into: &hasher)
+        theSameConfig.bestEffortHash(into: &hasher2)
+        XCTAssertEqual(hasher.finalize(), hasher2.finalize())
+    }
+
+    func testCallbackBearingConfigEqualsItselfRepeatedly() {
+        // The failure this guards against is a per-call heap allocation, so it can be
+        // sensitive to optimisation and to allocator state. Repeat it enough times that a
+        // regression cannot pass by luck.
+        var config = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [],
+            privateKey: .privateKey(TLSConfigurationTest.key1)
+        )
+        config.sslContextCallback = { _, _ in }
+        config.keyLogCallback = { _ in }
+        let theSameConfig = config
+
+        for _ in 0..<1000 {
+            XCTAssertTrue(config.bestEffortEquals(theSameConfig))
+        }
+    }
+
+    func testCallbacksDifferingOnlyByCaptureNotEqual() {
+        // Both configurations get a callback made from the same closure literal, so the
+        // function pointers are identical and only the captured context differs. This is
+        // the case the context word alone has to distinguish, and it guards against a
+        // comparison that looks at the function pointer but ignores the context.
+        func makeCallback(_ response: String) -> NIOSSLContextCallback {
+            { _, promise in
+                promise.succeed(NIOSSLContextConfigurationOverride())
+                _ = response
+            }
+        }
+
+        var config = TLSConfiguration.makeClientConfiguration()
+        config.sslContextCallback = makeCallback("first")
+        var differentConfig = config
+        differentConfig.sslContextCallback = makeCallback("second")
+
+        XCTAssertFalse(config.bestEffortEquals(differentConfig))
+        XCTAssertNotEqual(Wrapper(config: config), Wrapper(config: differentConfig))
+    }
+
+    func testCapturingCallbackEqualsItselfWhenCopied() {
+        // The mirror of the above: one capturing closure shared by both configurations.
+        // The context is a single heap box, so this must compare equal.
+        func makeCallback(_ response: String) -> NIOSSLContextCallback {
+            { _, promise in
+                promise.succeed(NIOSSLContextConfigurationOverride())
+                _ = response
+            }
+        }
+
+        var config = TLSConfiguration.makeClientConfiguration()
+        config.sslContextCallback = makeCallback("shared")
+        let theSameConfig = config
+
+        XCTAssertTrue(config.bestEffortEquals(theSameConfig))
+        XCTAssertEqual(Wrapper(config: config), Wrapper(config: theSameConfig))
+    }
+
+    func testCallbackSetVersusUnsetNotEqual() {
+        var withCallback = TLSConfiguration.makeClientConfiguration()
+        withCallback.sslContextCallback = { _, _ in }
+        let withoutCallback = TLSConfiguration.makeClientConfiguration()
+
+        XCTAssertFalse(withCallback.bestEffortEquals(withoutCallback))
+        XCTAssertFalse(withoutCallback.bestEffortEquals(withCallback))
+        XCTAssertNotEqual(Wrapper(config: withCallback), Wrapper(config: withoutCallback))
+
+        var withKeyLog = TLSConfiguration.makeClientConfiguration()
+        withKeyLog.keyLogCallback = { _ in }
+        XCTAssertFalse(withKeyLog.bestEffortEquals(withoutCallback))
+        XCTAssertNotEqual(Wrapper(config: withKeyLog), Wrapper(config: withoutCallback))
+    }
+
+    func testDistinctCallbacksNotEqual() {
+        // Two closures with distinguishable bodies. The bodies must differ: a compiler is
+        // free to fold two identical function bodies into a single function, and identical
+        // non-capturing closures then share a function pointer and a null context, so they
+        // compare equal. That is a false positive, which `bestEffortEquals` documents as the
+        // one result it must never produce.
+        //
+        // This is inherent to comparing closures byte-wise and is not specific to
+        // `sslContextCallback`; the same is true of the PSK providers, which have always
+        // been compared this way. It is called out here so that the guarantee this test
+        // relies on -- distinct bodies, hence distinct functions -- is explicit rather than
+        // accidental. `testDifferentSSLContextCallbacksNotEqual` above uses two empty
+        // closures and so does not reliably test this.
+        var config = TLSConfiguration.makeClientConfiguration()
+        config.sslContextCallback = { _, promise in
+            promise.succeed(NIOSSLContextConfigurationOverride())
+        }
+        var differentConfig = TLSConfiguration.makeClientConfiguration()
+        differentConfig.sslContextCallback = { _, promise in
+            promise.fail(NIOSSLError.unableToValidateCertificate)
+        }
+
+        XCTAssertFalse(config.bestEffortEquals(differentConfig))
+        XCTAssertNotEqual(Wrapper(config: config), Wrapper(config: differentConfig))
+    }
+
     func testCompatibleCurves() throws {
         var clientConfig = TLSConfiguration.makeClientConfiguration()
         clientConfig.curves = [.x25519]


### PR DESCRIPTION
Motivation:

TLSConfiguration aims to produce an equality comparison even though it contains closures. Unfortunately, the way it does this is subject to some bugs. Specifically, we pass the closure directly to the generic method `withUnsafeByes` which can in some cases force the compiler to emit a reabstraction thunk. This happens at the point of comparison, and so we can end up at a point where a TLSConfiguration object compares unequal _to itself_, which is not great.

Modifications:

Defend against the reabstraction thunks by temporarily storing the closures inside a struct, which can be passed to the generic method without the reabstraction thunks.

Adds a helper for comparisons as well to make this more likely to get correct implementations going forward.

Result:

Correct comparisons.