### PR TITLE
Accept every c_rehash collision suffix, not just .0

### DIFF
--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -782,25 +782,37 @@ extension NIOSSLContext {
     /// Takes a path and determines if the file at this path is of c_rehash format .
     internal static func _isRehashFormat(path: String) throws -> Bool {
         // Check if the element’s name matches the c_rehash symlink name format.
-        // The links created are of the form HHHHHHHH.D, where each H is a hexadecimal character and D is a single decimal digit.
+        // `openssl rehash` writes its links with `snprintf(..., "%08x.%s%d", ...)` (apps/rehash.c):
+        // eight hex characters, a period, a type infix that is empty for certificates and "r" for
+        // CRLs, and a decimal collision id that starts at 0 and counts up for every further
+        // certificate sharing the same subject name hash. The id is a plain %d, not one character,
+        // so ".10" and beyond are ordinary names and must be recognised here.
         let utf8PathView = path.utf8
         let utf8PathSplitView = utf8PathView.split(separator: UInt8(ascii: "/"))
 
-        // Make sure the path is at least 10 units long
-        guard let lastPathComponent = utf8PathSplitView.last,
-            lastPathComponent.count == 10
-        else { return false }
-        // Split into filename parts HHHHHHHH.D -> [[HHHHHHHH], [D]]
-        let filenameParts = lastPathComponent.split(separator: UInt8(ascii: "."))
+        guard let lastPathComponent = utf8PathSplitView.last else { return false }
 
-        // Double check that the extension did not fail to cast to an integer.
-        // Make sure that the filename is an 8 character hex based file name.
+        // Split into filename parts HHHHHHHH.D -> [[HHHHHHHH], [D]].
+        //
+        // The split must keep empty subsequences. With the default (omitting) behaviour a name
+        // such as "7f44456a..0", ".7f44456a.0" or "7f44456a.0." collapses to the same two parts
+        // as "7f44456a.0" and would be accepted, even though it has a period in a position
+        // `openssl rehash` never puts one. Keeping the empty pieces makes every stray period show
+        // up in the part count or as an empty part, so the checks below can reject it.
+        let filenameParts = lastPathComponent.split(
+            separator: UInt8(ascii: "."),
+            omittingEmptySubsequences: false
+        )
+
+        // Exactly one period, an 8 character hex filename before it and at least one decimal digit
+        // after it. No separate length check on the whole name is needed: those three conditions
+        // already pin it to 8 + 1 + digits.
         guard filenameParts.count == 2,
             let filename = filenameParts.first,
             let fileExtension = filenameParts.last,
-            fileExtension.count == 1,
             filename.count == 8,
             filename.allSatisfy({ $0.isHexDigit }),
+            !fileExtension.isEmpty,
             fileExtension.allSatisfy({ $0.isDecimalDigit })
         else { return false }
 
@@ -815,7 +827,8 @@ extension NIOSSLContext {
         #endif
 
         // Return true at this point because the file format is considered to be in rehash format and a symlink.
-        // Rehash format being "%08lx.%d" or HHHHHHHH.D
+        // Rehash format being "%08x.%s%d" with an empty infix, or HHHHHHHH.D where D is one or
+        // more decimal digits.
         return true
     }
 }

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -801,7 +801,7 @@ extension NIOSSLContext {
             fileExtension.count == 1,
             filename.count == 8,
             filename.allSatisfy({ $0.isHexDigit }),
-            fileExtension.first == UInt8(ascii: "0")
+            fileExtension.allSatisfy({ $0.isDecimalDigit })
         else { return false }
 
         // Check if the element is a symlink. If it is not, return false.
@@ -964,7 +964,8 @@ internal class DirectoryContents: Sequence, IteratorProtocol {
     }
 }
 
-// Used as part of the `_isRehashFormat` format to determine if the filename is a hexadecimal filename.
+// Used as part of the `_isRehashFormat` format to determine whether the filename is a hexadecimal
+// filename and whether its extension is a decimal digit.
 extension UTF8.CodeUnit {
     private static let asciiZero = UInt8(ascii: "0")
     private static let asciiNine = UInt8(ascii: "9")
@@ -978,6 +979,15 @@ extension UTF8.CodeUnit {
         case (.asciiZero)...(.asciiNine),
             (.asciiLowercaseA)...(.asciiLowercaseF),
             (.asciiUppercaseA)...(.asciiUppercaseF):
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isDecimalDigit: Bool {
+        switch self {
+        case (.asciiZero)...(.asciiNine):
             return true
         default:
             return false

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -1045,10 +1045,16 @@ class TLSConfigurationTest: XCTestCase {
     }
 
     func testRehashFormatAcceptsCollisionSuffixes() throws {
-        // `openssl rehash` names its links "%08lx.%d": when several certificates share a subject
-        // name hash, the suffix is incremented rather than staying at 0. Every one of those links
-        // is in c_rehash format and must be recognised, otherwise the CAs behind the higher
-        // suffixes are silently left out of the client CA list.
+        // `openssl rehash` names its links "%08x.%s%d", the infix being empty for certificates:
+        // when several certificates share a subject name hash, the id is incremented rather than
+        // staying at 0. Every one of those links is in c_rehash format and must be recognised,
+        // otherwise the CAs behind the higher ids are silently left out of the client CA list.
+        //
+        // The id is a plain %d, so it grows past one digit. `apps/rehash.c` caps a hash bucket at
+        // 256 entries (MAX_COLLISIONS), which makes 255 the largest id that tool can write. The
+        // older perl `tools/c_rehash.in`, still shipped on the 3.0 and 3.5 branches, has no such
+        // cap: its suffix loop just increments until it finds a free name. So the predicate
+        // deliberately accepts any number of digits rather than enforcing a ceiling of its own.
         let testName = String("\(#function)".dropLast(2))
 
         let rootCAPath = try dumpToFile(
@@ -1068,7 +1074,15 @@ class TLSConfigurationTest: XCTestCase {
             XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + removePath)!))
         }
 
-        for numericExtension in [0, 1, 2, 9] {
+        let acceptedSuffixes: [(id: Int, why: String)] = [
+            (0, "the first link for a hash"),
+            (1, "the first collision"),
+            (9, "the last single-digit id"),
+            (10, "the first two-digit id; a single-character check would drop it"),
+            (123, "an arbitrary id in the middle of the range"),
+            (255, "the largest id apps/rehash.c can write (MAX_COLLISIONS - 1)"),
+        ]
+        for (numericExtension, why) in acceptedSuffixes {
             let symlinkName = getRehashFilename(
                 path: rootCAPath,
                 testName: testName,
@@ -1084,7 +1098,42 @@ class TLSConfigurationTest: XCTestCase {
 
             XCTAssertTrue(
                 try NIOSSLContext._isRehashFormat(path: symlinkName),
-                "\(symlinkName) is a valid c_rehash link and should be recognised"
+                "\(symlinkName) is a valid c_rehash link (\(why)) and should be recognised"
+            )
+        }
+
+        // Names that have the right characters but a shape `openssl rehash` never produces. They
+        // are real symlinks to a real certificate, so the name check is the only thing that can
+        // reject them.
+        //
+        // The first three depend on the split keeping empty subsequences: ".7f44456a.0",
+        // "7f44456a..0" and "7f44456a.0." each collapse to the same two parts as "7f44456a.0"
+        // when empty pieces are discarded, and would be accepted. The other three are rejected
+        // for reasons that do not involve the split at all: "7f44456a." by the !isEmpty check,
+        // "7f44456a.0.1" by yielding three parts under either behaviour, and "7f44456a.r0" by
+        // isDecimalDigit.
+        let rejectedNames: [(name: String, why: String)] = [
+            (".7f44456a.0", "leading period gives an empty first part"),
+            ("7f44456a..0", "doubled period gives an empty middle part"),
+            ("7f44456a.0.", "trailing period gives an empty last part"),
+            ("7f44456a.", "empty extension: openssl rehash always writes at least one digit"),
+            ("7f44456a.0.1", "two periods: three parts, not two"),
+            ("7f44456a.r0", "CRL link: the caller loads every accepted name as a PEM certificate"),
+        ]
+        let tempDirPath = FileManager.default.temporaryDirectory.path + "/" + testName + "/"
+        for (name, why) in rejectedNames {
+            let symlinkName = tempDirPath + name
+            XCTAssertNoThrow(
+                try FileManager.default.createSymbolicLink(
+                    atPath: symlinkName,
+                    withDestinationPath: rootCAFilename
+                )
+            )
+            symlinks.append(symlinkName)
+
+            XCTAssertFalse(
+                try NIOSSLContext._isRehashFormat(path: symlinkName),
+                "\(symlinkName) is not a name openssl rehash produces (\(why)) and must be rejected"
             )
         }
     }

--- a/Tests/NIOSSLTests/TLSConfigurationTest.swift
+++ b/Tests/NIOSSLTests/TLSConfigurationTest.swift
@@ -995,9 +995,12 @@ class TLSConfigurationTest: XCTestCase {
         // Filename is not in rehash format.
         let acceptablePathBadFilename = try NIOSSLContext._isRehashFormat(path: "/etc/ssl/certs/myFile.pem")
         XCTAssertFalse(acceptablePathBadFilename)
-        // Filename is in bad rehash format.
+        // Filename is in bad rehash format: the extension is not a decimal digit.
         let acceptablePathBadRehashFormat = try NIOSSLContext._isRehashFormat(path: "/etc/ssl/certs/7f44456a.z")
         XCTAssertFalse(acceptablePathBadRehashFormat)
+        // Nor is a non-digit that happens to be a hex character.
+        let acceptablePathHexExtension = try NIOSSLContext._isRehashFormat(path: "/etc/ssl/certs/7f44456a.a")
+        XCTAssertFalse(acceptablePathHexExtension)
 
         // Test with an actual file, but no symlink.
         let dummyFile = try dumpToFile(data: Data(), fileExtension: ".txt", customPath: testName)
@@ -1039,6 +1042,51 @@ class TLSConfigurationTest: XCTestCase {
         // Test the success case for the symlink
         let successSymlink = try NIOSSLContext._isRehashFormat(path: rehashSymlinkName)
         XCTAssertTrue(successSymlink)
+    }
+
+    func testRehashFormatAcceptsCollisionSuffixes() throws {
+        // `openssl rehash` names its links "%08lx.%d": when several certificates share a subject
+        // name hash, the suffix is incremented rather than staying at 0. Every one of those links
+        // is in c_rehash format and must be recognised, otherwise the CAs behind the higher
+        // suffixes are silently left out of the client CA list.
+        let testName = String("\(#function)".dropLast(2))
+
+        let rootCAPath = try dumpToFile(
+            data: .init(customChain.rootPEM.utf8),
+            fileExtension: ".pem",
+            customPath: testName
+        )
+        let rootCAFilename = URL(string: "file://" + rootCAPath)!.lastPathComponent
+
+        var symlinks: [String] = []
+        defer {
+            for symlink in symlinks {
+                XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + symlink)!))
+            }
+            XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + rootCAPath)!))
+            let removePath = "\(FileManager.default.temporaryDirectory.path)/\(testName)/"
+            XCTAssertNoThrow(try FileManager.default.removeItem(at: URL(string: "file://" + removePath)!))
+        }
+
+        for numericExtension in [0, 1, 2, 9] {
+            let symlinkName = getRehashFilename(
+                path: rootCAPath,
+                testName: testName,
+                numericExtension: numericExtension
+            )
+            XCTAssertNoThrow(
+                try FileManager.default.createSymbolicLink(
+                    atPath: symlinkName,
+                    withDestinationPath: rootCAFilename
+                )
+            )
+            symlinks.append(symlinkName)
+
+            XCTAssertTrue(
+                try NIOSSLContext._isRehashFormat(path: symlinkName),
+                "\(symlinkName) is a valid c_rehash link and should be recognised"
+            )
+        }
     }
 
     func testNonexistentFileObject() throws {


### PR DESCRIPTION
`_isRehashFormat` recognises only a one-digit collision suffix, so `openssl rehash` links from `.10` upward are not seen as c_rehash links at all.

### The three barriers

On `main` the name check is:

```swift
guard let lastPathComponent = utf8PathSplitView.last,
    lastPathComponent.count == 10
else { return false }
let filenameParts = lastPathComponent.split(separator: UInt8(ascii: "."))

guard filenameParts.count == 2,
    let filename = filenameParts.first,
    let fileExtension = filenameParts.last,
    fileExtension.count == 1,
    filename.count == 8,
    filename.allSatisfy({ $0.isHexDigit }),
    fileExtension.first == UInt8(ascii: "0")
else { return false }
```

Three things reject a valid link independently:

1. `lastPathComponent.count == 10` — rejects any name longer than `HHHHHHHH.D` before the extension is examined at all.
2. `fileExtension.count == 1` — rejects any suffix of more than one digit.
3. `fileExtension.first == UInt8(ascii: "0")` — rejects every suffix that does not begin with `0`, which for the ids OpenSSL actually writes means everything except `.0`.

Relaxing any one of them is not enough on its own.

### Consequence

The filter lives in `loadVerifyLocations(_:context:sendCANames:)`, which calls `_isRehashFormat` over the directory contents when `sendCANames` is set, loads each surviving link as a PEM certificate, and passes it to `addCACertificateNameToList` so its CA name reaches the client CA list. (`addRootCertificate` is a different function; it adds a certificate to the trust store and does not walk the directory.)

A CA that lost the hash race is therefore skipped, so its name is absent from the CertificateRequest, and a client holding a certificate from that CA has no reason to send it. The failure is quiet: nothing errors, the handshake just proceeds without the client certificate.

### The change

- `fileExtension.allSatisfy({ $0.isDecimalDigit })` replaces the `== "0"` comparison, mirroring the `isHexDigit` check on the line above. `isDecimalDigit` is added to the same `UTF8.CodeUnit` extension as `isHexDigit`, in the same shape, reusing the existing `asciiZero`/`asciiNine` constants.
- `fileExtension.count == 1` becomes `!fileExtension.isEmpty`. Emptiness still has to be excluded explicitly, because `allSatisfy` is vacuously true on an empty collection.
- `lastPathComponent.count == 10` is removed rather than relaxed to `>= 10`. It is redundant once the parts are checked: `filenameParts.count == 2`, `filename.count == 8` and a non-empty all-digits extension already pin the name to 8 + 1 + digits. A second, looser length check would only be another thing to keep in sync.
- The split passes `omittingEmptySubsequences: false`. This is load-bearing. With the default behaviour `Collection.split` discards empty pieces, so `.7f44456a.0`, `7f44456a..0` and `7f44456a.0.` collapse to the same two parts as `7f44456a.0`. The removed `count == 10` check had been rejecting exactly those three by accident; the explicit split replaces that accident with an intentional rule, and the reasoning is recorded at the call site.

No upper bound on the number of digits is imposed. The reasoning, and the OpenSSL sources it rests on, are in a comment on this PR.

### Tests

`testRehashFormat` already asserts a non-digit extension (`.z`) is rejected; `.a` is added next to it, since a hex-but-not-decimal character is the case most likely to regress if someone reaches for `isHexDigit` here.

`testRehashFormatAcceptsCollisionSuffixes` creates real symlinks and covers:

- accepted: 0, 1, 9, 10, 123, 255.
- rejected: `.7f44456a.0`, `7f44456a..0`, `7f44456a.0.`, `7f44456a.`, `7f44456a.0.1` and `7f44456a.r0`.

Every assertion carries a message saying why that name is in the list. The rejected names are real symlinks to a real certificate, so the name check is the only thing that can reject them. Only the first three depend on the explicit split; the comment in the test says what rejects the other three, so nobody reads the split as decorative.

The existing `getRehashFilename` helper is used unchanged. It formats with `%08lx.%d` and already produces `.10`, `.123` and `.255` correctly.

One existing assertion changes meaning. `testRehashFormat` builds `7f44456a.1` for its "in rehash format, but not a symlink" case, and on `main` that passes for the wrong reason: the name is rejected at the `"0"` comparison, before the symlink check it is meant to exercise. I confirmed this by passing a nonexistent path through the function, where reaching `lstat` is observable as a throw:

| Source | `_isRehashFormat("/etc/ssl/certs/7f44456a.1")` |
| --- | --- |
| `main` | returns `false`, does not throw — rejected at the name check |
| this PR | throws — the name is accepted and execution reaches the symlink check |

After this change the assertion exercises what it was written for.

### Verification

Run in `swift:6.2-noble`, the image the Linux 6.2 leg of the shared matrix names (`apple/swift-nio`, `scripts/generate_matrix.sh` line 78):

```
docker run --rm -v "$PWD":/src -w /src swift:6.2-noble swift test --scratch-path .build-linux
```

| Run | Result |
| --- | --- |
| `apple:main` (03827c1), unmodified | `Executed 339 tests, with 0 failures (0 unexpected)` |
| PR head before this commit, unmodified | `Executed 340 tests, with 0 failures (0 unexpected)` |
| With this change | `Executed 340 tests, with 0 failures (0 unexpected)` |
| With this change, the matrix's 6.2 argument overrides | `Executed 340 tests, with 0 failures (0 unexpected)` |
| New test against `apple:main` source | 5 failures: `.1`, `.9`, `.10`, `.123`, `.255` |
| New test against this branch's first commit | 3 failures: `.10`, `.123`, `.255` |
| New test against a variant keeping the default split | 3 failures: `.7f44456a.0`, `7f44456a..0`, `7f44456a.0.` |

The last three are negative controls, showing the new assertions have teeth in both directions. `swift format lint` reports only the pre-existing `OrderedImports` warnings, unchanged from the baseline.

The `.10` case was reported by @stephenlclarke; I reproduced it here before changing anything.

---

The code in this pull request was written with Claude Fable 5.1. The verification above and this description were written with Claude Opus 5. I have reviewed and tested the change, and I am responsible for its content.
