### PR TITLE
fix: close before forwarding fatal input closure

### DIFF
--- a/Sources/NIOSSL/NIOSSLHandler.swift
+++ b/Sources/NIOSSL/NIOSSLHandler.swift
@@ -249,6 +249,13 @@ public class NIOSSLHandler: ChannelInboundHandler, ChannelOutboundHandler, Remov
             fatal = false
         }
 
+        if fatal {
+            // Mark the state terminal before invoking downstream handlers. Those handlers may
+            // synchronously complete an outstanding additional-verification future, which must
+            // not reactivate a connection whose input has already closed.
+            self.state = .closed
+        }
+
         context.fireErrorCaught(channelError)
         context.fireUserInboundEventTriggered(ChannelEvent.inputClosed)
 

--- a/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
+++ b/Tests/NIOSSLTests/NIOSSLIntegrationTest.swift
@@ -139,10 +139,16 @@ private final class InputClosedRecorder: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
 
     private(set) var inputClosedCount = 0
+    private let onInputClosed: @Sendable () -> Void
+
+    init(onInputClosed: @escaping @Sendable () -> Void = {}) {
+        self.onInputClosed = onInputClosed
+    }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         if case .some(.inputClosed) = event as? ChannelEvent {
             self.inputClosedCount += 1
+            self.onInputClosed()
         }
         context.fireUserInboundEventTriggered(event)
     }
@@ -1135,6 +1141,9 @@ class NIOSSLIntegrationTest: XCTestCase {
         let verificationPromise = clientChannel.eventLoop.makePromise(of: Void.self)
         let handshakeHandler = HandshakeCompletedHandler()
         let errorCatcher = ErrorCatcher<NIOSSLError>()
+        let reentrantVerificationCompletion = InputClosedRecorder {
+            verificationPromise.succeed(())
+        }
 
         XCTAssertNoThrow(
             try serverChannel.pipeline.syncOperations.addHandler(
@@ -1148,6 +1157,7 @@ class NIOSSLIntegrationTest: XCTestCase {
                     serverHostname: "localhost",
                     additionalPeerCertificateVerificationCallback: { _, _ in verificationPromise.futureResult }
                 ),
+                reentrantVerificationCompletion,
                 handshakeHandler,
                 errorCatcher
             )
@@ -1165,10 +1175,10 @@ class NIOSSLIntegrationTest: XCTestCase {
         )
         XCTAssertFalse(clientChannel.isActive)
 
-        // The callback is still outstanding: completing it after the close must not resurrect the
-        // handshake or trip the state machine.
-        verificationPromise.succeed(())
+        // The downstream input-closed handler completed verification synchronously. That callback
+        // must not resurrect the handshake or trip the state machine.
         clientChannel.embeddedEventLoop.run()
+        XCTAssertEqual(reentrantVerificationCompletion.inputClosedCount, 1)
         XCTAssertFalse(handshakeHandler.handshakeSucceeded)
         XCTAssertFalse(clientChannel.isActive)
     }


### PR DESCRIPTION
## Motivation

Follow up #603 by making its fatal input-closure path safe against synchronous downstream reentrancy.

While an additional certificate verification future is pending, `userInboundInputClosedTriggered` forwards `ChannelEvent.inputClosed` before `channelClose` changes the handler state. A downstream handler can synchronously complete that future from the callback, re-enter the handshake while the state still says `.additionalVerification`, and attempt to reactivate a connection whose input has already closed.

## Modifications

- Mark fatal handshake input closure as `.closed` before firing downstream error and input-closed events.
- Strengthen the existing additional-verification regression so a downstream input-closed handler completes the verification future synchronously.
- Preserve the post-handshake ragged-EOF and remote-half-closure behavior from #603.

## Testing

`swift test --filter NIOSSLIntegrationTest.testInputClosedDuringAdditionalVerificationClosesTheChannel`

Result: 1 test passed. The commit is signed and based directly on the merge commit for #603 (`03827c1a9fdb2b6b00a4e93ede8861520263af8c`).
