### PR TITLE
fix: send bad certificate alert for Darwin trust failures

### DIFF
--- a/Sources/CNIOBoringSSLShims/include/CNIOBoringSSLShims.h
+++ b/Sources/CNIOBoringSSLShims/include/CNIOBoringSSLShims.h
@@ -38,6 +38,8 @@ int CNIOBoringSSLShims_SSL_CTX_set_app_data(SSL_CTX *ctx, void *data);
 int CNIOBoringSSLShims_ERR_GET_LIB(uint32_t err);
 int CNIOBoringSSLShims_ERR_GET_REASON(uint32_t err);
 
+uint8_t CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE(void);
+
 #if defined(__cplusplus)
 }  // extern "C"
 #endif

--- a/Sources/CNIOBoringSSLShims/shims.c
+++ b/Sources/CNIOBoringSSLShims/shims.c
@@ -46,3 +46,7 @@ int CNIOBoringSSLShims_ERR_GET_LIB(uint32_t err) {
 int CNIOBoringSSLShims_ERR_GET_REASON(uint32_t err) {
   return ERR_GET_REASON(err);
 }
+
+uint8_t CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE(void) {
+  return SSL_AD_BAD_CERTIFICATE;
+}

--- a/Sources/NIOSSL/SSLCallbacks.swift
+++ b/Sources/NIOSSL/SSLCallbacks.swift
@@ -452,20 +452,29 @@ internal struct CustomVerifyManager {
 
     private var result: PendingResult = .notStarted
 
+    /// A fixed TLS alert for an internal verifier's rejected result.
+    ///
+    /// Public verification callbacks deliberately leave this unset so BoringSSL retains its
+    /// documented default alert selection.
+    let failureAlert: UInt8?
+
     /// Contains the metadata that the callback returned. As such, this property will *only* contain a value if
     /// `self.result` is `.complete` (and if the callback promise returns metadata).
     var verificationMetadata: VerificationMetadata?
 
     init(callback: @escaping NIOSSLCustomVerificationCallback) {
         self.callback = .public(callback)
+        self.failureAlert = nil
     }
 
     init(callback: @escaping NIOSSLCustomVerificationCallbackWithMetadata) {
         self.callback = .publicWithMetadata(callback)
+        self.failureAlert = nil
     }
 
-    init(callback: @escaping InternalCallback) {
+    init(callback: @escaping InternalCallback, failureAlert: UInt8? = nil) {
         self.callback = .internal(callback)
+        self.failureAlert = failureAlert
     }
 }
 
@@ -486,7 +495,10 @@ extension CustomVerifyManager {
 }
 
 extension CustomVerifyManager {
-    mutating func process(on connection: SSLConnection) -> ssl_verify_result_t {
+    mutating func process(
+        on connection: SSLConnection,
+        outAlert: UnsafeMutablePointer<UInt8>?
+    ) -> ssl_verify_result_t {
         // First, check if we have a result.
         switch self.result {
         case .complete(.certificateVerified):
@@ -496,6 +508,9 @@ extension CustomVerifyManager {
             self.verificationMetadata = metadata
             return ssl_verify_ok
         case .complete(.failed), .completeWithMetadata(.failed):
+            if let failureAlert = self.failureAlert {
+                outAlert?.pointee = failureAlert
+            }
             return ssl_verify_invalid
         case .pendingResult:
             // Ask me again.

--- a/Sources/NIOSSL/SSLConnection.swift
+++ b/Sources/NIOSSL/SSLConnection.swift
@@ -188,7 +188,7 @@ internal final class SSLConnection {
             let connection = SSLConnection.loadConnectionFromSSL(unwrappedSSL)
 
             // We force unwrap the custom verification manager because for it to not be set is a programmer error.
-            return connection.customVerificationManager!.process(on: connection)
+            return connection.customVerificationManager!.process(on: connection, outAlert: outAlert)
         }
     }
 

--- a/Sources/NIOSSL/SSLContext.swift
+++ b/Sources/NIOSSL/SSLContext.swift
@@ -540,16 +540,19 @@ public final class NIOSSLContext {
         switch self.configuration.trustRoots {
         case .some(.default), .none:
             conn.setCustomVerificationCallback(
-                CustomVerifyManager(callback: {
-                    do {
-                        conn.performSecurityFrameworkValidation(
-                            promise: $0,
-                            peerCertificates: try conn.getPeerCertificatesAsSecCertificate()
-                        )
-                    } catch {
-                        $0.fail(error)
-                    }
-                })
+                CustomVerifyManager(
+                    callback: {
+                        do {
+                            conn.performSecurityFrameworkValidation(
+                                promise: $0,
+                                peerCertificates: try conn.getPeerCertificatesAsSecCertificate()
+                            )
+                        } catch {
+                            $0.fail(error)
+                        }
+                    },
+                    failureAlert: CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE()
+                )
             )
         case .some(.certificates), .some(.file):
             break

--- a/Tests/NIOSSLTests/CustomVerifyManagerTests.swift
+++ b/Tests/NIOSSLTests/CustomVerifyManagerTests.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+import XCTest
+
+@_implementationOnly import CNIOBoringSSL
+@_implementationOnly import CNIOBoringSSLShims
+
+@testable import NIOSSL
+
+final class CustomVerifyManagerTests: XCTestCase {
+    private let unchangedAlert: UInt8 = 0xA5
+    // TLS AlertDescription.bad_certificate's wire value (RFC 5246 section 7.2).
+    private let tlsBadCertificateAlert: UInt8 = 42
+
+    private func makeConnection() throws -> (SSLConnection, EmbeddedEventLoop) {
+        var configuration = TLSConfiguration.makeClientConfiguration()
+        configuration.trustRoots = .certificates([])
+        let context = try NIOSSLContext(configuration: configuration)
+        let connection = context.createConnection()!
+        let eventLoop = EmbeddedEventLoop()
+        connection.eventLoop = eventLoop
+        return (connection, eventLoop)
+    }
+
+    private func process(
+        _ manager: CustomVerifyManager,
+        runEventLoop: Bool = true
+    ) throws -> (first: ssl_verify_result_t, second: ssl_verify_result_t?, alert: UInt8) {
+        let (connection, eventLoop) = try self.makeConnection()
+        connection.customVerificationManager = manager
+
+        var alert = self.unchangedAlert
+        let first = connection.customVerificationManager!.process(on: connection, outAlert: &alert)
+
+        guard runEventLoop else {
+            return (first, nil, alert)
+        }
+
+        eventLoop.run()
+        let second = connection.customVerificationManager!.process(on: connection, outAlert: &alert)
+        return (first, second, alert)
+    }
+
+    func testInternalFailureWritesConfiguredAlert() throws {
+        let expectedAlert = CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE()
+        let manager = CustomVerifyManager(
+            callback: { promise in promise.succeed(.failed) },
+            failureAlert: expectedAlert
+        )
+
+        let result = try self.process(manager)
+
+        XCTAssertEqual(expectedAlert, self.tlsBadCertificateAlert)
+        XCTAssertEqual(result.first, ssl_verify_retry)
+        XCTAssertEqual(result.second, ssl_verify_invalid)
+        XCTAssertEqual(result.alert, expectedAlert)
+    }
+
+    func testPublicFailureLeavesAlertUnspecified() throws {
+        let callback: NIOSSLCustomVerificationCallback = { _, promise in
+            promise.succeed(.failed)
+        }
+        let manager = CustomVerifyManager(callback: callback)
+
+        let result = try self.process(manager)
+
+        XCTAssertEqual(result.first, ssl_verify_retry)
+        XCTAssertEqual(result.second, ssl_verify_invalid)
+        XCTAssertEqual(result.alert, self.unchangedAlert)
+    }
+
+    func testPublicMetadataFailureLeavesAlertUnspecified() throws {
+        let callback: NIOSSLCustomVerificationCallbackWithMetadata = { _, promise in
+            promise.succeed(.failed)
+        }
+        let manager = CustomVerifyManager(callback: callback)
+
+        let result = try self.process(manager)
+
+        XCTAssertEqual(result.first, ssl_verify_retry)
+        XCTAssertEqual(result.second, ssl_verify_invalid)
+        XCTAssertEqual(result.alert, self.unchangedAlert)
+    }
+
+    func testInternalSuccessLeavesAlertUnchanged() throws {
+        let manager = CustomVerifyManager(
+            callback: { promise in promise.succeed(.certificateVerified) },
+            failureAlert: CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE()
+        )
+
+        let result = try self.process(manager)
+
+        XCTAssertEqual(result.first, ssl_verify_retry)
+        XCTAssertEqual(result.second, ssl_verify_ok)
+        XCTAssertEqual(result.alert, self.unchangedAlert)
+    }
+
+    func testPendingInternalVerificationLeavesAlertUnchanged() throws {
+        let manager = CustomVerifyManager(
+            callback: { _ in },
+            failureAlert: CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE()
+        )
+
+        let result = try self.process(manager, runEventLoop: false)
+
+        XCTAssertEqual(result.first, ssl_verify_retry)
+        XCTAssertNil(result.second)
+        XCTAssertEqual(result.alert, self.unchangedAlert)
+    }
+
+    func testDarwinDefaultTrustManagerUsesBadCertificateAlert() throws {
+        #if canImport(Darwin)
+        let context = try NIOSSLContext(configuration: .makeClientConfiguration())
+        let connection = context.createConnection()!
+
+        XCTAssertEqual(
+            connection.customVerificationManager?.failureAlert,
+            CNIOBoringSSLShims_SSL_AD_BAD_CERTIFICATE()
+        )
+        #endif
+    }
+}


### PR DESCRIPTION
## Motivation

Darwin's default Security.framework trust verifier reports a rejected chain to BoringSSL through the custom verification callback. The callback returned `ssl_verify_invalid` without setting `out_alert`, leaving the alert byte unspecified instead of sending the standard `bad_certificate` alert.

Public custom verification callbacks must retain BoringSSL's existing default alert selection, while the internal Darwin trust manager should provide an explicit, deterministic alert.

## Modifications

- Pass BoringSSL's `out_alert` pointer through to `CustomVerifyManager.process`.
- Allow only internal verification callbacks to configure a fixed failure alert.
- Configure the Darwin default trust manager with `SSL_AD_BAD_CERTIFICATE` through a small C shim.
- Add focused coverage for internal failure, public callback compatibility, success, pending verification, and Darwin default configuration.

## Testing

`swift test --filter CustomVerifyManagerTests`

Result: 6 tests passed. No public API is changed; public verification callbacks continue to leave BoringSSL's alert selection untouched.
